### PR TITLE
Fixes #120 - The spring context now fails to start if the stub cannot…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1298,7 +1298,7 @@ Example of a `pom.xml` inside the `server` folder.
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
-		<spring-cloud-contract.version>1.0.1.BUILD-SNAPSHOT</spring-cloud-contract.version>
+		<spring-cloud-contract.version>1.0.2.BUILD-SNAPSHOT</spring-cloud-contract.version>
 		<spring-cloud-dependencies.version>Camden.BUILD-SNAPSHOT</spring-cloud-dependencies.version>
 	</properties>
 

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
@@ -197,7 +197,7 @@ public class AetherStubDownloader implements StubDownloader {
 			throw new IllegalStateException("Cannot resolve version range", e);
 		}
 		if (rangeResult.getHighestVersion() == null) {
-			log.error("For groupId [" + stubsGroup + "] artifactId [" + stubsModule + "] "
+			throw new IllegalArgumentException("For groupId [" + stubsGroup + "] artifactId [" + stubsModule + "] "
 					+ "and classifier [" + classifier + "] the version was not resolved!");
 		}
 		return rangeResult.getHighestVersion() == null ? null : rangeResult.getHighestVersion().toString();

--- a/tests/spring-cloud-contract-stub-runner-context-path/src/test/java/com/example/loan/FailFastLoanApplicationServiceTests.java
+++ b/tests/spring-cloud-contract-stub-runner-context-path/src/test/java/com/example/loan/FailFastLoanApplicationServiceTests.java
@@ -17,14 +17,14 @@ public class FailFastLoanApplicationServiceTests {
 
     @Test
     public void shouldFailToStartContextWhenNoStubCanBeFound() {
-        // Given
+        // When
         final Throwable throwable = catchThrowable(() -> new SpringApplicationBuilder(Application.class, StubRunnerConfiguration.class)
                 .properties(ImmutableMap.of(
                         "stubrunner.repositoryRoot", "classpath:m2repo/repository/",
                         "stubrunner.ids", new String[]{"org.springframework.cloud.contract.verifier.stubs:should-not-be-found"}))
                 .run());
 
-        // When
+        // Then
         assertThat(throwable).isInstanceOf(BeanCreationException.class);
         assertThat(throwable.getCause()).isInstanceOf(BeanInstantiationException.class);
         assertThat(throwable.getCause().getCause())

--- a/tests/spring-cloud-contract-stub-runner-context-path/src/test/java/com/example/loan/FailFastLoanApplicationServiceTests.java
+++ b/tests/spring-cloud-contract-stub-runner-context-path/src/test/java/com/example/loan/FailFastLoanApplicationServiceTests.java
@@ -1,0 +1,35 @@
+package com.example.loan;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import org.springframework.beans.BeanInstantiationException;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cloud.contract.stubrunner.spring.StubRunnerConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/**
+ * @author Andrew Morgan
+ */
+public class FailFastLoanApplicationServiceTests {
+
+    @Test
+    public void shouldFailToStartContextWhenNoStubCanBeFound() {
+        // Given
+        final Throwable throwable = catchThrowable(() -> new SpringApplicationBuilder(Application.class, StubRunnerConfiguration.class)
+                .properties(ImmutableMap.of(
+                        "stubrunner.repositoryRoot", "classpath:m2repo/repository/",
+                        "stubrunner.ids", new String[]{"org.springframework.cloud.contract.verifier.stubs:should-not-be-found"}))
+                .run());
+
+        // When
+        assertThat(throwable).isInstanceOf(BeanCreationException.class);
+        assertThat(throwable.getCause()).isInstanceOf(BeanInstantiationException.class);
+        assertThat(throwable.getCause().getCause())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("For groupId [org.springframework.cloud.contract.verifier.stubs] artifactId [should-not-be-found] and classifier [stubs] the version was not resolved!");
+    }
+
+}


### PR DESCRIPTION
… be found, enabling the test to fail as quickly as possible for feedback