### PR TITLE
enable amqp integration by property (#131)

### DIFF
--- a/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/messaging/amqp/ContractVerifierAmqpAutoConfiguration.java
+++ b/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/messaging/amqp/ContractVerifierAmqpAutoConfiguration.java
@@ -20,7 +20,6 @@ import static java.util.Collections.emptyList;
 
 import java.util.List;
 
-import org.mockito.Mockito;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -34,7 +33,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.cloud.contract.verifier.messaging.MessageVerifier;
 import org.springframework.cloud.contract.verifier.messaging.integration.ContractVerifierIntegrationConfiguration;
@@ -51,8 +50,8 @@ import org.springframework.context.annotation.Configuration;
  * @since 1.0.2
  */
 @Configuration
-@ConditionalOnClass({Message.class, RabbitTemplate.class, Mockito.class})
-@ConditionalOnMissingClass("org.springframework.integration.core.MessageSource")
+@ConditionalOnClass(RabbitTemplate.class)
+@ConditionalOnProperty(name="stubrunner.amqp.enabled", havingValue="true")
 @AutoConfigureBefore(ContractVerifierIntegrationConfiguration.class)
 @AutoConfigureAfter(ContractVerifierStreamAutoConfiguration.class)
 public class ContractVerifierAmqpAutoConfiguration {

--- a/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/messaging/amqp/RabbitMockConnectionFactoryAutoConfiguration.java
+++ b/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/messaging/amqp/RabbitMockConnectionFactoryAutoConfiguration.java
@@ -5,14 +5,9 @@ import static org.mockito.Mockito.when;
 
 import java.util.concurrent.ExecutorService;
 
-import org.mockito.Mockito;
-import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,10 +24,8 @@ import com.rabbitmq.client.Connection;
  * @since 1.0.2
  */
 @Configuration
-@ConditionalOnClass({Message.class, RabbitTemplate.class, Mockito.class})
-@ConditionalOnMissingClass("org.springframework.integration.core.MessageSource")
-@AutoConfigureAfter(ContractVerifierAmqpAutoConfiguration.class)
-@ConditionalOnProperty(value = "verifier.amqp.mockConnection", havingValue = "true", matchIfMissing = true)
+@ConditionalOnBean(ContractVerifierAmqpAutoConfiguration.class)
+@ConditionalOnProperty(value = "stubrunner.amqp.mockConnection", havingValue = "true", matchIfMissing = true)
 public class RabbitMockConnectionFactoryAutoConfiguration {
 
 	@Bean

--- a/tests/samples-messaging-amqp/src/test/groovy/com/example/AmqpMessagingApplicationSpec.groovy
+++ b/tests/samples-messaging-amqp/src/test/groovy/com/example/AmqpMessagingApplicationSpec.groovy
@@ -20,21 +20,21 @@ import com.jayway.jsonpath.DocumentContext
 import com.jayway.jsonpath.JsonPath
 import com.toomuchcoding.jsonassert.JsonAssertion
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.IntegrationTest
 import org.springframework.boot.test.context.SpringBootContextLoader
 import org.springframework.cloud.contract.spec.Contract
 import org.springframework.cloud.contract.verifier.messaging.boot.AutoConfigureMessageVerifier
 import org.springframework.cloud.contract.verifier.messaging.internal.ContractVerifierMessaging
 import org.springframework.cloud.contract.verifier.messaging.internal.ContractVerifierObjectMapper
-import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ContextConfiguration
 import spock.lang.Specification
 
 import javax.inject.Inject
 // Context configuration would end up in base class
 @ContextConfiguration(classes = [AmqpMessagingApplication], loader = SpringBootContextLoader)
-@DirtiesContext
 @AutoConfigureMessageVerifier
-public class AmqpMessagingApplicationSpec extends Specification {
+@IntegrationTest("stubrunner.amqp.enabled=true")
+class AmqpMessagingApplicationSpec extends Specification {
 
 	// ALL CASES
 	@Inject ContractVerifierMessaging contractVerifierMessaging

--- a/tests/spring-cloud-contract-stub-runner-amqp/README.adoc
+++ b/tests/spring-cloud-contract-stub-runner-amqp/README.adoc
@@ -18,7 +18,7 @@ The message is triggered to all matching message listeners.
 
 ==== Adding it to the project
 
-It's enough to have both Spring AMQP and Spring Cloud Contract Stub Runner on the classpath.
+It's enough to have both Spring AMQP and Spring Cloud Contract Stub Runner on the classpath and set the property `stubrunner.amqp.enabled=true`.
 Remember to annotate your test class with `@AutoConfigureMessageVerifier`.
 
 ==== Examples
@@ -102,11 +102,11 @@ NOTE: The message is directly handed over to the `onMessage` method of the `Mess
 
 In order to avoid that Spring AMQP is trying to connect to a running broker during our tests we configure a mock `ConnectionFactory`.
 
-To disable the mocked ConnectionFactory set the property `verifier.amqp.mockConnection=false`
+To disable the mocked ConnectionFactory set the property `stubrunner.amqp.mockConnection=false`
 
 [source,yaml]
 ----
-verifier:
+stubrunner:
   amqp:
     mockConnection: false
 ----

--- a/tests/spring-cloud-contract-stub-runner-amqp/src/test/resources/application.yml
+++ b/tests/spring-cloud-contract-stub-runner-amqp/src/test/resources/application.yml
@@ -1,2 +1,5 @@
-stubrunner.repositoryRoot: classpath:m2repo/repository/
-stubrunner.ids: org.springframework.cloud.contract.verifier.stubs.amqp:spring-cloud-contract-amqp-test:0.4.0-SNAPSHOT:stubs
+stubrunner:
+  repositoryRoot: classpath:m2repo/repository/
+  ids: org.springframework.cloud.contract.verifier.stubs.amqp:spring-cloud-contract-amqp-test:0.4.0-SNAPSHOT:stubs
+  amqp:
+    enabled: true


### PR DESCRIPTION
Fixes #131
Changed the conditions to apply the amqp integration auto configuration as follows:

```
@ConditionalOnClass(RabbitTemplate.class)
@ConditionalOnProperty(name="stubrunner.amqp.enabled", havingValue="true")
```

Also changed the property name for the `RabbitMockConnectionFactoryAutoConfiguration` from `verifier.amqp.mockConnection` to `stubrunner.amqp.mockConnection` to use a common prefix.

```
@ConditionalOnProperty(value = "stubrunner.amqp.mockConnection", havingValue = "true", matchIfMissing = true)
```