### PR TITLE
Adds the env prop for every run server

### DIFF
--- a/spring-cloud-contract-stub-runner/README.adoc
+++ b/spring-cloud-contract-stub-runner/README.adoc
@@ -159,6 +159,15 @@ Below you can find an example of achieving the same result by setting values on 
 include::src/test/groovy/org/springframework/cloud/contract/stubrunner/spring/cloud/StubRunnerSpringCloudAutoConfigurationSpec.groovy[tags=autoconfigure]
 ----
 
+Stub Runner Spring registers environment variables in the following manner
+for every registered WireMock server. Example for Stub Runner ids
+ `com.example:foo`, `com.example:bar`.
+
+- `stubrunner.runningstubs.foo.port`
+- `stubrunner.runningstubs.bar.port`
+
+Which you can reference in your code.
+
 
 === Stub Runner Spring Cloud
 

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/spring/StubRunnerConfigurationSpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/spring/StubRunnerConfigurationSpec.groovy
@@ -25,6 +25,7 @@ import org.springframework.boot.test.context.SpringBootContextLoader
 import org.springframework.cloud.contract.stubrunner.StubFinder
 import org.springframework.cloud.contract.stubrunner.StubNotFoundException
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.env.Environment
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
@@ -45,6 +46,7 @@ import spock.lang.Specification
 class StubRunnerConfigurationSpec extends Specification {
 
 	@Autowired StubFinder stubFinder
+	@Autowired Environment environment
 
 	@BeforeClass
 	@AfterClass
@@ -79,6 +81,15 @@ class StubRunnerConfigurationSpec extends Specification {
 			stubFinder.findStubUrl('nonExistingGroupId', 'nonExistingArtifactId')
 		then:
 			thrown(StubNotFoundException)
+	}
+
+	def 'should register started servers as environment variables'() {
+		expect:
+			environment.getProperty("stubrunner.runningstubs.loanIssuance.port") != null
+			stubFinder.findAllRunningStubs().getPort("loanIssuance") == (environment.getProperty("stubrunner.runningstubs.loanIssuance.port") as Integer)
+		and:
+			environment.getProperty("stubrunner.runningstubs.fraudDetectionServer.port") != null
+			stubFinder.findAllRunningStubs().getPort("fraudDetectionServer") == (environment.getProperty("stubrunner.runningstubs.fraudDetectionServer.port") as Integer)
 	}
 
 	@Configuration


### PR DESCRIPTION
without this change you can't reference the port of a server as an env var

fixes #147