### PR TITLE
Allow MethodBodyBuilder to evaluate ExecutionProperty objects

### DIFF
--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/ExecutionProperty.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/ExecutionProperty.groovy
@@ -42,4 +42,9 @@ class ExecutionProperty {
 	String insertValue(String valueToInsert) {
 		return executionCommand.replaceAll(PLACEHOLDER_VALUE, valueToInsert)
 	}
+
+	@Override
+	public String toString() {
+		return executionCommand;
+	}
 }

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JUnitMessagingMethodBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JUnitMessagingMethodBodyBuilder.groovy
@@ -153,7 +153,7 @@ class JUnitMessagingMethodBodyBuilder extends MessagingMethodBodyBuilder {
 
 	@Override
 	protected String getHeaderString(Header header) {
-		return ".header(\"${getTestSideValue(header.name)}\", \"${getTestSideValue(header.serverValue)}\")"
+		return ".header(${getTestSideValue(header.name)}, ${getTestSideValue(header.serverValue)})"
 	}
 
 	@Override

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JUnitMethodBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JUnitMethodBodyBuilder.groovy
@@ -125,7 +125,7 @@ abstract class JUnitMethodBodyBuilder extends RequestProcessingMethodBodyBuilder
 
 	@Override
 	protected String getHeaderString(Header header) {
-		return ".header(\"${getTestSideValue(header.name)}\", \"${getTestSideValue(header.serverValue)}\")"
+		return ".header(${getTestSideValue(header.name)}, ${getTestSideValue(header.serverValue)})"
 	}
 
 	@Override

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/MethodBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/MethodBodyBuilder.groovy
@@ -359,8 +359,17 @@ abstract class MethodBodyBuilder {
 	 * combines them into a String representation
 	 */
 	protected String getTestSideValue(Object object) {
-		return MapConverter.getTestSideValues(object).toString()
+		return '"' + MapConverter.getTestSideValues(object).toString() + '"'
 	}
+
+	/**
+	 * Extracts the executable test side values and
+	 * returns the code of the executable
+	 */
+	protected String getTestSideValue(ExecutionProperty executionProperty) {
+		return executionProperty.toString()
+	}
+
 
 	/**
 	 * Appends to the {@link BlockBuilder} the assertion for the given body element

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/RequestProcessingMethodBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/RequestProcessingMethodBodyBuilder.groovy
@@ -109,7 +109,7 @@ abstract class RequestProcessingMethodBodyBuilder extends MethodBodyBuilder {
 		String url = buildUrl(request)
 		String method = request.method.serverValue.toString().toLowerCase()
 
-		bb.addLine(/.${method}("$url")/)
+		bb.addLine(/.${method}($url)/)
 		addColonIfRequired(bb)
 		bb.unindent()
 	}

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/SpockMessagingMethodBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/SpockMessagingMethodBodyBuilder.groovy
@@ -150,7 +150,7 @@ class SpockMessagingMethodBodyBuilder extends MessagingMethodBodyBuilder {
 
 	@Override
 	protected String getHeaderString(Header header) {
-		return "'${getTestSideValue(header.name)}': '${getTestSideValue(header.serverValue)}'"
+		return "${getTestSideValue(header.name)}: ${getTestSideValue(header.serverValue)}"
 	}
 
 	@Override

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/SpockMethodRequestProcessingBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/SpockMethodRequestProcessingBodyBuilder.groovy
@@ -106,7 +106,7 @@ abstract class SpockMethodRequestProcessingBodyBuilder extends RequestProcessing
 
 	@Override
 	protected String getHeaderString(Header header) {
-		return ".header('${getTestSideValue(header.name)}', '${getTestSideValue(header.serverValue)}')"
+		return ".header(${getTestSideValue(header.name)}, ${getTestSideValue(header.serverValue)})"
 	}
 
 	@Override

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/ContractHttpDocsSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/ContractHttpDocsSpec.groovy
@@ -268,7 +268,7 @@ class ContractHttpDocsSpec extends Specification {
 """
  given:
   def request = given()
-    .header('Content-Type', 'application/json')
+    .header("Content-Type", "application/json")
     .body('''{"email":"abc@abc.com","callback_url":"http://partners.com"}''')
 
  when:


### PR DESCRIPTION
Fixes #111.

Currently `MethodBodyBuilder::getTestSideValue` returns a String without quotes around it.

If the server value is a static string, it returns the static string wrapped in double quotes.
If the server value is an `ExecutionProperty` instance, it returns the command's code unquoted.