### PR TITLE
Add UUID regex compatible with java.util.UUID.

### DIFF
--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/RegexPatterns.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/RegexPatterns.groovy
@@ -36,6 +36,7 @@ class RegexPatterns {
 	private static final Pattern HOSTNAME_PATTERN = Pattern.compile('((http[s]?|ftp):\\/)\\/?([^:\\/\\s]+)(:[0-9]{1,5})?');
 	private static final Pattern EMAIL = Pattern.compile('[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}');
 	private static final Pattern URL = Pattern.compile('((www\\.|(http|https|ftp|news|file)+\\:\\/\\/)[_.a-z0-9-]+\\.[a-z0-9\\/_:@=.+?,##%&~-]*[^.|\\\'|\\# |!|\\(|?|,| |>|<|;|\\)])')
+	private static final Pattern UUID = Pattern.compile('[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}')
 
 	String onlyAlphaUnicode() {
 		return ONLY_ALPHA_UNICODE.pattern()
@@ -63,6 +64,10 @@ class RegexPatterns {
 
 	String url() {
 		return URL.pattern()
+	}
+
+	String uuid(){
+		return UUID.pattern()
 	}
 	// end::regexps[]
 	

--- a/spring-cloud-contract-spec/src/test/groovy/org/springframework/cloud/contract/spec/internal/RegexPatternsSpec.groovy
+++ b/spring-cloud-contract-spec/src/test/groovy/org/springframework/cloud/contract/spec/internal/RegexPatternsSpec.groovy
@@ -66,13 +66,25 @@ class RegexPatternsSpec extends Specification {
 
 	def "should generate a regex for a number [#textToMatch] that is a match [#shouldMatch]"() {
 		expect:
-			shouldMatch == Pattern.compile(regexPatterns.number()).matcher(textToMatch).matches()
+		shouldMatch == Pattern.compile(regexPatterns.number()).matcher(textToMatch).matches()
 		where:
-			textToMatch || shouldMatch
-			'1'         || true
-			'1.0'       || true
-			'0.1'       || true
-			'.1'        || true
-			'1.'        || false
+		textToMatch || shouldMatch
+		'1'         || true
+		'1.0'       || true
+		'0.1'       || true
+		'.1'        || true
+		'1.'        || false
+	}
+
+	def "should generate a regex for a uuid [#textToMatch] that is a match [#shouldMatch]"() {
+		expect:
+		shouldMatch == Pattern.compile(regexPatterns.uuid()).matcher(textToMatch).matches()
+		where:
+		textToMatch							|| shouldMatch
+		UUID.randomUUID().toString()   		|| true
+		UUID.randomUUID().toString()   		|| true
+		UUID.randomUUID().toString() + "!" 	|| false
+		'dog'       						|| false
+		'5'          						|| false
 	}
 }


### PR DESCRIPTION
fixes #113 

Not sure if this regex is as inclusive as necessary, but it covers `java.util.UUID::randomUUID`