### PR TITLE
Throw explicit exceptions for stub runner boot

### DIFF
--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerExecutor.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerExecutor.java
@@ -197,7 +197,9 @@ class StubRunnerExecutor implements StubFinder {
 				.entrySet()) {
 			Collection<String> values = new ArrayList<>();
 			for (Contract contract : it.getValue()) {
-				values.add(contract.getLabel());
+				if (contract.getLabel() != null) {
+					values.add(contract.getLabel());
+				}
 			}
 			labels.put(it.getKey().toColonSeparatedDependencyNotation(), values);
 		}

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/server/TriggerController.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/server/TriggerController.java
@@ -24,7 +24,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.contract.stubrunner.StubFinder;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -55,10 +54,7 @@ public class TriggerController {
 			this.stubFinder.trigger(label);
 			return ResponseEntity.ok().body(Collections.<String, Collection<String>>emptyMap());
 		} catch (Exception e) {
-			if (log.isDebugEnabled()) {
-				log.debug("Exception occurred while trying to return " + label + " label", e);
-			}
-			return new ResponseEntity<>(this.stubFinder.labels(), HttpStatus.NOT_FOUND);
+			throw new RuntimeException("Exception occurred while trying to return [" + label + "] label. \n\nAvailable labels are [" + this.stubFinder.labels() +" ]", e);
 		}
 	}
 
@@ -68,10 +64,7 @@ public class TriggerController {
 			this.stubFinder.trigger(ivyNotation, label);
 			return ResponseEntity.ok().body(Collections.<String, Collection<String>>emptyMap());
 		} catch (Exception e) {
-			if (log.isDebugEnabled()) {
-				log.debug("Exception occurred while trying to return " + label + " label", e);
-			}
-			return new ResponseEntity<>(this.stubFinder.labels(), HttpStatus.NOT_FOUND);
+			throw new RuntimeException("Exception occurred while trying to return [" + label + "] label. \n\nAvailable labels are [" + this.stubFinder.labels() +" ]", e);
 		}
 	}
 

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/server/StubRunnerBootSpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/server/StubRunnerBootSpec.groovy
@@ -104,13 +104,15 @@ class StubRunnerBootSpec extends Specification {
 			stubId << ['org.springframework.cloud.contract.verifier.stubs:bootService:stubs', 'org.springframework.cloud.contract.verifier.stubs:bootService', 'bootService']
 	}
 
-	def 'should return when trigger is missing'() {
+	def 'should throw exception when trigger is missing'() {
 		when:
-			def response = RestAssuredMockMvc.post("/triggers/missing_label")
+			RestAssuredMockMvc.post("/triggers/missing_label")
 		then:
-			response.statusCode == 404
-			def root = new JsonSlurper().parseText(response.body.asString())
-			root.'org.springframework.cloud.contract.verifier.stubs:bootService:0.0.1-SNAPSHOT:stubs'?.containsAll(["delete_book","return_book_1","return_book_2"])
+			Exception e = thrown(Exception)
+			e.message.contains("Exception occurred while trying to return [missing_label] label.")
+			e.message.contains("Available labels are")
+			e.message.contains("org.springframework.cloud.contract.verifier.stubs:loanIssuance:0.0.1-SNAPSHOT:stubs=[]")
+			e.message.contains("org.springframework.cloud.contract.verifier.stubs:bootService:0.0.1-SNAPSHOT:stubs=")
 	}
 
 }


### PR DESCRIPTION
without this whenever sth went wrong we got a 404 and message in logs in debug
with this change we explicitly say what went wrong and return the list of possible labels

fixes #118