### PR TITLE
Added options to pass props via @AutoConfigureStubRunner

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -28,6 +28,8 @@ dependencies:
     - ./scripts/downloadDependencies.sh
 test:
   override:
+    - rm -rf ~/.m2/repository/org/springframework/cloud/contract
+    - rm -rf ~/.m2/repository/com/example
     - ./mvnw -s .settings.xml clean org.jacoco:jacoco-maven-plugin:prepare-agent install -U -Pdocs,integration,sonar -nsu --batch-mode -Dmaven.test.redirectTestOutputToFile=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
   post:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/

--- a/docs/src/main/asciidoc/verifier/stubrunner.adoc
+++ b/docs/src/main/asciidoc/verifier/stubrunner.adoc
@@ -55,15 +55,15 @@ Some of the properties that are repetitive can be set using system properties or
 | Property name | Default value | Description
 |stubrunner.minPort|10000| Minimal value of a port for a started WireMock with stubs
 |stubrunner.maxPort|15000| Minimal value of a port for a started WireMock with stubs
-|stubrunner.stubs.repositoryRoot|| Maven repo url. If blank then will call the local maven repo
-|stubrunner.stubs.classifier|stubs| Default classifier for the stub artifacts
+|stubrunner.repositoryRoot|| Maven repo url. If blank then will call the local maven repo
+|stubrunner.classifier|stubs| Default classifier for the stub artifacts
 |stubrunner.workOffline|false| If true then will not contact any remote repositories to download stubs
-|stubrunner.stubs.ids|| Array of Ivy notation stubs to download
+|stubrunner.ids|| Array of Ivy notation stubs to download
 |======================
 
 ===== Stub runner stubs ids
 
-You can provide the stubs to download via the `stubrunner.stubs.ids` system property. They follow the following pattern:
+You can provide the stubs to download via the `stubrunner.ids` system property. They follow the following pattern:
 
 [source,java,indent=0]
 ----

--- a/pom.xml
+++ b/pom.xml
@@ -200,12 +200,6 @@
 						<fileset>
 							<directory>target</directory>
 						</fileset>
-						<fileset>
-							<directory>${env.HOME}/.m2/repository/org/springframework/cloud/contract/verifier/stubs/</directory>
-							<includes>
-								<include>**/*</include>
-							</includes>
-						</fileset>
 					</filesets>
 				</configuration>
 			</plugin>

--- a/samples/standalone/dsl/http-client/src/test/java/com/example/loan/LoanApplicationServiceTests.java
+++ b/samples/standalone/dsl/http-client/src/test/java/com/example/loan/LoanApplicationServiceTests.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 // tag::autoconfigure_stubrunner[]
 @RunWith(SpringRunner.class)
 @SpringBootTest
-@AutoConfigureStubRunner
+@AutoConfigureStubRunner(ids = {"com.example:http-server-dsl:+:stubs:8080"}, workOffline = true)
 public class LoanApplicationServiceTests {
 // end::autoconfigure_stubrunner[]
 

--- a/samples/standalone/dsl/http-client/src/test/resources/application-test-repo.yaml
+++ b/samples/standalone/dsl/http-client/src/test/resources/application-test-repo.yaml
@@ -1,3 +1,3 @@
-stubrunner.stubs:
+stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
   repositoryRoot: http://repo.spring.io/libs-snapshot

--- a/samples/standalone/dsl/http-client/src/test/resources/application.yaml
+++ b/samples/standalone/dsl/http-client/src/test/resources/application.yaml
@@ -1,3 +1,3 @@
 stubrunner:
   work-offline: true
-  stubs.ids: 'com.example:http-server-dsl:+:stubs:8080'
+  ids: 'com.example:http-server-dsl:+:stubs:8080'

--- a/samples/standalone/messaging/stream-sink/src/test/resources/application.yml
+++ b/samples/standalone/messaging/stream-sink/src/test/resources/application.yml
@@ -1,3 +1,3 @@
 stubrunner:
   work-offline: true
-  stubs.ids: 'com.example:stream-source'
+  ids: 'com.example:stream-source'

--- a/spring-cloud-contract-stub-runner/README.adoc
+++ b/spring-cloud-contract-stub-runner/README.adoc
@@ -182,7 +182,7 @@ include::src/test/resources/application.yml[]
 
 ==== Additional Configuration
 
-You can match the artifactId of the stub with the name of your app by using the `stubrunner.stubs.idsToServiceIds:` map.
+You can match the artifactId of the stub with the name of your app by using the `stubrunner.idsToServiceIds:` map.
 You can disable Stub Runner Ribbon support by providing: `stubrunner.cloud.ribbon.enabled` equal to `false`
 You can disable Stub Runner support by providing: `stubrunner.cloud.enabled` equal to `false`
 

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
@@ -171,7 +171,7 @@ public class AetherStubDownloader implements StubDownloader {
 			throw new IllegalStateException("Cannot resolve version range", e);
 		}
 		if (rangeResult.getHighestVersion() == null) {
-			log.error("For groupId [" + stubsGroup + "] artifactId [" + artifact + "] "
+			log.error("For groupId [" + stubsGroup + "] artifactId [" + stubsModule + "] "
 					+ "and classifier [" + classifier + "] the version was not resolved!");
 		}
 		return rangeResult.getHighestVersion() == null ? null : rangeResult.getHighestVersion().toString();

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
@@ -68,19 +68,19 @@ public class AetherStubDownloader implements StubDownloader {
 			log.debug("Will be resolving versions for the following options: [" + stubRunnerOptions + "]");
 		}
 		this.remoteRepos = remoteRepositories(stubRunnerOptions);
-		boolean remoteReposNotPassed = remoteReposNotPassed();
-		if (!remoteReposNotPassed && stubRunnerOptions.workOffline) {
+		boolean remoteReposMissing = remoteReposMissing();
+		if (remoteReposMissing && stubRunnerOptions.workOffline) {
 			log.info("Remote repos not passed but the switch to work offline was set. "
 					+ "Stubs will be downloaded from your local Maven repository.");
 		}
-		if (remoteReposNotPassed && !stubRunnerOptions.workOffline) {
+		if (remoteReposMissing && !stubRunnerOptions.workOffline) {
 			throw new IllegalStateException("Remote repositories for stubs are not specified and work offline flag wasn't passed");
 		}
 		this.repositorySystem = newRepositorySystem();
 		this.session = newSession(this.repositorySystem, stubRunnerOptions.workOffline);
 	}
 
-	private boolean remoteReposNotPassed() {
+	private boolean remoteReposMissing() {
 		return remoteRepos == null || remoteRepos.isEmpty();
 	}
 
@@ -96,7 +96,7 @@ public class AetherStubDownloader implements StubDownloader {
 		this.remoteRepos = remoteRepositories;
 		this.repositorySystem = repositorySystem;
 		this.session = session;
-		if (remoteReposNotPassed()) {
+		if (remoteReposMissing()) {
 			log.error("Remote repositories for stubs are not specified and work offline flag wasn't passed");
 		}
 	}
@@ -158,6 +158,9 @@ public class AetherStubDownloader implements StubDownloader {
 		String version = getVersion(stubConfiguration.groupId,
 				stubConfiguration.artifactId, stubConfiguration.version,
 				stubConfiguration.classifier);
+		if (log.isDebugEnabled()) {
+			log.debug("Will download the stub for version [" + version + "]");
+		}
 		File unpackedJar = unpackedJar(version, stubConfiguration.groupId,
 				stubConfiguration.artifactId, stubConfiguration.classifier);
 		if (unpackedJar == null) {

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
@@ -68,7 +68,12 @@ public class AetherStubDownloader implements StubDownloader {
 			log.debug("Will be resolving versions for the following options: [" + stubRunnerOptions + "]");
 		}
 		this.remoteRepos = remoteRepositories(stubRunnerOptions);
-		if (remoteReposNotPassed() && !stubRunnerOptions.workOffline) {
+		boolean remoteReposNotPassed = remoteReposNotPassed();
+		if (!remoteReposNotPassed && stubRunnerOptions.workOffline) {
+			log.info("Remote repos not passed but the switch to work offline was set. "
+					+ "Stubs will be downloaded from your local Maven repository.");
+		}
+		if (remoteReposNotPassed && !stubRunnerOptions.workOffline) {
 			throw new IllegalStateException("Remote repositories for stubs are not specified and work offline flag wasn't passed");
 		}
 		this.repositorySystem = newRepositorySystem();
@@ -92,7 +97,7 @@ public class AetherStubDownloader implements StubDownloader {
 		this.repositorySystem = repositorySystem;
 		this.session = session;
 		if (remoteReposNotPassed()) {
-			throw new IllegalStateException("Remote repositories for stubs are not specified and work offline flag wasn't passed");
+			log.error("Remote repositories for stubs are not specified and work offline flag wasn't passed");
 		}
 	}
 

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
@@ -64,9 +64,12 @@ public class AetherStubDownloader implements StubDownloader {
 	private final RepositorySystemSession session;
 
 	public AetherStubDownloader(StubRunnerOptions stubRunnerOptions) {
+		if (log.isDebugEnabled()) {
+			log.debug("Will be resolving versions for the following options: [" + stubRunnerOptions + "]");
+		}
 		this.remoteRepos = remoteRepositories(stubRunnerOptions);
 		if (remoteRepos == null || remoteRepos.isEmpty()) {
-			log.error("Remote repositories for stubs are not specified!");
+			log.warn("Remote repositories for stubs are not specified! Will work offline");
 		}
 		this.repositorySystem = newRepositorySystem();
 		this.session = newSession(this.repositorySystem, stubRunnerOptions.workOffline);

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
@@ -171,7 +171,8 @@ public class AetherStubDownloader implements StubDownloader {
 			throw new IllegalStateException("Cannot resolve version range", e);
 		}
 		if (rangeResult.getHighestVersion() == null) {
-			log.error("Version was not resolved!");
+			log.error("For groupId [" + stubsGroup + "] artifactId [" + artifact + "] "
+					+ "and classifier [" + classifier + "] the version was not resolved!");
 		}
 		return rangeResult.getHighestVersion() == null ? null : rangeResult.getHighestVersion().toString();
 	}

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
@@ -103,8 +103,12 @@ public class AetherStubDownloader implements StubDownloader {
 
 	private List<RemoteRepository> remoteRepositories(
 			StubRunnerOptions stubRunnerOptions) {
-		return newRepositories(
+		List<RemoteRepository>  remoteRepos = newRepositories(
 				Arrays.asList(stubRunnerOptions.stubRepositoryRoot.split(",")));
+		if (log.isDebugEnabled()) {
+			log.debug("Using the following remote repos " + remoteRepos);
+		}
+		return remoteRepos;
 	}
 
 	private File unpackedJar(String resolvedVersion, String stubsGroup,
@@ -181,6 +185,9 @@ public class AetherStubDownloader implements StubDownloader {
 		try {
 			rangeResult = repositorySystem.resolveVersionRange(session,
 					versionRangeRequest);
+			if (log.isDebugEnabled()) {
+				log.debug("Resolved version range is [" + rangeResult + "]");
+			}
 		}
 		catch (VersionRangeResolutionException e) {
 			throw new IllegalStateException("Cannot resolve version range", e);

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
@@ -76,6 +76,10 @@ public class AetherStubDownloader implements StubDownloader {
 		if (remoteReposMissing && !stubRunnerOptions.workOffline) {
 			throw new IllegalStateException("Remote repositories for stubs are not specified and work offline flag wasn't passed");
 		}
+		if (!remoteReposMissing && stubRunnerOptions.workOffline) {
+			throw new IllegalStateException("Remote repositories for stubs are specified and work offline flag is set. "
+					+ "You have to provide one of them.");
+		}
 		this.repositorySystem = newRepositorySystem();
 		this.session = newSession(this.repositorySystem, stubRunnerOptions.workOffline);
 	}

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
@@ -68,11 +68,15 @@ public class AetherStubDownloader implements StubDownloader {
 			log.debug("Will be resolving versions for the following options: [" + stubRunnerOptions + "]");
 		}
 		this.remoteRepos = remoteRepositories(stubRunnerOptions);
-		if (remoteRepos == null || remoteRepos.isEmpty()) {
-			log.warn("Remote repositories for stubs are not specified! Will work offline");
+		if (remoteReposNotPassed() && !stubRunnerOptions.workOffline) {
+			throw new IllegalStateException("Remote repositories for stubs are not specified and work offline flag wasn't passed");
 		}
 		this.repositorySystem = newRepositorySystem();
 		this.session = newSession(this.repositorySystem, stubRunnerOptions.workOffline);
+	}
+
+	private boolean remoteReposNotPassed() {
+		return remoteRepos == null || remoteRepos.isEmpty();
 	}
 
 	/**
@@ -87,8 +91,8 @@ public class AetherStubDownloader implements StubDownloader {
 		this.remoteRepos = remoteRepositories;
 		this.repositorySystem = repositorySystem;
 		this.session = session;
-		if (remoteRepos == null || remoteRepos.isEmpty()) {
-			log.error("Remote remoteRepositories for stubs are not specified!");
+		if (remoteReposNotPassed()) {
+			throw new IllegalStateException("Remote repositories for stubs are not specified and work offline flag wasn't passed");
 		}
 	}
 

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
@@ -71,7 +71,7 @@ public class AetherStubDownloader implements StubDownloader {
 		boolean remoteReposMissing = remoteReposMissing();
 		if (remoteReposMissing && stubRunnerOptions.workOffline) {
 			log.info("Remote repos not passed but the switch to work offline was set. "
-					+ "Stubs will be downloaded from your local Maven repository.");
+					+ "Stubs will be used from your local Maven repository.");
 		}
 		if (remoteReposMissing && !stubRunnerOptions.workOffline) {
 			throw new IllegalStateException("Remote repositories for stubs are not specified and work offline flag wasn't passed");

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerFactory.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerFactory.java
@@ -58,6 +58,9 @@ class StubRunnerFactory {
 		for (StubConfiguration stubsConfiguration : stubRunnerOptions.getDependencies()) {
 			Map.Entry<StubConfiguration, File> entry = stubDownloader
 					.downloadAndUnpackStubJar(stubRunnerOptions, stubsConfiguration);
+			if (log.isDebugEnabled()) {
+				log.debug("For stub configuration [" + stubsConfiguration + "] the downloaded entry is [" + entry + "]");
+			}
 			if (entry != null) {
 				result.add(createStubRunner(entry.getKey(), entry.getValue()));
 			}

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerFactory.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerFactory.java
@@ -17,10 +17,13 @@
 package org.springframework.cloud.contract.stubrunner;
 
 import java.io.File;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.contract.verifier.messaging.MessageVerifier;
 
 /**
@@ -28,6 +31,8 @@ import org.springframework.cloud.contract.verifier.messaging.MessageVerifier;
  * stubs and returns a list of corresponding stub runners.
  */
 class StubRunnerFactory {
+
+	private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
 	private final StubRunnerOptions stubRunnerOptions;
 	private final StubDownloader stubDownloader;
@@ -42,6 +47,13 @@ class StubRunnerFactory {
 	}
 
 	public Collection<StubRunner> createStubsFromServiceConfiguration() {
+		if (log.isDebugEnabled()) {
+			log.debug("Will download stubs for dependencies " + this.stubRunnerOptions.getDependencies());
+		}
+		if (this.stubRunnerOptions.getDependencies().isEmpty()) {
+			log.warn("No stubs to download have been passed. Most likely you have forgotten to pass "
+					+ "them either via annotation or a property");
+		}
 		Collection<StubRunner> result = new ArrayList<>();
 		for (StubConfiguration stubsConfiguration : stubRunnerOptions.getDependencies()) {
 			Map.Entry<StubConfiguration, File> entry = stubDownloader

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/junit/StubRunnerRule.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/junit/StubRunnerRule.java
@@ -67,10 +67,10 @@ public class StubRunnerRule implements TestRule, StubFinder {
 		return new StubRunnerOptionsBuilder()
 				.withMinPort(Integer.valueOf(System.getProperty("stubrunner.port.range.min", "10000")))
 				.withMaxPort(Integer.valueOf(System.getProperty("stubrunner.port.range.max", "15000")))
-				.withStubRepositoryRoot(System.getProperty("stubrunner.stubs.repository.root", ""))
+				.withStubRepositoryRoot(System.getProperty("stubrunner.repository.root", ""))
 				.withWorkOffline(Boolean.parseBoolean(System.getProperty("stubrunner.work-offline", "false")))
-				.withStubsClassifier(System.getProperty("stubrunner.stubs.classifier", "stubs"))
-				.withStubs(System.getProperty("stubrunner.stubs.ids", ""))
+				.withStubsClassifier(System.getProperty("stubrunner.classifier", "stubs"))
+				.withStubs(System.getProperty("stubrunner.ids", ""))
 				.build();
 	}
 

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/AutoConfigureStubRunner.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/AutoConfigureStubRunner.java
@@ -23,6 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.properties.PropertyMapping;
 import org.springframework.cloud.contract.verifier.messaging.boot.AutoConfigureMessageVerifier;
 
 /**
@@ -34,6 +35,31 @@ import org.springframework.cloud.contract.verifier.messaging.boot.AutoConfigureM
 @Documented
 @ImportAutoConfiguration
 @AutoConfigureMessageVerifier
+@PropertyMapping("stubrunner")
 public @interface AutoConfigureStubRunner {
 
+	/**
+	 * Min value of a port for the automatically started WireMock server
+	 */
+	int minPort() default 10000;
+
+	/**
+	 * Max value of a port for the automatically started WireMock server
+	 */
+	int maxPort() default 15000;
+
+	/**
+	 * Should the stubs be checked for presence only locally
+	 */
+	boolean workOffline() default false;
+
+	/**
+	 * The ids of the stubs to run in "ivy" notation (groupId:artifactId[:classifier]:version[:port]).
+	 */
+	String[] ids() default {};
+
+	/**
+	 * The classifier to use by default in ivy co-ordinates for a stub.
+	 */
+	String classifier() default "stubs";
 }

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/AutoConfigureStubRunner.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/AutoConfigureStubRunner.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Target;
 
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.properties.PropertyMapping;
+import org.springframework.boot.test.autoconfigure.properties.SkipPropertyMapping;
 import org.springframework.cloud.contract.verifier.messaging.boot.AutoConfigureMessageVerifier;
 
 /**
@@ -35,7 +36,7 @@ import org.springframework.cloud.contract.verifier.messaging.boot.AutoConfigureM
 @Documented
 @ImportAutoConfiguration
 @AutoConfigureMessageVerifier
-@PropertyMapping("stubrunner")
+@PropertyMapping(value = "stubrunner", skip = SkipPropertyMapping.ON_DEFAULT_VALUE)
 public @interface AutoConfigureStubRunner {
 
 	/**
@@ -52,6 +53,11 @@ public @interface AutoConfigureStubRunner {
 	 * Should the stubs be checked for presence only locally
 	 */
 	boolean workOffline() default false;
+
+	/**
+	 * The repository root to use (defaults to local Maven repo).
+	 */
+	String repositoryRoot() default "";
 
 	/**
 	 * The ids of the stubs to run in "ivy" notation (groupId:artifactId[:classifier]:version[:port]).

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerConfiguration.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerConfiguration.java
@@ -54,25 +54,17 @@ public class StubRunnerConfiguration {
 	 * Bean that initializes stub runners, runs them and on shutdown closes them. Upon its
 	 * instantiation JAR with stubs is downloaded and unpacked to a temporary folder and
 	 * WireMock server are started for each of those stubs
-	 *
-	 * @param minPortValue min port value of the WireMock instance for stubs
-	 * @param maxPortValue max port value of the WireMock instance for stubs
-	 * @param stubRepositoryRoot root URL from where the JAR with stub mappings will be
-	 * downloaded
-	 * @param stubsSuffix classifier for the jar containing stubs
-	 * @param workOffline forces offline work
-	 * @param stubs comma separated list of stubs presented in Ivy notation
 	 */
 	@Bean
 	public BatchStubRunner batchStubRunner() throws IOException {
 		StubRunnerOptions stubRunnerOptions = new StubRunnerOptionsBuilder()
 				.withMinMaxPort(props.getMinPort(), props.getMaxPort())
 				.withStubRepositoryRoot(
-						uriStringOrEmpty(props.getStubs().getRepositoryRoot()))
-				.withWorkOffline(props.getStubs().getRepositoryRoot() == null
+						uriStringOrEmpty(props.getRepositoryRoot()))
+				.withWorkOffline(props.getRepositoryRoot() == null
 						|| props.isWorkOffline())
-				.withStubsClassifier(props.getStubs().getClassifier())
-				.withStubs(props.getStubs().getIds()).build();
+				.withStubsClassifier(props.getClassifier())
+				.withStubs(props.getIds()).build();
 		BatchStubRunner batchStubRunner = new BatchStubRunnerFactory(stubRunnerOptions,
 				stubDownloader != null ? stubDownloader
 						: new AetherStubDownloader(stubRunnerOptions),

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerProperties.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerProperties.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.contract.stubrunner.spring;
 
+import java.util.Arrays;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.io.Resource;
 
@@ -104,4 +106,10 @@ public class StubRunnerProperties {
 		this.classifier = classifier;
 	}
 
+	@Override public String toString() {
+		return "StubRunnerProperties{" + "minPort=" + minPort + ", maxPort=" + maxPort
+				+ ", workOffline=" + workOffline + ", repositoryRoot=" + repositoryRoot
+				+ ", ids=" + Arrays.toString(ids) + ", classifier='" + classifier + '\''
+				+ '}';
+	}
 }

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerProperties.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerProperties.java
@@ -27,21 +27,34 @@ import org.springframework.core.io.Resource;
 public class StubRunnerProperties {
 
 	/**
-	 * 
+	 * Min value of a port for the automatically started WireMock server
 	 */
 	private int minPort = 10000;
 
 	/**
-	 * 
+	 * Max value of a port for the automatically started WireMock server
 	 */
 	private int maxPort = 15000;
 
 	/**
-	 * 
+	 * Should the stubs be checked for presence only locally
 	 */
 	private boolean workOffline;
 
-	private Stubs stubs = new Stubs();
+	/**
+	 * The repository root to use (defaults to local Maven repo).
+	 */
+	private Resource repositoryRoot;
+
+	/**
+	 * The ids of the stubs to run in "ivy" notation (groupId:artifactId[:classifier]:version[:port]).
+	 */
+	private String[] ids = new String[0];
+
+	/**
+	 * The classifier to use by default in ivy co-ordinates for a stub.
+	 */
+	private String classifier = "stubs";
 
 	public int getMinPort() {
 		return minPort;
@@ -67,51 +80,28 @@ public class StubRunnerProperties {
 		this.workOffline = workOffline;
 	}
 
-	public Stubs getStubs() {
-		return stubs;
+	public Resource getRepositoryRoot() {
+		return repositoryRoot;
 	}
 
-	public void setStubs(Stubs stubs) {
-		this.stubs = stubs;
+	public void setRepositoryRoot(Resource repositoryRoot) {
+		this.repositoryRoot = repositoryRoot;
 	}
 
-	public static class Stubs {
-		/**
-		 * The repository root to use (defaults to local Maven repo).
-		 */
-		private Resource repositoryRoot;
-		/**
-		 * The ids of the stubs to run in "ivy" notation (groupId:artifactId[:classifier]:version[:port]).
-		 */
-		private String[] ids = new String[0];
-		/**
-		 * The classifier to use by default in ivy co-ordinates for a stub.
-		 */
-		private String classifier = "stubs";
+	public String[] getIds() {
+		return ids;
+	}
 
-		public Resource getRepositoryRoot() {
-			return repositoryRoot;
-		}
+	public void setIds(String[] ids) {
+		this.ids = ids;
+	}
 
-		public void setRepositoryRoot(Resource repositoryRoot) {
-			this.repositoryRoot = repositoryRoot;
-		}
+	public String getClassifier() {
+		return classifier;
+	}
 
-		public String[] getIds() {
-			return ids;
-		}
-
-		public void setIds(String[] ids) {
-			this.ids = ids;
-		}
-
-		public String getClassifier() {
-			return classifier;
-		}
-
-		public void setClassifier(String classifier) {
-			this.classifier = classifier;
-		}
+	public void setClassifier(String classifier) {
+		this.classifier = classifier;
 	}
 
 }

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerProperties.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerProperties.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.contract.stubrunner.spring;
 import java.util.Arrays;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 
 /**
@@ -86,8 +87,8 @@ public class StubRunnerProperties {
 		return repositoryRoot;
 	}
 
-	public void setRepositoryRoot(Resource repositoryRoot) {
-		this.repositoryRoot = repositoryRoot;
+	public void setRepositoryRoot(String repositoryRoot) {
+		this.repositoryRoot = new DefaultResourceLoader().getResource(repositoryRoot);
 	}
 
 	public String[] getIds() {

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/cloud/StubMapperProperties.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/cloud/StubMapperProperties.java
@@ -28,7 +28,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * Just provide in your properties file for example:
  *
- * stubrunner.stubs.idsToServiceIds:
+ * stubrunner.idsToServiceIds:
  *     ivyNotation: someValueInsideYourCode
  *     fraudDetectionServer: someNameThatShouldMapFraudDetectionServer
  *
@@ -36,7 +36,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @since 1.0.0
  */
-@ConfigurationProperties("stubrunner.stubs")
+@ConfigurationProperties("stubrunner")
 public class StubMapperProperties {
 
 	/**

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/junit/StubRunnerRuleCustomPortJUnitTest.java
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/junit/StubRunnerRuleCustomPortJUnitTest.java
@@ -36,8 +36,8 @@ public class StubRunnerRuleCustomPortJUnitTest {
 	@BeforeClass
 	@AfterClass
 	public static void setupProps() {
-			System.clearProperty("stubrunner.stubs.repository.root");
-			System.clearProperty("stubrunner.stubs.classifier");
+			System.clearProperty("stubrunner.repository.root");
+			System.clearProperty("stubrunner.classifier");
 	}
 
 	// tag::classrule_with_port[]

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/junit/StubRunnerRuleJUnitTest.java
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/junit/StubRunnerRuleJUnitTest.java
@@ -36,8 +36,8 @@ public class StubRunnerRuleJUnitTest {
 	@BeforeClass
 	@AfterClass
 	public static void setupProps() {
-			System.clearProperty("stubrunner.stubs.repository.root");
-			System.clearProperty("stubrunner.stubs.classifier");
+			System.clearProperty("stubrunner.repository.root");
+			System.clearProperty("stubrunner.classifier");
 	}
 
 	// tag::classrule[]

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/junit/StubRunnerRuleSpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/junit/StubRunnerRuleSpec.groovy
@@ -30,8 +30,8 @@ class StubRunnerRuleSpec extends Specification {
 	@BeforeClass
 	@AfterClass
 	void setupProps() {
-		System.clearProperty("stubrunner.stubs.repository.root");
-		System.clearProperty("stubrunner.stubs.classifier");
+		System.clearProperty("stubrunner.repository.root");
+		System.clearProperty("stubrunner.classifier");
 	}
 
 	// tag::classrule[]

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/server/StubRunnerBootSpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/server/StubRunnerBootSpec.groovy
@@ -16,25 +16,22 @@
 
 package org.springframework.cloud.contract.stubrunner.server
 
+import com.jayway.restassured.module.mockmvc.RestAssuredMockMvc
 import groovy.json.JsonSlurper
-
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.IntegrationTest
 import org.springframework.boot.test.context.SpringBootContextLoader
 import org.springframework.cloud.contract.stubrunner.StubRunning
-import org.springframework.context.annotation.Configuration
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
-
 import spock.lang.Specification
-
-import com.jayway.restassured.module.mockmvc.RestAssuredMockMvc
-
 /**
  * @author Marcin Grzejszczak
  */
 // tag::boot_usage[]
 @ContextConfiguration(classes = StubRunnerBoot, loader = SpringBootContextLoader)
 @IntegrationTest("spring.cloud.zookeeper.enabled=false")
+@ActiveProfiles("test")
 class StubRunnerBootSpec extends Specification {
 
 	@Autowired StubRunning stubRunning

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/spring/StubRunnerConfigurationSpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/spring/StubRunnerConfigurationSpec.groovy
@@ -25,6 +25,7 @@ import org.springframework.boot.test.context.SpringBootContextLoader
 import org.springframework.cloud.contract.stubrunner.StubFinder
 import org.springframework.context.annotation.Configuration
 import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 
 import spock.lang.Specification
@@ -39,6 +40,7 @@ import spock.lang.Specification
 @IntegrationTest(["stubrunner.cloud.enabled=false", "stubrunner.camel.enabled=false"])
 @AutoConfigureStubRunner
 @DirtiesContext
+@ActiveProfiles("test")
 class StubRunnerConfigurationSpec extends Specification {
 
 	@Autowired StubFinder stubFinder
@@ -46,8 +48,8 @@ class StubRunnerConfigurationSpec extends Specification {
 	@BeforeClass
 	@AfterClass
 	void setupProps() {
-		System.clearProperty("stubrunner.stubs.repository.root");
-		System.clearProperty("stubrunner.stubs.classifier");
+		System.clearProperty("stubrunner.repository.root");
+		System.clearProperty("stubrunner.classifier");
 	}
 
 	def 'should start WireMock servers'() {

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/spring/cloud/StubRunnerSpringCloudAutoConfigurationSpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/spring/cloud/StubRunnerSpringCloudAutoConfigurationSpec.groovy
@@ -27,6 +27,7 @@ import org.springframework.cloud.client.discovery.EnableDiscoveryClient
 import org.springframework.cloud.client.loadbalancer.LoadBalanced
 import org.springframework.cloud.contract.stubrunner.StubFinder
 import org.springframework.cloud.contract.stubrunner.spring.AutoConfigureStubRunner
+import org.springframework.cloud.contract.stubrunner.spring.StubRunnerProperties
 import org.springframework.cloud.zookeeper.ZookeeperProperties
 import org.springframework.cloud.zookeeper.discovery.ZookeeperServiceDiscovery
 import org.springframework.context.annotation.Bean
@@ -54,12 +55,17 @@ class StubRunnerSpringCloudAutoConfigurationSpec extends Specification {
 	@Autowired @LoadBalanced RestTemplate restTemplate
 	// TODO: this shouldn't be needed?
 	@Autowired ZookeeperServiceDiscovery zookeeperServiceDiscovery
+	@Autowired StubRunnerProperties stubRunnerProperties
 
 	@BeforeClass
 	@AfterClass
 	static void setupProps() {
 		System.clearProperty("stubrunner.repository.root")
 		System.clearProperty("stubrunner.classifier")
+	}
+
+	def setup() {
+		println "StubRunner properties are [$stubRunnerProperties]"
 	}
 
 	// tag::test[]

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/spring/cloud/StubRunnerSpringCloudAutoConfigurationSpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/spring/cloud/StubRunnerSpringCloudAutoConfigurationSpec.groovy
@@ -37,6 +37,7 @@ import org.springframework.test.context.ContextConfiguration
 import org.springframework.util.SocketUtils
 import org.springframework.web.client.RestTemplate
 import spock.lang.Specification
+
 /**
  * @author Marcin Grzejszczak
  */
@@ -45,9 +46,10 @@ import spock.lang.Specification
 		properties = ["stubrunner.camel.enabled=false"])
 @AutoConfigureStubRunner(ids =
 		["org.springframework.cloud.contract.verifier.stubs:loanIssuance",
-				"org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer",
-				"org.springframework.cloud.contract.verifier.stubs:bootService"],
-		workOffline = true)
+		"org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer",
+		"org.springframework.cloud.contract.verifier.stubs:bootService"],
+		workOffline = true,
+		repositoryRoot = "classpath:m2repo/repository/")
 @DirtiesContext
 class StubRunnerSpringCloudAutoConfigurationSpec extends Specification {
 
@@ -71,11 +73,11 @@ class StubRunnerSpringCloudAutoConfigurationSpec extends Specification {
 	// tag::test[]
 	def 'should make service discovery work'() {
 		expect: 'WireMocks are running'
-		"${stubFinder.findStubUrl('loanIssuance').toString()}/name".toURL().text == 'loanIssuance'
-		"${stubFinder.findStubUrl('fraudDetectionServer').toString()}/name".toURL().text == 'fraudDetectionServer'
+			"${stubFinder.findStubUrl('loanIssuance').toString()}/name".toURL().text == 'loanIssuance'
+			"${stubFinder.findStubUrl('fraudDetectionServer').toString()}/name".toURL().text == 'fraudDetectionServer'
 		and: 'Stubs can be reached via load service discovery'
-		restTemplate.getForObject('http://loanIssuance/name', String) == 'loanIssuance'
-		restTemplate.getForObject('http://someNameThatShouldMapFraudDetectionServer/name', String) == 'fraudDetectionServer'
+			restTemplate.getForObject('http://loanIssuance/name', String) == 'loanIssuance'
+			restTemplate.getForObject('http://someNameThatShouldMapFraudDetectionServer/name', String) == 'fraudDetectionServer'
 	}
 	// end::test[]
 

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/spring/cloud/StubRunnerSpringCloudAutoConfigurationSpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/spring/cloud/StubRunnerSpringCloudAutoConfigurationSpec.groovy
@@ -48,7 +48,6 @@ import spock.lang.Specification
 		["org.springframework.cloud.contract.verifier.stubs:loanIssuance",
 		"org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer",
 		"org.springframework.cloud.contract.verifier.stubs:bootService"],
-		workOffline = true,
 		repositoryRoot = "classpath:m2repo/repository/")
 @DirtiesContext
 class StubRunnerSpringCloudAutoConfigurationSpec extends Specification {

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/spring/cloud/StubRunnerSpringCloudAutoConfigurationWithoutDiscoverySpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/spring/cloud/StubRunnerSpringCloudAutoConfigurationWithoutDiscoverySpec.groovy
@@ -45,7 +45,6 @@ import spock.lang.Specification
 		["org.springframework.cloud.contract.verifier.stubs:loanIssuance",
 		"org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer",
 		"org.springframework.cloud.contract.verifier.stubs:bootService"],
-		workOffline = true,
 		repositoryRoot = "classpath:m2repo/repository/")
 @DirtiesContext
 class StubRunnerSpringCloudAutoConfigurationWithoutDiscoverySpec extends Specification {

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/spring/cloud/StubRunnerSpringCloudAutoConfigurationWithoutDiscoverySpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/spring/cloud/StubRunnerSpringCloudAutoConfigurationWithoutDiscoverySpec.groovy
@@ -41,7 +41,7 @@ import spock.lang.Specification
 		properties = ["stubrunner.camel.enabled=false",
 				"spring.cloud.zookeeper.enabled=false",
 				"spring.cloud.zookeeper.discovery.enabled=false"])
-@AutoConfigureStubRunner(workOffline = true)
+@AutoConfigureStubRunner(workOffline = true, repositoryRoot = "classpath:m2repo/repository/")
 @DirtiesContext
 class StubRunnerSpringCloudAutoConfigurationWithoutDiscoverySpec extends Specification {
 

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/spring/cloud/StubRunnerSpringCloudAutoConfigurationWithoutDiscoverySpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/spring/cloud/StubRunnerSpringCloudAutoConfigurationWithoutDiscoverySpec.groovy
@@ -41,7 +41,7 @@ import spock.lang.Specification
 		properties = ["stubrunner.camel.enabled=false",
 				"spring.cloud.zookeeper.enabled=false",
 				"spring.cloud.zookeeper.discovery.enabled=false"])
-@AutoConfigureStubRunner
+@AutoConfigureStubRunner(workOffline = true)
 @DirtiesContext
 class StubRunnerSpringCloudAutoConfigurationWithoutDiscoverySpec extends Specification {
 

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/spring/cloud/StubRunnerSpringCloudAutoConfigurationWithoutDiscoverySpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/spring/cloud/StubRunnerSpringCloudAutoConfigurationWithoutDiscoverySpec.groovy
@@ -41,7 +41,12 @@ import spock.lang.Specification
 		properties = ["stubrunner.camel.enabled=false",
 				"spring.cloud.zookeeper.enabled=false",
 				"spring.cloud.zookeeper.discovery.enabled=false"])
-@AutoConfigureStubRunner(workOffline = true, repositoryRoot = "classpath:m2repo/repository/")
+@AutoConfigureStubRunner( ids =
+		["org.springframework.cloud.contract.verifier.stubs:loanIssuance",
+		"org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer",
+		"org.springframework.cloud.contract.verifier.stubs:bootService"],
+		workOffline = true,
+		repositoryRoot = "classpath:m2repo/repository/")
 @DirtiesContext
 class StubRunnerSpringCloudAutoConfigurationWithoutDiscoverySpec extends Specification {
 

--- a/spring-cloud-contract-stub-runner/src/test/resources/application-test.yml
+++ b/spring-cloud-contract-stub-runner/src/test/resources/application-test.yml
@@ -1,4 +1,5 @@
 stubrunner:
+  repositoryRoot: classpath:m2repo/repository/
   ids:
     - org.springframework.cloud.contract.verifier.stubs:loanIssuance
     - org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer

--- a/spring-cloud-contract-stub-runner/src/test/resources/application-test.yml
+++ b/spring-cloud-contract-stub-runner/src/test/resources/application-test.yml
@@ -1,0 +1,5 @@
+stubrunner:
+  ids:
+    - org.springframework.cloud.contract.verifier.stubs:loanIssuance
+    - org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer
+    - org.springframework.cloud.contract.verifier.stubs:bootService

--- a/spring-cloud-contract-stub-runner/src/test/resources/application.yml
+++ b/spring-cloud-contract-stub-runner/src/test/resources/application.yml
@@ -1,5 +1,4 @@
 stubrunner:
-  repositoryRoot: classpath:m2repo/repository/
   idsToServiceIds:
     ivyNotation: someValueInsideYourCode
     fraudDetectionServer: someNameThatShouldMapFraudDetectionServer

--- a/spring-cloud-contract-stub-runner/src/test/resources/application.yml
+++ b/spring-cloud-contract-stub-runner/src/test/resources/application.yml
@@ -1,9 +1,5 @@
-stubrunner.stubs.repositoryRoot: classpath:m2repo/repository/
-stubrunner.stubs.ids:
-  - org.springframework.cloud.contract.verifier.stubs:loanIssuance
-  - org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer
-  - org.springframework.cloud.contract.verifier.stubs:bootService
-
-stubrunner.stubs.idsToServiceIds:
-  ivyNotation: someValueInsideYourCode
-  fraudDetectionServer: someNameThatShouldMapFraudDetectionServer
+stubrunner:
+  repositoryRoot: classpath:m2repo/repository/
+  idsToServiceIds:
+    ivyNotation: someValueInsideYourCode
+    fraudDetectionServer: someNameThatShouldMapFraudDetectionServer

--- a/spring-cloud-contract-stub-runner/src/test/resources/logback.xml
+++ b/spring-cloud-contract-stub-runner/src/test/resources/logback.xml
@@ -16,15 +16,10 @@
 
 <configuration>
 
-	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-		<!-- encoders are assigned the type
-			 ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
-		<encoder>
-			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-		</encoder>
-	</appender>
+	<include resource="org/springframework/boot/logging/logback/base.xml"/>
+	<logger name="org.springframework.cloud" level="DEBUG"/>
 
 	<root level="INFO">
-		<appender-ref ref="STDOUT" />
+		<appender-ref ref="CONSOLE" />
 	</root>
 </configuration>

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/test/resources/functionalTest/bootSimple/src/test/resources/logback-test.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/test/resources/functionalTest/bootSimple/src/test/resources/logback-test.groovy
@@ -27,4 +27,4 @@ appender(console, ConsoleAppender) {
 }
 
 root(INFO, [console])
-logger("org.springframework.cloud.contract.verifier", DEBUG)
+logger("org.springframework.cloud", DEBUG)

--- a/tests/spring-cloud-contract-stub-runner-camel/src/test/resources/application.yml
+++ b/tests/spring-cloud-contract-stub-runner-camel/src/test/resources/application.yml
@@ -1,2 +1,2 @@
-stubrunner.stubs.repositoryRoot: classpath:m2repo/repository/
-stubrunner.stubs.ids: org.springframework.cloud.contract.verifier.stubs:camelService
+stubrunner.repositoryRoot: classpath:m2repo/repository/
+stubrunner.ids: org.springframework.cloud.contract.verifier.stubs:camelService

--- a/tests/spring-cloud-contract-stub-runner-integration/src/test/groovy/org/springframework/cloud/contract/stubrunner/messaging/integration/IntegrationStubRunnerSpec.groovy
+++ b/tests/spring-cloud-contract-stub-runner-integration/src/test/groovy/org/springframework/cloud/contract/stubrunner/messaging/integration/IntegrationStubRunnerSpec.groovy
@@ -18,9 +18,6 @@ package org.springframework.cloud.contract.stubrunner.messaging.integration
 
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
-
-import java.util.concurrent.TimeUnit
-
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.test.context.SpringBootContextLoader
@@ -33,16 +30,13 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.ImportResource
 import org.springframework.messaging.Message
 import org.springframework.test.context.ContextConfiguration
-
 import spock.lang.Specification
 
+import java.util.concurrent.TimeUnit
 /**
  * @author Marcin Grzejszczak
  */
-@Configuration
-@ComponentScan
-@EnableAutoConfiguration
-@ContextConfiguration(classes = IntegrationStubRunnerSpec, loader = SpringBootContextLoader)
+@ContextConfiguration(classes = Config, loader = SpringBootContextLoader)
 @ImportResource("classpath*:integration-context.xml")
 @AutoConfigureStubRunner
 class IntegrationStubRunnerSpec extends Specification {
@@ -225,5 +219,12 @@ class IntegrationStubRunnerSpec extends Specification {
 				}
 			}
 	// end::sample_dsl_3[]
+
+	@Configuration
+	@ComponentScan
+	@EnableAutoConfiguration
+	static class Config {
+
+	}
 
 }

--- a/tests/spring-cloud-contract-stub-runner-integration/src/test/resources/application.yml
+++ b/tests/spring-cloud-contract-stub-runner-integration/src/test/resources/application.yml
@@ -1,2 +1,2 @@
-stubrunner.stubs.repositoryRoot: classpath:m2repo/repository/
-stubrunner.stubs.ids: org.springframework.cloud.contract.verifier.stubs:integrationService:0.0.1-SNAPSHOT
+stubrunner.repositoryRoot: classpath:m2repo/repository/
+stubrunner.ids: org.springframework.cloud.contract.verifier.stubs:integrationService:0.0.1-SNAPSHOT

--- a/tests/spring-cloud-contract-stub-runner-stream/src/test/resources/application.yml
+++ b/tests/spring-cloud-contract-stub-runner-stream/src/test/resources/application.yml
@@ -1,5 +1,5 @@
-stubrunner.stubs.repositoryRoot: classpath:m2repo/repository/
-stubrunner.stubs.ids: org.springframework.cloud.contract.verifier.stubs:streamService:0.0.1-SNAPSHOT:stubs
+stubrunner.repositoryRoot: classpath:m2repo/repository/
+stubrunner.ids: org.springframework.cloud.contract.verifier.stubs:streamService:0.0.1-SNAPSHOT:stubs
 
 spring:
   cloud:


### PR DESCRIPTION
it's much easier to pass props via the annotation instead of property files. With this change the user can provide the properties inside the test via the annotation. The only thing that has to be passed via props is repositoryRoot (typically it's a very constant property that you set once).

fixes #46

cc @dsyer 
BTW for some reason I couldn't make `repositoryRoot` set via the annotation. Even if I made it a String. What always was taken was the default value. Strange...