### PR TITLE
add support for spring-amqp annotated listener endpoints

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-contract.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-contract.adoc
@@ -5,7 +5,7 @@
 = Spring Cloud Contract
 
 _Documentation Authors: Adam Dudczak, Marcin Grzejszczak, Jakub Kubryński, Karol Lassak,
-Olga Maciaszek-Sharma, Mariusz Smykuła, Dave Syer_
+Olga Maciaszek-Sharma, Mariusz Smykuła, Dave Syer, Mathias Düsterhöft_
 
 {spring-cloud-version}
 

--- a/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/messaging/amqp/ContractVerifierAmqpAutoConfiguration.java
+++ b/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/messaging/amqp/ContractVerifierAmqpAutoConfiguration.java
@@ -16,10 +16,16 @@
 
 package org.springframework.cloud.contract.verifier.messaging.amqp;
 
+import static java.util.Collections.emptyList;
+
+import java.util.List;
+
 import org.mockito.Mockito;
+import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
+import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.support.SimpleAmqpHeaderMapper;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.amqp.support.converter.MessagingMessageConverter;
@@ -55,12 +61,20 @@ public class ContractVerifierAmqpAutoConfiguration {
 	private RabbitTemplate rabbitTemplate;
 
 	@Autowired(required = false)
-	private MessageListenerAdapter messageListenerAdapter;
+	private RabbitListenerEndpointRegistry rabbitListenerEndpointRegistry;
+
+	@Autowired(required = false)
+	private List<SimpleMessageListenerContainer> simpleMessageListenerContainers = emptyList();
+
+	@Autowired(required = false)
+	private List<Binding> bindings = emptyList();
 
 	@Bean
 	@ConditionalOnMissingBean
 	public MessageVerifier<Message> contractVerifierMessageExchange() {
-		return new SpringAmqpStubMessages(this.rabbitTemplate, this.messageListenerAdapter);
+
+		return new SpringAmqpStubMessages(this.rabbitTemplate,
+				new MessageListenerAccessor(this.rabbitListenerEndpointRegistry, this.simpleMessageListenerContainers, this.bindings));
 	}
 
 	@Bean

--- a/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/messaging/amqp/MessageListenerAccessor.java
+++ b/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/messaging/amqp/MessageListenerAccessor.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.Binding.DestinationType;
 import org.springframework.amqp.rabbit.listener.MessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
@@ -20,21 +21,20 @@ import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
  * @author Mathias Düsterhöft
  * @since 1.0.2
  */
-public class MessageListenerAccessor {
+class MessageListenerAccessor {
 
 	private final RabbitListenerEndpointRegistry rabbitListenerEndpointRegistry;
-
 	private final List<SimpleMessageListenerContainer> simpleMessageListenerContainers;
 	private final List<Binding> bindings;
 
-	public MessageListenerAccessor(RabbitListenerEndpointRegistry rabbitListenerEndpointRegistry,
+	MessageListenerAccessor(RabbitListenerEndpointRegistry rabbitListenerEndpointRegistry,
 									List<SimpleMessageListenerContainer> simpleMessageListenerContainers, List<Binding> bindings) {
 		this.rabbitListenerEndpointRegistry = rabbitListenerEndpointRegistry;
 		this.simpleMessageListenerContainers = simpleMessageListenerContainers;
 		this.bindings = bindings;
 	}
 
-	public List<SimpleMessageListenerContainer> getListenerContainersForDestination(String destination) {
+	List<SimpleMessageListenerContainer> getListenerContainersForDestination(String destination) {
 		List<SimpleMessageListenerContainer> listenerContainers = collectListenerContainers();
 		//we interpret the destination as exchange name and collect all the queues bound to this exchange
 		Set<String> queueNames = collectQueuesBoundToDestination(destination);
@@ -60,7 +60,7 @@ public class MessageListenerAccessor {
 	private Set<String> collectQueuesBoundToDestination(String destination) {
 		Set<String> queueNames = new HashSet<>();
 		for (Binding binding: this.bindings) {
-			if (binding.getExchange().equals(destination) && binding.getDestinationType().equals(Binding.DestinationType.QUEUE)) {
+			if (destination.equals(binding.getExchange()) && DestinationType.QUEUE.equals(binding.getDestinationType())) {
 				queueNames.add(binding.getDestination());
 			}
 		}

--- a/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/messaging/amqp/MessageListenerAccessor.java
+++ b/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/messaging/amqp/MessageListenerAccessor.java
@@ -1,0 +1,84 @@
+package org.springframework.cloud.contract.verifier.messaging.amqp;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.rabbit.listener.MessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+
+/**
+ * Abstraction hiding details of the different sources of message listeners
+ *
+ * Needed because {@link org.springframework.amqp.rabbit.annotation.RabbitListenerAnnotationBeanPostProcessor} adds the listners to the
+ * {@link RabbitListenerEndpointRegistry} so that the registry is empty when wired into an auto configuration class
+ * so we wrap it in the accessor to access the listeners late at runtime
+ *
+ * @author Mathias Düsterhöft
+ * @since 1.0.2
+ */
+public class MessageListenerAccessor {
+
+	private final RabbitListenerEndpointRegistry rabbitListenerEndpointRegistry;
+
+	private final List<SimpleMessageListenerContainer> simpleMessageListenerContainers;
+	private final List<Binding> bindings;
+
+	public MessageListenerAccessor(RabbitListenerEndpointRegistry rabbitListenerEndpointRegistry,
+									List<SimpleMessageListenerContainer> simpleMessageListenerContainers, List<Binding> bindings) {
+		this.rabbitListenerEndpointRegistry = rabbitListenerEndpointRegistry;
+		this.simpleMessageListenerContainers = simpleMessageListenerContainers;
+		this.bindings = bindings;
+	}
+
+	public List<SimpleMessageListenerContainer> getListenerContainersForDestination(String destination) {
+		List<SimpleMessageListenerContainer> listenerContainers = collectListenerContainers();
+		//we interpret the destination as exchange name and collect all the queues bound to this exchange
+		Set<String> queueNames = collectQueuesBoundToDestination(destination);
+
+		return getListenersByBoundQueues(listenerContainers, queueNames);
+	}
+
+	private List<SimpleMessageListenerContainer> getListenersByBoundQueues(List<SimpleMessageListenerContainer> listenerContainers, Set<String> queueNames) {
+		List<SimpleMessageListenerContainer> matchingContainers = new ArrayList<>();
+		for (SimpleMessageListenerContainer listenerContainer : listenerContainers) {
+			if (listenerContainer.getQueueNames() != null) {
+				for (String queueName :  listenerContainer.getQueueNames()) {
+					if (queueNames.contains(queueName)) {
+						matchingContainers.add(listenerContainer);
+						break;
+					}
+				}
+			}
+		}
+		return matchingContainers;
+	}
+
+	private Set<String> collectQueuesBoundToDestination(String destination) {
+		Set<String> queueNames = new HashSet<>();
+		for (Binding binding: this.bindings) {
+			if (binding.getExchange().equals(destination) && binding.getDestinationType().equals(Binding.DestinationType.QUEUE)) {
+				queueNames.add(binding.getDestination());
+			}
+		}
+		return queueNames;
+	}
+
+	private List<SimpleMessageListenerContainer> collectListenerContainers() {
+		List<SimpleMessageListenerContainer> listenerContainers = new ArrayList<>();
+		if (this.simpleMessageListenerContainers != null) {
+			listenerContainers.addAll(this.simpleMessageListenerContainers);
+		}
+		if (this.rabbitListenerEndpointRegistry != null) {
+			for (MessageListenerContainer listenerContainer : this.rabbitListenerEndpointRegistry.getListenerContainers()) {
+				if (listenerContainer instanceof SimpleMessageListenerContainer) {
+					listenerContainers.add((SimpleMessageListenerContainer) listenerContainer);
+				}
+			}
+		}
+		return listenerContainers;
+	}
+}

--- a/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/messaging/amqp/SpringAmqpStubMessages.java
+++ b/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/messaging/amqp/SpringAmqpStubMessages.java
@@ -88,7 +88,7 @@ public class SpringAmqpStubMessages implements
 	public void send(Message message, String destination) {
 		List<SimpleMessageListenerContainer> listenerContainers = this.messageListenerAccessor.getListenerContainersForDestination(destination);
 		if (listenerContainers.isEmpty()) {
-			log.warn("no message listener container(s) found for destination {}", destination);
+			throw new IllegalStateException("no listeners found for destination " + destination);
 		}
 		for (SimpleMessageListenerContainer listenerContainer : listenerContainers) {
 			MessageListener messageListener = (MessageListener) listenerContainer.getMessageListener();

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/messaging/amqp/MessageListenerAccessorSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/messaging/amqp/MessageListenerAccessorSpec.groovy
@@ -1,5 +1,6 @@
 package org.springframework.cloud.contract.verifier.messaging.amqp
 
+import org.springframework.amqp.core.Binding
 import org.springframework.amqp.core.BindingBuilder
 import org.springframework.amqp.core.DirectExchange
 import org.springframework.amqp.core.Queue
@@ -9,28 +10,28 @@ import spock.lang.Specification
 
 class MessageListenerAccessorSpec extends Specification {
 
-    def queueName = "test.queue"
-    def exchange = "test-exchange"
-    def listenerContainer
-    def binding
+    String queueName = "test.queue"
+    String exchange = "test-exchange"
+    SimpleMessageListenerContainer listenerContainer
+    Binding binding
 
     def "should get single simple listener container"(){
         given:
             givenSimpleMessageListenerContainer()
-            def messageListenerAccessor = new MessageListenerAccessor(null, [listenerContainer], [binding])
+        MessageListenerAccessor messageListenerAccessor = new MessageListenerAccessor(null, [this.listenerContainer], [this.binding])
         when:
-            def listenerContainersForDestination = messageListenerAccessor.getListenerContainersForDestination(exchange)
+            List<SimpleMessageListenerContainer> listenerContainersForDestination = messageListenerAccessor.getListenerContainersForDestination(this.exchange)
         then:
             listenerContainersForDestination.size() == 1
-            listenerContainersForDestination.get(0) == listenerContainer
+            listenerContainersForDestination.get(0) == this.listenerContainer
     }
 
     def "should get empty listener container list for unknown destination"(){
         given:
             givenSimpleMessageListenerContainer()
-            def messageListenerAccessor = new MessageListenerAccessor(null, [listenerContainer], [binding])
+            MessageListenerAccessor messageListenerAccessor = new MessageListenerAccessor(null, [this.listenerContainer], [this.binding])
         when:
-            def listenerContainersForDestination = messageListenerAccessor.getListenerContainersForDestination("some-exchange")
+            List<SimpleMessageListenerContainer> listenerContainersForDestination = messageListenerAccessor.getListenerContainersForDestination("some-exchange")
         then:
             listenerContainersForDestination.isEmpty()
     }
@@ -38,10 +39,10 @@ class MessageListenerAccessorSpec extends Specification {
     def "should get empty listener container list for queue with no matching listener"(){
         given:
             givenSimpleMessageListenerContainer()
-            binding = BindingBuilder.bind(new Queue("some.queue")).to(new DirectExchange(exchange)).with("#")
-            def messageListenerAccessor = new MessageListenerAccessor(null, [listenerContainer], [binding])
+            this.binding = BindingBuilder.bind(new Queue("some.queue")).to(new DirectExchange(this.exchange)).with("#")
+            MessageListenerAccessor messageListenerAccessor = new MessageListenerAccessor(null, [this.listenerContainer], [this.binding])
         when:
-            def listenerContainersForDestination = messageListenerAccessor.getListenerContainersForDestination(exchange)
+            List<SimpleMessageListenerContainer> listenerContainersForDestination = messageListenerAccessor.getListenerContainersForDestination(this.exchange)
         then:
             listenerContainersForDestination.isEmpty()
     }
@@ -49,19 +50,19 @@ class MessageListenerAccessorSpec extends Specification {
     def "should get single simple listener container from RabbitListenerEndpointRegistry"(){
         given:
             givenSimpleMessageListenerContainer()
-            def rabbitListenerEndpointRegistryMock = Mock(RabbitListenerEndpointRegistry)
-            rabbitListenerEndpointRegistryMock.getListenerContainers() >> [listenerContainer]
-            def messageListenerAccessor = new MessageListenerAccessor(rabbitListenerEndpointRegistryMock, [], [binding])
+            RabbitListenerEndpointRegistry rabbitListenerEndpointRegistryMock = Mock(RabbitListenerEndpointRegistry)
+            rabbitListenerEndpointRegistryMock.getListenerContainers() >> [this.listenerContainer]
+            MessageListenerAccessor messageListenerAccessor = new MessageListenerAccessor(rabbitListenerEndpointRegistryMock, [], [this.binding])
         when:
-            def listenerContainersForDestination = messageListenerAccessor.getListenerContainersForDestination(exchange)
+            List<SimpleMessageListenerContainer> listenerContainersForDestination = messageListenerAccessor.getListenerContainersForDestination(this.exchange)
         then:
             listenerContainersForDestination.size() == 1
-            listenerContainersForDestination.get(0) == listenerContainer
+            listenerContainersForDestination.get(0) == this.listenerContainer
     }
 
     def givenSimpleMessageListenerContainer() {
-        listenerContainer = new SimpleMessageListenerContainer()
-        listenerContainer.setQueueNames(queueName)
-        binding = BindingBuilder.bind(new Queue(queueName)).to(new DirectExchange(exchange)).with("#")
+        this.listenerContainer = new SimpleMessageListenerContainer()
+        this.listenerContainer.setQueueNames(this.queueName)
+        this.binding = BindingBuilder.bind(new Queue(this.queueName)).to(new DirectExchange(this.exchange)).with("#")
     }
 }

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/messaging/amqp/MessageListenerAccessorSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/messaging/amqp/MessageListenerAccessorSpec.groovy
@@ -1,0 +1,67 @@
+package org.springframework.cloud.contract.verifier.messaging.amqp
+
+import org.springframework.amqp.core.BindingBuilder
+import org.springframework.amqp.core.DirectExchange
+import org.springframework.amqp.core.Queue
+import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer
+import spock.lang.Specification
+
+class MessageListenerAccessorSpec extends Specification {
+
+    def queueName = "test.queue"
+    def exchange = "test-exchange"
+    def listenerContainer
+    def binding
+
+    def "should get single simple listener container"(){
+        given:
+            givenSimpleMessageListenerContainer()
+            def messageListenerAccessor = new MessageListenerAccessor(null, [listenerContainer], [binding])
+        when:
+            def listenerContainersForDestination = messageListenerAccessor.getListenerContainersForDestination(exchange)
+        then:
+            listenerContainersForDestination.size() == 1
+            listenerContainersForDestination.get(0) == listenerContainer
+    }
+
+    def "should get empty listener container list for unknown destination"(){
+        given:
+            givenSimpleMessageListenerContainer()
+            def messageListenerAccessor = new MessageListenerAccessor(null, [listenerContainer], [binding])
+        when:
+            def listenerContainersForDestination = messageListenerAccessor.getListenerContainersForDestination("some-exchange")
+        then:
+            listenerContainersForDestination.isEmpty()
+    }
+
+    def "should get empty listener container list for queue with no matching listener"(){
+        given:
+            givenSimpleMessageListenerContainer()
+            binding = BindingBuilder.bind(new Queue("some.queue")).to(new DirectExchange(exchange)).with("#")
+            def messageListenerAccessor = new MessageListenerAccessor(null, [listenerContainer], [binding])
+        when:
+            def listenerContainersForDestination = messageListenerAccessor.getListenerContainersForDestination(exchange)
+        then:
+            listenerContainersForDestination.isEmpty()
+    }
+
+    def "should get single simple listener container from RabbitListenerEndpointRegistry"(){
+        given:
+            givenSimpleMessageListenerContainer()
+            def rabbitListenerEndpointRegistryMock = Mock(RabbitListenerEndpointRegistry)
+            rabbitListenerEndpointRegistryMock.getListenerContainers() >> [listenerContainer]
+            def messageListenerAccessor = new MessageListenerAccessor(rabbitListenerEndpointRegistryMock, [], [binding])
+        when:
+            def listenerContainersForDestination = messageListenerAccessor.getListenerContainersForDestination(exchange)
+        then:
+            listenerContainersForDestination.size() == 1
+            listenerContainersForDestination.get(0) == listenerContainer
+    }
+
+    def givenSimpleMessageListenerContainer() {
+        listenerContainer = new SimpleMessageListenerContainer()
+        listenerContainer.setQueueNames(queueName)
+        binding = BindingBuilder.bind(new Queue(queueName)).to(new DirectExchange(exchange)).with("#")
+    }
+}

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/messaging/amqp/SpringAmqpStubMessagesSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/messaging/amqp/SpringAmqpStubMessagesSpec.groovy
@@ -1,9 +1,12 @@
 package org.springframework.cloud.contract.verifier.messaging.amqp
 
 import com.google.common.collect.ImmutableMap
-import org.mockito.ArgumentCaptor
-import org.springframework.amqp.core.Message
+import org.springframework.amqp.core.Binding
+import org.springframework.amqp.core.BindingBuilder
+import org.springframework.amqp.core.DirectExchange
+import org.springframework.amqp.core.Queue
 import org.springframework.amqp.rabbit.core.RabbitTemplate
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer
 import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter
 import spock.lang.Specification
 
@@ -16,20 +19,28 @@ import static org.springframework.amqp.support.converter.DefaultClassMapper.DEFA
 class SpringAmqpStubMessagesSpec extends Specification {
 
     RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class)
+    SimpleMessageListenerContainer listenerContainer = new SimpleMessageListenerContainer()
     MessageListenerAdapter messageListenerAdapter = Mock(MessageListenerAdapter.class)
+
+    String queueName = "test.queue"
+    String exchange = "test-exchange"
+    String payload = '''{"name":"some"}'''
 
     def "should send amqp message with type id"() {
         given:
-            String payload = '''{"name":"some"}'''
-            ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class)
-            SpringAmqpStubMessages messageVerifier = new SpringAmqpStubMessages(rabbitTemplate, messageListenerAdapter)
+            listenerContainer.setMessageListener(messageListenerAdapter)
+            listenerContainer.setQueueNames(queueName)
+            Binding binding = BindingBuilder.bind(new Queue(queueName)).to(new DirectExchange(exchange)).with("#")
+            MessageListenerAccessor messageListenerAccessor = new MessageListenerAccessor(null, [listenerContainer], [binding])
+            SpringAmqpStubMessages messageVerifier = new SpringAmqpStubMessages(rabbitTemplate, messageListenerAccessor)
+
         when:
             messageVerifier.send(payload,
                     ImmutableMap.builder()
                             .put(DEFAULT_CLASSID_FIELD_NAME, "org.example.Some")
                             .put("contentType", CONTENT_TYPE_JSON)
                             .build(),
-                    "test-exchange")
+                    exchange)
         then:
             1 * messageListenerAdapter.onMessage({
                 it.getMessageProperties().getContentType() == CONTENT_TYPE_JSON &&

--- a/tests/spring-cloud-contract-stub-runner-amqp/README.adoc
+++ b/tests/spring-cloud-contract-stub-runner-amqp/README.adoc
@@ -4,15 +4,21 @@ Spring Cloud Contract Verifier Stub Runner's messaging module provides an easy w
 For the provided artifacts it will automatically download the stubs and register the required
 routes.
 
-The integration tries to work standalone, that is without interaction with a running RabbitMQ message broker. It expects a `RabbitTemplate` on the application context and uses it as a spring boot test `@SpyBean`.
+The integration tries to work standalone, that is without interaction with a running RabbitMQ message broker.
+It expects a `RabbitTemplate` on the application context and uses it as a spring boot test `@SpyBean`.
 Thus it can use the mockito spy functionality to verify and introspect messages sent by the application.
 
-IMPORTANT: In the current status of the implementation tries to find a `MessageListenerAdapter` on the application context to send messages into the application, because we want to avoid interacting with a running bus.
-Using annotation driven listener endpoints (e.g. `@RabbitListener` annotated listener methods) is currently not supported.
+On the message consumer side, it considers all `@RabbitListener` annotated endpoints as well as all `SimpleMessageListenerContainer`s on the application context.
+
+As messages are usually sent to exchanges in AMQP the message contract contains the exchange name as the destination.
+Message listeners on the other side are bound to queues. Bindings connect an exchange to a queue.
+If message contracts are triggered the Spring AMQP stub runner integration will look for bindings on the application context that match this exchange.
+Then it collects the queues from the Spring exchanges and tries to find messages listeners bound to these queues.
+The message is triggered to all matching message listeners.
 
 ==== Adding it to the project
 
-It's enough to have both Spring AMQP and Spring Cloud Contract Stub Runner on classpath.
+It's enough to have both Spring AMQP and Spring Cloud Contract Stub Runner on the classpath.
 Remember to annotate your test class with `@AutoConfigureMessageVerifier`.
 
 ==== Examples
@@ -53,7 +59,6 @@ Let's consider the following contract:
 include::src/test/groovy/org/springframework/cloud/contract/stubrunner/messaging/amqp/AmqpStubRunnerSpec.groovy[tags=amqp_contract,indent=0]
 ----
 
-
 and the following Spring configuration:
 
 [source,yaml]
@@ -69,6 +74,29 @@ So to trigger a message using the contract above we'll use the `StubTrigger` int
 ----
 include::src/test/groovy/org/springframework/cloud/contract/stubrunner/messaging/amqp/AmqpStubRunnerSpec.groovy[tags=client_trigger,indent=0]
 ----
+
+The message has the destination `contract-test.exchange` so the Spring AMQP stub runner integration looks for bindings related to this exchange.
+
+[source,java]
+----
+include::src/main/java/org/springframework/cloud/contract/stubrunner/messaging/amqp/AmqpMessagingApplication.java[tags=amqp_binding,indent=0]
+----
+
+The binding definition binds the queue `test.queue`.
+So the following listener definition is a match and is invoked with the contract message.
+
+[source,java]
+----
+include::src/main/java/org/springframework/cloud/contract/stubrunner/messaging/amqp/AmqpMessagingApplication.java[tags=amqp_listener,indent=0]
+----
+
+Also, the following annotated listener represents a match and would be invoked.
+[source,java]
+----
+include::src/main/java/org/springframework/cloud/contract/stubrunner/messaging/amqp/MessageSubscriberRabbitListener.java[tags=amqp_annotated_listener,indent=0]
+----
+
+NOTE: The message is directly handed over to the `onMessage` method of the `MessageListener` associated with the matching `SimpleMessageListenerContainer`.
 
 ===== Spring AMQP Test Configuration
 

--- a/tests/spring-cloud-contract-stub-runner-amqp/src/main/java/org/springframework/cloud/contract/stubrunner/messaging/amqp/AmqpMessagingApplication.java
+++ b/tests/spring-cloud-contract-stub-runner-amqp/src/main/java/org/springframework/cloud/contract/stubrunner/messaging/amqp/AmqpMessagingApplication.java
@@ -2,10 +2,15 @@ package org.springframework.cloud.contract.stubrunner.messaging.amqp;
 
 import static org.springframework.amqp.core.MessageProperties.CONTENT_TYPE_JSON;
 
-import org.springframework.amqp.core.Exchange;
-import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
 import org.springframework.amqp.support.converter.ContentTypeDelegatingMessageConverter;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
@@ -13,6 +18,8 @@ import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -40,13 +47,61 @@ public class AmqpMessagingApplication {
 		return rabbitTemplate;
 	}
 
-	@Bean
-	public Exchange testExchange() {
-		return new TopicExchange("test-exchange");
+	@Configuration
+	@Profile("!listener")
+	static class MessageListenerAdapterConfig {
+
+		@Bean
+		public MessageListenerAdapter messageListenerAdapter(MessageSubscriber messageSubscriber, MessageConverter messageConverter) {
+			return new MessageListenerAdapter(messageSubscriber, messageConverter);
+		}
+
+		// tag::amqp_binding[]
+
+		@Bean
+		public Binding binding() {
+			return BindingBuilder.bind(new Queue("test.queue")).to(new DirectExchange("contract-test.exchange")).with("#");
+		}
+		// end::amqp_binding[]
+
+		// tag::amqp_listener[]
+		@Bean
+		public SimpleMessageListenerContainer simpleMessageListenerContainer(ConnectionFactory connectionFactory,
+																				MessageListenerAdapter listenerAdapter) {
+			SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+			container.setConnectionFactory(connectionFactory);
+			container.setQueueNames("test.queue");
+			container.setMessageListener(listenerAdapter);
+
+			return container;
+		}
+		// end::amqp_listener[]
+
+		@Bean
+		public MessageSubscriber messageSubscriber() {
+			return new MessageSubscriber();
+		}
 	}
 
-	@Bean
-	public MessageListenerAdapter messageListenerAdapter(MessageSubscriber messageSubscriber, MessageConverter messageConverter) {
-		return new MessageListenerAdapter(messageSubscriber, messageConverter);
+	@Configuration
+	@EnableRabbit
+	@Profile("listener")
+	static class RabbitListenerConfig {
+
+		@Bean
+		public MessageSubscriberRabbitListener messageSubscriberRabbitLister() {
+			return new MessageSubscriberRabbitListener();
+		}
+
+		@Bean
+		public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory(ConnectionFactory connectionFactory,
+																					MessageConverter messageConverter) {
+			SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+			factory.setConnectionFactory(connectionFactory);
+			factory.setConcurrentConsumers(3);
+			factory.setMaxConcurrentConsumers(10);
+			factory.setMessageConverter(messageConverter);
+			return factory;
+		}
 	}
 }

--- a/tests/spring-cloud-contract-stub-runner-amqp/src/main/java/org/springframework/cloud/contract/stubrunner/messaging/amqp/MessageSubscriber.java
+++ b/tests/spring-cloud-contract-stub-runner-amqp/src/main/java/org/springframework/cloud/contract/stubrunner/messaging/amqp/MessageSubscriber.java
@@ -1,8 +1,5 @@
 package org.springframework.cloud.contract.stubrunner.messaging.amqp;
 
-import org.springframework.stereotype.Component;
-
-@Component
 public class MessageSubscriber {
 
 	public void handleMessage(Person person) {

--- a/tests/spring-cloud-contract-stub-runner-amqp/src/main/java/org/springframework/cloud/contract/stubrunner/messaging/amqp/MessageSubscriberRabbitListener.java
+++ b/tests/spring-cloud-contract-stub-runner-amqp/src/main/java/org/springframework/cloud/contract/stubrunner/messaging/amqp/MessageSubscriberRabbitListener.java
@@ -1,0 +1,23 @@
+package org.springframework.cloud.contract.stubrunner.messaging.amqp;
+
+import org.springframework.amqp.rabbit.annotation.Exchange;
+import org.springframework.amqp.rabbit.annotation.Queue;
+import org.springframework.amqp.rabbit.annotation.QueueBinding;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+
+public class MessageSubscriberRabbitListener {
+
+	private Person person;
+
+	// tag::amqp_annotated_listener[]
+	@RabbitListener(bindings = @QueueBinding(
+			value = @Queue(value = "test.queue"),
+			exchange = @Exchange(value = "contract-test.exchange", ignoreDeclarationExceptions = "true")))
+	public void handlePerson(Person person) {
+		this.person = person;
+	}
+	// end::amqp_annotated_listener[]
+	public Person getPerson() {
+		return this.person;
+	}
+}

--- a/tests/spring-cloud-contract-stub-runner-amqp/src/test/groovy/org/springframework/cloud/contract/stubrunner/messaging/amqp/AmqpStubRunnerRabbitListenerSpec.groovy
+++ b/tests/spring-cloud-contract-stub-runner-amqp/src/test/groovy/org/springframework/cloud/contract/stubrunner/messaging/amqp/AmqpStubRunnerRabbitListenerSpec.groovy
@@ -1,0 +1,34 @@
+package org.springframework.cloud.contract.stubrunner.messaging.amqp
+
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootContextLoader
+import org.springframework.cloud.contract.stubrunner.StubTrigger
+import org.springframework.cloud.contract.stubrunner.spring.AutoConfigureStubRunner
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import spock.lang.Specification
+
+@ContextConfiguration(classes = [AmqpMessagingApplication], loader = SpringBootContextLoader)
+@AutoConfigureStubRunner
+@ActiveProfiles("listener")
+class AmqpStubRunnerRabbitListenerSpec extends Specification {
+
+    @Autowired
+    StubTrigger stubTrigger
+
+    @Autowired
+    MessageSubscriberRabbitListener messageSubscriber
+
+    @Captor
+    ArgumentCaptor<Person> personArgumentCaptor
+    
+    def "should trigger stub amqp message consumed by annotated listener"() {
+        when:
+            stubTrigger.trigger("contract-test.person.created.event")
+        then:
+            messageSubscriber.person != null
+            messageSubscriber.person.name != null
+    }
+}


### PR DESCRIPTION
I improved the first version of the spring-ampq integration by adding support for multiple listener containers on the application context and also for `@RabbitListener` annotated endpoints.

Let me know what you think.

I am trying to get some feedback from the spring-amqp team via gitter as well.
