### PR TITLE
Fixes #124 - When specifying 'workOffline=false', the stubrunner will…

### DIFF
--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerConfiguration.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerConfiguration.java
@@ -63,8 +63,7 @@ public class StubRunnerConfiguration {
 				.withMinMaxPort(this.props.getMinPort(), this.props.getMaxPort())
 				.withStubRepositoryRoot(
 						uriStringOrEmpty(this.props.getRepositoryRoot()))
-				.withWorkOffline(this.props.getRepositoryRoot() == null
-						|| this.props.isWorkOffline())
+				.withWorkOffline(this.props.isWorkOffline())
 				.withStubsClassifier(this.props.getClassifier())
 				.withStubs(this.props.getIds())
 				.withContextPath(contextPath())

--- a/tests/spring-cloud-contract-stub-runner-context-path/src/test/java/com/example/loan/FailFastLoanApplicationServiceTests.java
+++ b/tests/spring-cloud-contract-stub-runner-context-path/src/test/java/com/example/loan/FailFastLoanApplicationServiceTests.java
@@ -32,4 +32,21 @@ public class FailFastLoanApplicationServiceTests {
                 .hasMessage("For groupId [org.springframework.cloud.contract.verifier.stubs] artifactId [should-not-be-found] and classifier [stubs] the version was not resolved!");
     }
 
+    @Test
+    public void shouldNotTryAndWorkOfflineWhenWorkOfflineIsSetToFalse() {
+        // When
+        final Throwable throwable = catchThrowable(() -> new SpringApplicationBuilder(Application.class, StubRunnerConfiguration.class)
+                .properties(ImmutableMap.of(
+                        "stubrunner.workOffline", "false",
+                        "stubrunner.ids", new String[]{"org.springframework.cloud.contract.verifier.stubs:should-not-be-found"}))
+                .run());
+
+        // Then
+        assertThat(throwable).isInstanceOf(BeanCreationException.class);
+        assertThat(throwable.getCause()).isInstanceOf(BeanInstantiationException.class);
+        assertThat(throwable.getCause().getCause())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Remote repositories for stubs are not specified and work offline flag wasn't passed");
+    }
+
 }


### PR DESCRIPTION
… now always fail if unable to find the stub remotely