### PR TITLE
Stub / Test Matchers

### DIFF
--- a/docs/src/main/asciidoc/verifier/contract.adoc
+++ b/docs/src/main/asciidoc/verifier/contract.adoc
@@ -128,9 +128,12 @@ Besides status response may contain **headers** and **body**, which are specifie
 
 The contract can contain some dynamic properties - timestamps / ids etc. You don't want to enforce the consumers to stub their
 clocks to always return the same value of time so that it gets matched by the stub. That's why we allow you to provide the dynamic
-parts in your contracts in the following way
+parts in your contracts in two ways. One is to pass them directly in the
+body and one to set them in a separate section called `testMatchers` and `stubMatchers`.
 
-either via the `value` method
+===== Dynamic properties inside the body
+
+You can set the properties inside the body either via the `value` method
 
 [source,groovy,indent=0]
 ----
@@ -153,7 +156,7 @@ $(client(...), server(...))
 All of the aforementioned approaches are equal. That means that `stub` and `client` methods are aliases over the `consumer`
 method. Let's take a closer look at what we can do with those values in the subsequent sections.
 
-==== Regular expressions
+====== Regular expressions
 
 You can use regular expressions to write your requests in Contract DSL. It is particularly useful when you want to indicate that a given response
 should be provided for requests that follow a given pattern. Also, you can use it when you need to use patterns and not exact values both
@@ -190,8 +193,7 @@ so in your contract you can use it like this
 include::{verifier_core_path}/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MockMvcMethodBodyBuilderSpec.groovy[tags=contract_with_regex,indent=0]
 ----
 
-
-==== Passing optional parameters
+====== Passing optional parameters
 
 It is possible to provide optional parameters in your contract. It's only possible to have optional parameter for the:
 
@@ -221,9 +223,115 @@ and the following stub:
 include::{plugins_path}/spring-cloud-contract-converters/src/test/groovy/org/springframework/cloud/contract/verifier/wiremock/DslToWireMockClientConverterSpec.groovy[tags=wiremock,indent=0]
 ----
 
-==== Executing custom methods on server side
+====== Executing custom methods on server side
+
 It is also possible to define a method call to be executed on the server side during the test. Such a method can be added to the class defined as "baseClassForTests"
 in the configuration. Please see the examples below:
+
+===== Dynamic properties in matchers sections
+
+If you've been working with https://docs.pact.io/[Pact] this might seem familiar. Quite a few users
+are used to having a separation between the body and setting dynamic parts of your contract.
+
+That's why you can profit from two separate sections. One is called `stubMatchers` where you can
+define the dynamic values that should end up in a stub. You can set it in the `request` or `inputMessage`
+part of your contract. The other is called `testMatchers` which is present in the `response` or
+`outputMessage` side of the contract.
+
+Currently we support only JSON Path based matchers with the following matching possibilities.
+For `stubMatchers`:
+
+- `byRegex(...)` - the value taken from the response via the provided JSON Path needs
+to match the regex
+- `byDate()` - the value taken from the response via the provided JSON Path needs to
+match the regex for ISO Date
+- `byTimestamp()` - the value taken from the response via the provided JSON Path needs
+to match the regex for ISO DateTime
+- `byTime()` - the value taken from the response via the provided JSON Path needs to
+match the regex for ISO Time
+
+For `testMatchers`:
+
+- `byRegex(...)` - the value taken from the response via the provided JSON Path needs
+to match the regex
+- `byDate()` - the value taken from the response via the provided JSON Path needs to
+match the regex for ISO Date
+- `byTimestamp()` - the value taken from the response via the provided JSON Path needs
+to match the regex for ISO DateTime
+- `byTime()` - the value taken from the response via the provided JSON Path needs to
+match the regex for ISO Time
+- `byType()` - the value taken from the response via the provided JSON Path needs to
+be of the same type as the type defined in the body of the response in the contract.
+`byType` can take a closure where you can set `minOccurrence` and `maxOccurrence`.
+That way you can assert on the size of the collection.
+
+Let's take a look at the following example:
+
+[source,groovy,indent=0]
+----
+include::{verifier_core_path}/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MockMvcMethodBodyBuilderWithMatchersSpec.groovy[tags=matchers,indent=0]
+----
+
+In this example we're providing the dynamic portions of the contract in the matchers sections.
+ For the request part you can see that for all fields but `valueWithoutAMatcher` we're setting
+ explicitly the values of regular expressions we'd like the stub to contain. For the `valueWithoutAMatcher`
+ the verification will take place in the same way as without the usage of matchers - the test
+ will perform an equality check in this case.
+
+For the response side in the `testMatchers` section we're defining all the dynamic parts
+ in a similar manner. The only difference is that we have the `byType` matchers too. In that
+ case we're checking 4 fields in the way that we're verifying whether the response from the test
+ has a value whose JSON path matching the given field is of the same type as the one defined in the response body and:
+
+ - for `$.valueWithTypeMatch` - we're just checking the whether the type is the same
+ - for `$.valueWithMin` - we're checking the type and assert if the size is greater or equal to the min occurrence
+ - for `$.valueWithMax` - we're checking the type and assert if the size is smaller or equal to the max occurrence
+ - for `$.valueWithMinMax` - we're checking the type and assert if the size is between the min and max occurrence
+
+The resulting test would look more or less like this (note that we're separating the autogenerated
+assertions and the one from matchers with an `and` section):
+
+[source,java,indent=0]
+----
+ // given:
+  MockMvcRequestSpecification request = given()
+    .header("Content-Type", "application/json")
+    .body("{\"duck\":123,\"alpha\":\"abc\",\"number\":123,\"aBoolean\":true,\"date\":\"2017-01-01\",\"dateTime\":\"2017-01-01T01:23:45\",\"time\":\"01:02:34\",\"valueWithoutAMatcher\":\"foo\",\"valueWithTypeMatch\":\"string\"}");
+
+ // when:
+  ResponseOptions response = given().spec(request)
+    .get("/get");
+
+ // then:
+  assertThat(response.statusCode()).isEqualTo(200);
+  assertThat(response.header("Content-Type")).matches("application/json.*");
+ // and:
+  DocumentContext parsedJson = JsonPath.parse(response.getBody().asString());
+  assertThatJson(parsedJson).field("valueWithoutAMatcher").isEqualTo("foo");
+ // and:
+  assertThat(parsedJson.read("$.duck", String.class)).matches("[0-9]{3}");
+  assertThat(parsedJson.read("$.alpha", String.class)).matches("[\\p{L}]*");
+  assertThat(parsedJson.read("$.number", String.class)).matches("-?\\d*(\\.\\d+)?");
+  assertThat(parsedJson.read("$.aBoolean", String.class)).matches("(true|false)");
+  assertThat(parsedJson.read("$.date", String.class)).matches("(\\d\\d\\d\\d)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])");
+  assertThat(parsedJson.read("$.dateTime", String.class)).matches("([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])");
+  assertThat(parsedJson.read("$.time", String.class)).matches("(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])");
+  assertThat((Object) parsedJson.read("$.valueWithTypeMatch")).isInstanceOf(class java.lang.String.class);
+  assertThat((Object) parsedJson.read("$.valueWithMin")).isInstanceOf(java.util.List.class);
+  assertThat(parsedJson.read("$.valueWithMin", java.util.Collection.class).size()).isLessThanOrEqualTo(1);
+  assertThat((Object) parsedJson.read("$.valueWithMax")).isInstanceOf(java.util.List.class);
+  assertThat(parsedJson.read("$.valueWithMax", java.util.Collection.class).size()).isGreaterThanOrEqualTo(3);
+  assertThat((Object) parsedJson.read("$.valueWithMinMax")).isInstanceOf(java.util.List.class);
+  assertThat(parsedJson.read("$.valueWithMinMax", java.util.Collection.class).size()).isStrictlyBetween(1, 3);
+----
+
+and the WireMock stub like this:
+
+[source,json,indent=0]
+----
+include::{plugins_path}/spring-cloud-contract-converters/src/test/groovy/org/springframework/cloud/contract/verifier/wiremock/DslToWireMockClientConverterSpec.groovy[tags=matchers,indent=0]
+----
+
 
 ===== Contract DSL
 

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/BodyMatcher.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/BodyMatcher.groovy
@@ -7,6 +7,12 @@ package org.springframework.cloud.contract.spec.internal
  * @since 1.0.3
  */
 interface BodyMatcher {
+
+	/**
+	 * What kind of matching are we dealing with
+	 */
+	MatchingType matchingType()
+
 	/**
 	 * Path to the path. Example for JSON it will be JSON Path
 	 */
@@ -20,4 +26,14 @@ interface BodyMatcher {
 	 * contained a string then the assertion should fail
 	 */
 	String value()
+
+	/**
+	 * Min no of occurrence when matching by type. In all other cases it will be ignored
+	 */
+	Integer minTypeOccurrence()
+
+	/**
+	 * Max no of occurrence when matching by type. In all other cases it will be ignored
+	 */
+	Integer maxTypeOccurrence()
 }

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/BodyMatcher.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/BodyMatcher.groovy
@@ -1,0 +1,23 @@
+package org.springframework.cloud.contract.spec.internal
+
+/**
+ * A jsonPathMatchers for the given path.
+ *
+ * @author Marcin Grzejszczak
+ * @since 1.0.3
+ */
+interface BodyMatcher {
+	/**
+	 * Path to the path. Example for JSON it will be JSON Path
+	 */
+	String path()
+
+	/**
+	 * Optional value that the given path should be checked against.
+	 * If there is no value then presence will be checked only together with
+	 * type check. Example if we expect a JSON Path path {@code $.a} to be matched
+	 * by type, the defined response body contained an integer but the actual one
+	 * contained a string then the assertion should fail
+	 */
+	String value()
+}

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/BodyMatchers.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/BodyMatchers.groovy
@@ -40,6 +40,7 @@ class BodyMatchers {
 	}
 
 	MatchingTypeValue byRegex(String regex) {
+		assert regex
 		return new MatchingTypeValue(MatchingType.REGEX, regex)
 	}
 }

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/BodyMatchers.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/BodyMatchers.groovy
@@ -1,0 +1,70 @@
+package org.springframework.cloud.contract.spec.internal
+
+import groovy.transform.Canonical
+import groovy.transform.CompileStatic
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+/**
+ * Matching strategy of dynamic parts of the body.
+ *
+ * @author Marcin Grzejszczak
+ * @since 1.0.3
+ */
+@CompileStatic
+class BodyMatchers {
+	private final RegexPatterns regexPatterns = new RegexPatterns()
+	private final List<BodyMatcher> jsonPathMatchers = []
+
+	void jsonPath(String path, MatchingTypeValue matchingType) {
+		this.jsonPathMatchers << new JsonPathBodyMatcher(path, matchingType.value)
+	}
+
+	List<BodyMatcher> jsonPathMatchers() {
+		return this.jsonPathMatchers
+	}
+
+	MatchingTypeValue byType() {
+		return new MatchingTypeValue(MatchingType.TYPE)
+	}
+
+	MatchingTypeValue byDate() {
+		return new MatchingTypeValue(MatchingType.DATE, this.regexPatterns.isoDate())
+	}
+
+	MatchingTypeValue byTime() {
+		return new MatchingTypeValue(MatchingType.TIME, this.regexPatterns.isoTime())
+	}
+
+	MatchingTypeValue byTimestamp() {
+		return new MatchingTypeValue(MatchingType.TIMESTAMP, this.regexPatterns.isoDateTime())
+	}
+
+	MatchingTypeValue byRegex(String regex) {
+		return new MatchingTypeValue(MatchingType.REGEX, regex)
+	}
+}
+
+@ToString
+@EqualsAndHashCode
+@Canonical
+@CompileStatic
+class JsonPathBodyMatcher implements BodyMatcher {
+	String jsonPath
+	String value
+
+	@Override
+	String path() {
+		return this.jsonPath
+	}
+
+	@Override
+	String value() {
+		return this.value
+	}
+}
+
+@Canonical
+class MatchingTypeValue {
+	MatchingType type
+	String value
+}

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/BodyMatchers.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/BodyMatchers.groovy
@@ -23,10 +23,6 @@ class BodyMatchers {
 		return this.jsonPathMatchers
 	}
 
-	MatchingTypeValue byType() {
-		return new MatchingTypeValue(MatchingType.TYPE)
-	}
-
 	MatchingTypeValue byDate() {
 		return new MatchingTypeValue(MatchingType.DATE, this.regexPatterns.isoDate())
 	}

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/BodyMatchers.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/BodyMatchers.groovy
@@ -13,14 +13,18 @@ import groovy.transform.ToString
 @CompileStatic
 class BodyMatchers {
 	private final RegexPatterns regexPatterns = new RegexPatterns()
-	private final List<BodyMatcher> jsonPathMatchers = []
+	private final List<BodyMatcher> jsonPathRegexMatchers = []
 
 	void jsonPath(String path, MatchingTypeValue matchingType) {
-		this.jsonPathMatchers << new JsonPathBodyMatcher(path, matchingType.value)
+		this.jsonPathRegexMatchers << new JsonPathBodyMatcher(path, matchingType)
+	}
+
+	boolean hasMatchers() {
+		return !this.jsonPathRegexMatchers.empty
 	}
 
 	List<BodyMatcher> jsonPathMatchers() {
-		return this.jsonPathMatchers
+		return this.jsonPathRegexMatchers
 	}
 
 	MatchingTypeValue byDate() {
@@ -46,7 +50,12 @@ class BodyMatchers {
 @CompileStatic
 class JsonPathBodyMatcher implements BodyMatcher {
 	String jsonPath
-	String value
+	MatchingTypeValue matchingTypeValue
+
+	@Override
+	MatchingType matchingType() {
+		return this.matchingTypeValue.type
+	}
 
 	@Override
 	String path() {
@@ -55,12 +64,39 @@ class JsonPathBodyMatcher implements BodyMatcher {
 
 	@Override
 	String value() {
-		return this.value
+		return this.matchingTypeValue.value
+	}
+
+	@Override
+	Integer minTypeOccurrence() {
+		return this.matchingTypeValue.minTypeOccurrence
+	}
+
+	@Override
+	Integer maxTypeOccurrence() {
+		return this.matchingTypeValue.maxTypeOccurrence
 	}
 }
 
+/**
+ * Matching type with corresponding values
+ */
 @Canonical
 class MatchingTypeValue {
 	MatchingType type
+
+	/**
+	 * Value of regular expression
+	 */
 	String value
+
+	/**
+	 * Min occurrence when matching by type
+	 */
+	Integer minTypeOccurrence
+
+	/**
+	 * Max occurrence when matching by type
+	 */
+	Integer maxTypeOccurrence
 }

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/Input.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/Input.groovy
@@ -40,6 +40,7 @@ class Input extends Common {
 	Headers messageHeaders
 	BodyType messageBody
 	ExecutionProperty assertThat
+	BodyMatchers matchers
 
 	Input() {}
 
@@ -101,6 +102,12 @@ class Input extends Common {
 
 	void assertThat(String assertThat) {
 		this.assertThat = new ExecutionProperty(assertThat)
+	}
+
+	void stubMatchers(@DelegatesTo(BodyMatchers) Closure closure) {
+		this.matchers = new BodyMatchers()
+		closure.delegate = this.matchers
+		closure()
 	}
 }
 

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/MatchingType.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/MatchingType.groovy
@@ -1,5 +1,8 @@
 package org.springframework.cloud.contract.spec.internal
 
+import groovy.transform.CompileStatic
+import groovy.transform.PackageScope
+
 /**
  * Represents the type of matching the should be done against
  * the body of the request or response.
@@ -7,6 +10,8 @@ package org.springframework.cloud.contract.spec.internal
  * @author Marcin Grzejszczak
  * @since 1.0.3
  */
+@CompileStatic
+@PackageScope
 enum MatchingType {
 	TYPE, DATE, TIME, TIMESTAMP, REGEX
 }

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/MatchingType.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/MatchingType.groovy
@@ -1,0 +1,12 @@
+package org.springframework.cloud.contract.spec.internal
+
+/**
+ * Represents the type of matching the should be done against
+ * the body of the request or response.
+ *
+ * @author Marcin Grzejszczak
+ * @since 1.0.3
+ */
+enum MatchingType {
+	TYPE, DATE, TIME, TIMESTAMP, REGEX
+}

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/MatchingType.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/MatchingType.groovy
@@ -1,7 +1,6 @@
 package org.springframework.cloud.contract.spec.internal
 
 import groovy.transform.CompileStatic
-import groovy.transform.PackageScope
 
 /**
  * Represents the type of matching the should be done against
@@ -11,7 +10,6 @@ import groovy.transform.PackageScope
  * @since 1.0.3
  */
 @CompileStatic
-@PackageScope
 enum MatchingType {
-	TYPE, DATE, TIME, TIMESTAMP, REGEX
+	EQUALITY, TYPE, DATE, TIME, TIMESTAMP, REGEX
 }

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/OptionalProperty.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/OptionalProperty.groovy
@@ -39,9 +39,8 @@ class OptionalProperty {
 		return "($value)?"
 	}
 
-
 	@Override
-	public String toString() {
+	String toString() {
 		return optionalPattern()
 	}
 }

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/OutputMessage.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/OutputMessage.groovy
@@ -33,7 +33,7 @@ class OutputMessage extends Common {
 	Headers headers
 	DslProperty body
 	ExecutionProperty assertThat
-	BodyMatchers matchers
+	OutputMessageBodyMatchers matchers
 
 	OutputMessage() {}
 
@@ -77,8 +77,8 @@ class OutputMessage extends Common {
 		return new DslProperty(value, server.serverValue)
 	}
 
-	void testMatchers(@DelegatesTo(BodyMatchers) Closure closure) {
-		this.matchers = new BodyMatchers()
+	void testMatchers(@DelegatesTo(OutputMessageBodyMatchers) Closure closure) {
+		this.matchers = new OutputMessageBodyMatchers()
 		closure.delegate = this.matchers
 		closure()
 	}
@@ -101,3 +101,14 @@ class ClientOutputMessage extends OutputMessage {
 		super(request)
 	}
 }
+
+@CompileStatic
+@EqualsAndHashCode
+@ToString(includePackage = false)
+class OutputMessageBodyMatchers extends BodyMatchers {
+
+	MatchingTypeValue byType() {
+		return new MatchingTypeValue(MatchingType.TYPE)
+	}
+}
+

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/OutputMessage.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/OutputMessage.groovy
@@ -33,6 +33,7 @@ class OutputMessage extends Common {
 	Headers headers
 	DslProperty body
 	ExecutionProperty assertThat
+	BodyMatchers matchers
 
 	OutputMessage() {}
 
@@ -74,6 +75,12 @@ class OutputMessage extends Common {
 			value = new Xeger(((Pattern)server.clientValue).pattern()).generate()
 		}
 		return new DslProperty(value, server.serverValue)
+	}
+
+	void testMatchers(@DelegatesTo(BodyMatchers) Closure closure) {
+		this.matchers = new BodyMatchers()
+		closure.delegate = this.matchers
+		closure()
 	}
 }
 

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/OutputMessage.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/OutputMessage.groovy
@@ -33,7 +33,7 @@ class OutputMessage extends Common {
 	Headers headers
 	DslProperty body
 	ExecutionProperty assertThat
-	OutputMessageBodyMatchers matchers
+	ResponseBodyMatchers matchers
 
 	OutputMessage() {}
 
@@ -77,8 +77,8 @@ class OutputMessage extends Common {
 		return new DslProperty(value, server.serverValue)
 	}
 
-	void testMatchers(@DelegatesTo(OutputMessageBodyMatchers) Closure closure) {
-		this.matchers = new OutputMessageBodyMatchers()
+	void testMatchers(@DelegatesTo(ResponseBodyMatchers) Closure closure) {
+		this.matchers = new ResponseBodyMatchers()
 		closure.delegate = this.matchers
 		closure()
 	}
@@ -99,16 +99,6 @@ class ServerOutputMessage extends OutputMessage {
 class ClientOutputMessage extends OutputMessage {
 	ClientOutputMessage(OutputMessage request) {
 		super(request)
-	}
-}
-
-@CompileStatic
-@EqualsAndHashCode
-@ToString(includePackage = false)
-class OutputMessageBodyMatchers extends BodyMatchers {
-
-	MatchingTypeValue byType() {
-		return new MatchingTypeValue(MatchingType.TYPE)
 	}
 }
 

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/Request.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/Request.groovy
@@ -43,6 +43,7 @@ class Request extends Common {
 	RequestHeaders headers
 	Body body
 	Multipart multipart
+	BodyMatchers matchers
 
 	Request() {
 	}
@@ -202,6 +203,12 @@ class Request extends Common {
 
 	DslProperty $(Pattern client) {
 		return value(client)
+	}
+
+	void stubMatchers(@DelegatesTo(BodyMatchers) Closure closure) {
+		this.matchers = new BodyMatchers()
+		closure.delegate = this.matchers
+		closure()
 	}
 
 	@Override

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/Response.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/Response.groovy
@@ -174,15 +174,5 @@ class Response extends Common {
 			return new ServerDslProperty(pattern, generatedValue)
 		}
 	}
-
-	@CompileStatic
-	@EqualsAndHashCode
-	@ToString(includePackage = false)
-	private class ResponseBodyMatchers extends BodyMatchers {
-
-		MatchingTypeValue byType() {
-			return new MatchingTypeValue(MatchingType.TYPE)
-		}
-	}
 }
 

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/Response.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/Response.groovy
@@ -41,7 +41,7 @@ class Response extends Common {
 	ResponseHeaders headers
 	Body body
 	boolean async
-	BodyMatchers matchers
+	ResponseBodyMatchers matchers
 
 	Response() {
 	}
@@ -112,8 +112,8 @@ class Response extends Common {
 		return value(server)
 	}
 
-	void testMatchers(@DelegatesTo(BodyMatchers) Closure closure) {
-		this.matchers = new BodyMatchers()
+	void testMatchers(@DelegatesTo(ResponseBodyMatchers) Closure closure) {
+		this.matchers = new ResponseBodyMatchers()
 		closure.delegate = this.matchers
 		closure()
 	}
@@ -172,6 +172,16 @@ class Response extends Common {
 		@Override
 		protected ServerDslProperty createProperty(Pattern pattern, Object generatedValue) {
 			return new ServerDslProperty(pattern, generatedValue)
+		}
+	}
+
+	@CompileStatic
+	@EqualsAndHashCode
+	@ToString(includePackage = false)
+	private class ResponseBodyMatchers extends BodyMatchers {
+
+		MatchingTypeValue byType() {
+			return new MatchingTypeValue(MatchingType.TYPE)
 		}
 	}
 }

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/Response.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/Response.groovy
@@ -41,6 +41,7 @@ class Response extends Common {
 	ResponseHeaders headers
 	Body body
 	boolean async
+	BodyMatchers matchers
 
 	Response() {
 	}
@@ -109,6 +110,12 @@ class Response extends Common {
 
 	DslProperty $(Pattern server) {
 		return value(server)
+	}
+
+	void testMatchers(@DelegatesTo(BodyMatchers) Closure closure) {
+		this.matchers = new BodyMatchers()
+		closure.delegate = this.matchers
+		closure()
 	}
 
 	@Override

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/ResponseBodyMatchers.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/ResponseBodyMatchers.groovy
@@ -1,0 +1,42 @@
+package org.springframework.cloud.contract.spec.internal
+
+import groovy.transform.CompileStatic
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+
+/**
+ * Body matchers for the response side (output message, REST response)
+ *
+ * @author Marcin Grzejszczak
+ * @since 1.0.3
+ */
+@CompileStatic
+@EqualsAndHashCode
+@ToString(includePackage = false)
+class ResponseBodyMatchers extends BodyMatchers {
+
+	MatchingTypeValue byType() {
+		return new MatchingTypeValue(MatchingType.TYPE)
+	}
+
+	MatchingTypeValue byType(@DelegatesTo(MatchingTypeValueHolder) Closure closure) {
+		MatchingTypeValueHolder matchingTypeValue = new MatchingTypeValueHolder()
+		closure.delegate = matchingTypeValue
+		return closure() as MatchingTypeValue
+	}
+}
+
+@CompileStatic
+class MatchingTypeValueHolder {
+	MatchingTypeValue matchingTypeValue = new MatchingTypeValue()
+
+	MatchingTypeValue minOccurrence(int number) {
+		this.matchingTypeValue.minTypeOccurrence = number
+		return this.matchingTypeValue
+	}
+
+	MatchingTypeValue maxOccurrence(int number) {
+		this.matchingTypeValue.maxTypeOccurrence = number
+		return this.matchingTypeValue
+	}
+}

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/messaging/integration/StubRunnerIntegrationMessageSelector.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/messaging/integration/StubRunnerIntegrationMessageSelector.java
@@ -20,10 +20,13 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import org.springframework.cloud.contract.spec.Contract;
+import org.springframework.cloud.contract.spec.internal.BodyMatcher;
+import org.springframework.cloud.contract.spec.internal.BodyMatchers;
 import org.springframework.cloud.contract.spec.internal.Header;
 import org.springframework.cloud.contract.verifier.messaging.internal.ContractVerifierObjectMapper;
 import org.springframework.cloud.contract.verifier.util.JsonPaths;
 import org.springframework.cloud.contract.verifier.util.JsonToJsonPathsConverter;
+import org.springframework.cloud.contract.verifier.util.MapConverter;
 import org.springframework.cloud.contract.verifier.util.MethodBufferingJsonVerifiable;
 import org.springframework.integration.core.MessageSelector;
 import org.springframework.messaging.Message;
@@ -32,7 +35,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import com.toomuchcoding.jsonassert.JsonAssertion;
-import com.toomuchcoding.jsonassert.JsonVerifiable;
 
 /**
  * Passes through a message that matches the one defined in the DSL
@@ -54,9 +56,13 @@ class StubRunnerIntegrationMessageSelector implements MessageSelector {
 			return false;
 		}
 		Object inputMessage = message.getPayload();
+		BodyMatchers matchers = this.groovyDsl.getInput().getMatchers();
+		Object dslBody = MapConverter.getStubSideValues(this.groovyDsl.getInput().getMessageBody());
+		Object matchingInputMessage = JsonToJsonPathsConverter
+				.removeMatchingJsonPaths(dslBody, matchers);
 		JsonPaths jsonPaths = JsonToJsonPathsConverter
 				.transformToJsonPathWithStubsSideValuesAndNoArraySizeCheck(
-						this.groovyDsl.getInput().getMessageBody());
+						matchingInputMessage);
 		DocumentContext parsedJson;
 		try {
 			parsedJson = JsonPath.parse(this.objectMapper.writeValueAsString(inputMessage));
@@ -66,16 +72,21 @@ class StubRunnerIntegrationMessageSelector implements MessageSelector {
 		}
 		boolean matches = true;
 		for (MethodBufferingJsonVerifiable path : jsonPaths) {
-			matches &= matchesJsonPath(parsedJson, path);
+			matches &= matchesJsonPath(parsedJson, path.jsonPath());
+		}
+		if (matchers != null && matchers.hasMatchers()) {
+			for (BodyMatcher matcher : matchers.jsonPathMatchers()) {
+				String jsonPath = JsonToJsonPathsConverter.convertJsonPathAndRegexToAJsonPath(matcher.path(), matcher.value());
+				matches &= matchesJsonPath(parsedJson, jsonPath);
+			}
 		}
 		return matches;
 	}
 
-	private boolean matchesJsonPath(DocumentContext parsedJson,
-			JsonVerifiable jsonVerifiable) {
+	private boolean matchesJsonPath(DocumentContext parsedJson, String jsonPath) {
 		try {
 			JsonAssertion.assertThat(parsedJson)
-					.matchesJsonPath(jsonVerifiable.jsonPath());
+					.matchesJsonPath(jsonPath);
 			return true;
 		}
 		catch (Exception e) {

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/messaging/camel/StubRunnerCamelPredicateSpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/messaging/camel/StubRunnerCamelPredicateSpec.groovy
@@ -1,0 +1,137 @@
+package org.springframework.cloud.contract.stubrunner.messaging.camel
+
+import org.apache.camel.Exchange
+import org.apache.camel.Message
+import org.springframework.cloud.contract.spec.Contract
+import spock.lang.Specification
+
+/**
+ * @author Marcin Grzejszczak
+ */
+class StubRunnerCamelPredicateSpec extends Specification {
+	Exchange exchange = Stub(Exchange)
+	Message message = Stub(Message)
+
+	def "should return false if headers don't match"() {
+		given:
+			Contract dsl = Contract.make {
+				input {
+					messageFrom "foo"
+					messageBody(foo: "bar")
+					messageHeaders {
+						header("foo", $(c(regex("[0-9]{3}")), p(123)))
+					}
+				}
+			}
+		and:
+			StubRunnerCamelPredicate predicate = new StubRunnerCamelPredicate(dsl)
+			exchange.in >> message
+			message.headers >> [
+			        foo: "non matching stuff"
+			]
+		expect:
+			!predicate.matches(exchange)
+	}
+
+	def "should return false if headers match and body doesn't"() {
+		given:
+			Contract dsl = Contract.make {
+				input {
+					messageFrom "foo"
+					messageHeaders {
+						header("foo", 123)
+					}
+					messageBody(foo: $(c(regex("[0-9]{3}")), p(123)))
+				}
+			}
+		and:
+			StubRunnerCamelPredicate predicate = new StubRunnerCamelPredicate(dsl)
+			exchange.in >> message
+			message.headers >> [
+					foo: 123
+			]
+			message.body >> [
+					foo: "non matching stuff"
+			]
+		expect:
+			!predicate.matches(exchange)
+	}
+
+	def "should return false if headers match and body doesn't when it's using matchers"() {
+		given:
+			Contract dsl = Contract.make {
+				input {
+					messageFrom "foo"
+					messageHeaders {
+						header("foo", 123)
+					}
+					messageBody(foo: "non matching stuff")
+					stubMatchers {
+						jsonPath('$.foo', byRegex("[0-9]{3}"))
+					}
+				}
+			}
+		and:
+			StubRunnerCamelPredicate predicate = new StubRunnerCamelPredicate(dsl)
+			exchange.in >> message
+			message.headers >> [
+					foo: 123
+			]
+			message.body >> [
+					foo: "non matching stuff"
+			]
+		expect:
+			!predicate.matches(exchange)
+	}
+	def "should return true if headers and body match"() {
+		given:
+			Contract dsl = Contract.make {
+				input {
+					messageFrom "foo"
+					messageHeaders {
+						header("foo", 123)
+					}
+					messageBody(foo: $(c(regex("[0-9]{3}")), p(123)))
+
+				}
+			}
+		and:
+			StubRunnerCamelPredicate predicate = new StubRunnerCamelPredicate(dsl)
+			exchange.in >> message
+			message.headers >> [
+					foo: 123
+			]
+			message.body >> [
+					foo: 123
+			]
+		expect:
+			predicate.matches(exchange)
+
+	}
+	def "should return true if headers and body using matchers match"() {
+		given:
+			Contract dsl = Contract.make {
+				input {
+					messageFrom "foo"
+					messageHeaders {
+						header("foo", 123)
+					}
+					messageBody(foo: 123)
+					stubMatchers {
+						jsonPath('$.foo', byRegex("[0-9]{3}"))
+					}
+				}
+			}
+		and:
+			StubRunnerCamelPredicate predicate = new StubRunnerCamelPredicate(dsl)
+			exchange.in >> message
+			message.headers >> [
+					foo: 123
+			]
+			message.body >> [
+					foo: 123
+			]
+		expect:
+			predicate.matches(exchange)
+	}
+}

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/messaging/integration/StubRunnerIntegrationMessageSelectorSpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/messaging/integration/StubRunnerIntegrationMessageSelectorSpec.groovy
@@ -1,0 +1,130 @@
+package org.springframework.cloud.contract.stubrunner.messaging.integration
+
+import org.springframework.cloud.contract.spec.Contract
+import org.springframework.messaging.Message
+import spock.lang.Specification
+/**
+ * @author Marcin Grzejszczak
+ */
+class StubRunnerIntegrationMessageSelectorSpec extends Specification {
+	Message message = Mock(Message)
+	
+	def "should return false if headers don't match"() {
+		given:
+			Contract dsl = Contract.make {
+				input {
+					messageFrom "foo"
+					messageBody(foo: "bar")
+					messageHeaders {
+						header("foo", $(c(regex("[0-9]{3}")), p(123)))
+					}
+				}
+			}
+		and:
+			StubRunnerIntegrationMessageSelector predicate = new StubRunnerIntegrationMessageSelector(dsl)
+			message.headers >> [
+					foo: "non matching stuff"
+			]
+		expect:
+			!predicate.accept(message)
+	}
+
+	def "should return false if headers match and body doesn't"() {
+		given:
+			Contract dsl = Contract.make {
+				input {
+					messageFrom "foo"
+					messageHeaders {
+						header("foo", 123)
+					}
+					messageBody(foo: $(c(regex("[0-9]{3}")), p(123)))
+				}
+			}
+		and:
+			StubRunnerIntegrationMessageSelector predicate = new StubRunnerIntegrationMessageSelector(dsl)
+			message.headers >> [
+					foo: 123
+			]
+			message.payload >> [
+					foo: "non matching stuff"
+			]
+		expect:
+			!predicate.accept(message)
+	}
+
+	def "should return false if headers match and body doesn't when it's using matchers"() {
+		given:
+			Contract dsl = Contract.make {
+				input {
+					messageFrom "foo"
+					messageHeaders {
+						header("foo", 123)
+					}
+					messageBody(foo: "non matching stuff")
+					stubMatchers {
+						jsonPath('$.foo', byRegex("[0-9]{3}"))
+					}
+				}
+			}
+		and:
+			StubRunnerIntegrationMessageSelector predicate = new StubRunnerIntegrationMessageSelector(dsl)
+			message.headers >> [
+					foo: 123
+			]
+			message.payload >> [
+					foo: "non matching stuff"
+			]
+		expect:
+			!predicate.accept(message)
+	}
+
+	def "should return true if headers and body match"() {
+		given:
+			Contract dsl = Contract.make {
+				input {
+					messageFrom "foo"
+					messageHeaders {
+						header("foo", 123)
+					}
+					messageBody(foo: $(c(regex("[0-9]{3}")), p(123)))
+	
+				}
+			}
+		and:
+			StubRunnerIntegrationMessageSelector predicate = new StubRunnerIntegrationMessageSelector(dsl)
+			message.headers >> [
+					foo: 123
+			]
+			message.payload >> [
+					foo: 123
+			]
+		expect:
+			predicate.accept(message)
+	}
+
+	def "should return true if headers and body using matchers match"() {
+		given:
+			Contract dsl = Contract.make {
+				input {
+					messageFrom "foo"
+					messageHeaders {
+						header("foo", 123)
+					}
+					messageBody(foo: 123)
+					stubMatchers {
+						jsonPath('$.foo', byRegex("[0-9]{3}"))
+					}
+				}
+			}
+		and:
+			StubRunnerIntegrationMessageSelector predicate = new StubRunnerIntegrationMessageSelector(dsl)
+			message.headers >> [
+					foo: 123
+			]
+			message.payload >> [
+					foo: 123
+			]
+		expect:
+			predicate.accept(message)
+	}
+}

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/messaging/stream/StubRunnerStreamMessageSelectorSpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/messaging/stream/StubRunnerStreamMessageSelectorSpec.groovy
@@ -1,0 +1,131 @@
+package org.springframework.cloud.contract.stubrunner.messaging.stream
+
+import org.springframework.cloud.contract.spec.Contract
+import org.springframework.messaging.Message
+import spock.lang.Specification
+
+/**
+ * @author Marcin Grzejszczak
+ */
+class StubRunnerStreamMessageSelectorSpec extends Specification {
+	Message message = Mock(Message)
+
+	def "should return false if headers don't match"() {
+		given:
+			Contract dsl = Contract.make {
+				input {
+					messageFrom "foo"
+					messageBody(foo: "bar")
+					messageHeaders {
+						header("foo", $(c(regex("[0-9]{3}")), p(123)))
+					}
+				}
+			}
+		and:
+			StubRunnerStreamMessageSelector predicate = new StubRunnerStreamMessageSelector(dsl)
+			message.headers >> [
+					foo: "non matching stuff"
+			]
+		expect:
+			!predicate.accept(message)
+	}
+
+	def "should return false if headers match and body doesn't"() {
+		given:
+			Contract dsl = Contract.make {
+				input {
+					messageFrom "foo"
+					messageHeaders {
+						header("foo", 123)
+					}
+					messageBody(foo: $(c(regex("[0-9]{3}")), p(123)))
+				}
+			}
+		and:
+			StubRunnerStreamMessageSelector predicate = new StubRunnerStreamMessageSelector(dsl)
+			message.headers >> [
+					foo: 123
+			]
+			message.payload >> [
+					foo: "non matching stuff"
+			]
+		expect:
+			!predicate.accept(message)
+	}
+
+	def "should return false if headers match and body doesn't when it's using matchers"() {
+		given:
+			Contract dsl = Contract.make {
+				input {
+					messageFrom "foo"
+					messageHeaders {
+						header("foo", 123)
+					}
+					messageBody(foo: "non matching stuff")
+					stubMatchers {
+						jsonPath('$.foo', byRegex("[0-9]{3}"))
+					}
+				}
+			}
+		and:
+			StubRunnerStreamMessageSelector predicate = new StubRunnerStreamMessageSelector(dsl)
+			message.headers >> [
+					foo: 123
+			]
+			message.payload >> [
+					foo: "non matching stuff"
+			]
+		expect:
+			!predicate.accept(message)
+	}
+
+	def "should return true if headers and body match"() {
+		given:
+			Contract dsl = Contract.make {
+				input {
+					messageFrom "foo"
+					messageHeaders {
+						header("foo", 123)
+					}
+					messageBody(foo: $(c(regex("[0-9]{3}")), p(123)))
+
+				}
+			}
+		and:
+			StubRunnerStreamMessageSelector predicate = new StubRunnerStreamMessageSelector(dsl)
+			message.headers >> [
+					foo: 123
+			]
+			message.payload >> [
+					foo: 123
+			]
+		expect:
+			predicate.accept(message)
+	}
+
+	def "should return true if headers and body using matchers match"() {
+		given:
+			Contract dsl = Contract.make {
+				input {
+					messageFrom "foo"
+					messageHeaders {
+						header("foo", 123)
+					}
+					messageBody(foo: 123)
+					stubMatchers {
+						jsonPath('$.foo', byRegex("[0-9]{3}"))
+					}
+				}
+			}
+		and:
+			StubRunnerStreamMessageSelector predicate = new StubRunnerStreamMessageSelector(dsl)
+			message.headers >> [
+					foo: 123
+			]
+			message.payload >> [
+					foo: 123
+			]
+		expect:
+			predicate.accept(message)
+	}
+}

--- a/spring-cloud-contract-tools/spring-cloud-contract-converters/src/test/groovy/org/springframework/cloud/contract/verifier/wiremock/DslToWireMockClientConverterSpec.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-converters/src/test/groovy/org/springframework/cloud/contract/verifier/wiremock/DslToWireMockClientConverterSpec.groovy
@@ -427,7 +427,7 @@ class DslToWireMockClientConverterSpec extends Specification {
 		when:
 		String json = converter.convertContent("Test", new ContractMetadata(file.toPath(), false, 0, null))
 		then:
-		JSONAssert.assertEquals(
+		JSONAssert.assertEquals(//tag::matchers[]
 				'''
 {
   "request" : {
@@ -475,6 +475,7 @@ class DslToWireMockClientConverterSpec extends Specification {
   }
 }
 '''
+//end::matchers[]
 				, json, false)
 	}
 

--- a/spring-cloud-contract-tools/spring-cloud-contract-converters/src/test/groovy/org/springframework/cloud/contract/verifier/wiremock/DslToWireMockClientConverterSpec.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-converters/src/test/groovy/org/springframework/cloud/contract/verifier/wiremock/DslToWireMockClientConverterSpec.groovy
@@ -27,7 +27,7 @@ import spock.lang.Specification
 class DslToWireMockClientConverterSpec extends Specification {
 
 	@Rule
-	public TemporaryFolder tmpFolder = new TemporaryFolder();
+	public TemporaryFolder tmpFolder = new TemporaryFolder()
 
 	def "should convert DSL file to WireMock JSON"() {
 		given:
@@ -317,6 +317,236 @@ class DslToWireMockClientConverterSpec extends Specification {
 }
 '''
 // end::wiremock[]
+				, json, false)
+	}
+
+	def 'should convert dsl to wiremock with stub matchers'() {
+		given:
+		def converter = new DslToWireMockClientConverter()
+		and:
+		File file = tmpFolder.newFile("dsl_from_docs.groovy")
+		file.write('''
+			org.springframework.cloud.contract.spec.Contract.make {
+				request {
+					method 'GET'
+					urlPath '/get'
+					body([
+							duck: 123,
+							alpha: "abc",
+							number: 123,
+							aBoolean: true,
+							date: "2017-01-01",
+							dateTime: "2017-01-01T01:23:45",
+							time: "01:02:34",
+							valueWithoutAMatcher: "foo",
+							valueWithTypeMatch: "string",
+							list: [
+								some: [
+									nested: [
+										json: "with value",
+										anothervalue: 4
+									]
+								],
+								someother: [
+									nested: [
+										json: "with value",
+										anothervalue: 4
+									]
+								]
+							]
+					])
+					stubMatchers {
+						jsonPath('$.duck', byRegex("[0-9]{3}"))
+						jsonPath('$.alpha', byRegex(onlyAlphaUnicode()))
+						jsonPath('$.number', byRegex(number()))
+						jsonPath('$.aBoolean', byRegex(anyBoolean()))
+						jsonPath('$.date', byDate())
+						jsonPath('$.dateTime', byTimestamp())
+						jsonPath('$.time', byTime())
+						jsonPath('$.list.some.nested.json', byRegex(".*"))
+					}
+					headers {
+						contentType(applicationJson())
+					}
+				}
+				response {
+					status 200
+					body([
+							duck: 123,
+							alpha: "abc",
+							number: 123,
+							aBoolean: true,
+							date: "2017-01-01",
+							dateTime: "2017-01-01T01:23:45",
+							time: "01:02:34",
+							valueWithoutAMatcher: "foo",
+							valueWithTypeMatch: "string",
+							valueWithMin: [
+								1,2,3
+							],
+							valueWithMax: [
+								1,2,3
+							],
+							valueWithMinMax: [
+								1,2,3
+							],
+					])
+					testMatchers {
+						// asserts the jsonpath value against manual regex
+						jsonPath('$.duck', byRegex("[0-9]{3}"))
+						// asserts the jsonpath value against some default regex
+						jsonPath('$.alpha', byRegex(onlyAlphaUnicode()))
+						jsonPath('$.number', byRegex(number()))
+						jsonPath('$.aBoolean', byRegex(anyBoolean()))
+						// asserts vs inbuilt time related regex
+						jsonPath('$.date', byDate())
+						jsonPath('$.dateTime', byTimestamp())
+						jsonPath('$.time', byTime())
+						// asserts that the resulting type is the same as in response body
+						jsonPath('$.valueWithTypeMatch', byType())
+						jsonPath('$.valueWithMin', byType {
+							// results in verification of size of array (min 1)
+							minOccurrence(1)
+						})
+						jsonPath('$.valueWithMax', byType {
+							// results in verification of size of array (max 3)
+							maxOccurrence(3)
+						})
+						jsonPath('$.valueWithMinMax', byType {
+							// results in verification of size of array (min 1 & max 3)
+							minOccurrence(1)
+							maxOccurrence(3)
+						})
+					}
+					headers {
+						contentType(applicationJson())
+					}
+				}
+			}
+	''')
+		when:
+		String json = converter.convertContent("Test", new ContractMetadata(file.toPath(), false, 0, null))
+		then:
+		JSONAssert.assertEquals(
+				'''
+{
+  "request" : {
+    "urlPath" : "/get",
+    "method" : "GET",
+    "headers" : {
+      "Content-Type" : {
+        "matches" : "application/json.*"
+      }
+    },
+    "bodyPatterns" : [ {
+      "matchesJsonPath" : "$[?(@.valueWithoutAMatcher == 'foo')]"
+    }, {
+      "matchesJsonPath" : "$[?(@.valueWithTypeMatch == 'string')]"
+    }, {
+      "matchesJsonPath" : "$.list.some.nested[?(@.anothervalue == 4)]"
+    }, {
+      "matchesJsonPath" : "$.list.someother.nested[?(@.anothervalue == 4)]"
+    }, {
+      "matchesJsonPath" : "$.list.someother.nested[?(@.json == 'with value')]"
+    }, {
+      "matchesJsonPath" : "$[?(@.duck =~ /([0-9]{3})/)]"
+    }, {
+      "matchesJsonPath" : "$[?(@.alpha =~ /([\\\\p{L}]*)/)]"
+    }, {
+      "matchesJsonPath" : "$[?(@.number =~ /(-?\\\\d*(\\\\.\\\\d+)?)/)]"
+    }, {
+      "matchesJsonPath" : "$[?(@.aBoolean =~ /((true|false))/)]"
+    }, {
+      "matchesJsonPath" : "$[?(@.date =~ /((\\\\d\\\\d\\\\d\\\\d)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]))/)]"
+    }, {
+      "matchesJsonPath" : "$[?(@.dateTime =~ /(([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9]))/)]"
+    }, {
+      "matchesJsonPath" : "$[?(@.time =~ /((2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9]))/)]"
+    }, {
+      "matchesJsonPath" : "$.list.some.nested[?(@.json =~ /(.*)/)]"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\\"duck\\":123,\\"alpha\\":\\"abc\\",\\"number\\":123,\\"aBoolean\\":true,\\"date\\":\\"2017-01-01\\",\\"dateTime\\":\\"2017-01-01T01:23:45\\",\\"time\\":\\"01:02:34\\",\\"valueWithoutAMatcher\\":\\"foo\\",\\"valueWithTypeMatch\\":\\"string\\",\\"valueWithMin\\":[1,2,3],\\"valueWithMax\\":[1,2,3],\\"valueWithMinMax\\":[1,2,3]}",
+    "headers" : {
+      "Content-Type" : "application/json"
+    }
+  }
+}
+'''
+				, json, false)
+	}
+
+	def 'should convert dsl to wiremock with stub matchers with docs example'() {
+		given:
+			def converter = new DslToWireMockClientConverter()
+		and:
+			File file = tmpFolder.newFile("dsl_from_docs.groovy")
+			file.write('''
+				org.springframework.cloud.contract.spec.Contract.make {
+					priority 1
+					request {
+						method 'POST'
+						url '/users/password'
+						headers {
+							header 'Content-Type': 'application/json'
+						}
+						body(
+							email: 'abc@abc.com',
+							callback_url: 'http://partners.com'
+						)
+						stubMatchers {
+							jsonPath('$.email', byRegex(email()))
+							jsonPath('$.callback_url', byRegex(hostname()))
+						}
+					}
+					response {
+						status 404
+						headers {
+							header 'Content-Type': 'application/json'
+						}
+						body(
+							code: "123123",
+							message: "User not found by email == [not.existing@user.com]"
+						)
+						testMatchers {
+							jsonPath('$.code', byRegex("123123"))
+							jsonPath('$.message', byRegex("User not found by email == ${email()}"))
+						}
+					}
+				}
+		''')
+		when:
+			String json = converter.convertContent("Test", new ContractMetadata(file.toPath(), false, 0, null))
+		then:
+			JSONAssert.assertEquals(
+					'''
+	{
+	  "request" : {
+		"url" : "/users/password",
+		"method" : "POST",
+		"bodyPatterns" : [ {
+		  "matchesJsonPath" : "$[?(@.email =~ /([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,4})/)]"
+		}, {
+		  "matchesJsonPath" : "$[?(@.callback_url =~ /(((http[s]?|ftp):\\\\/)\\\\/?([^:\\\\/\\\\s]+)(:[0-9]{1,5})?)/)]"
+		} ],
+		"headers" : {
+		  "Content-Type" : {
+			"equalTo" : "application/json"
+		  }
+		}
+	  },
+	  "response" : {
+		"status" : 404,
+		"body" : "{\\"code\\":\\"123123\\",\\"message\\":\\"User not found by email == [not.existing@user.com]\\"}",
+		"headers" : {
+		  "Content-Type" : "application/json"
+		}
+	  },
+	  "priority" : 1
+	}
+	'''
 				, json, false)
 	}
 

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JaxRsClientSpockMethodRequestProcessingBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JaxRsClientSpockMethodRequestProcessingBodyBuilder.groovy
@@ -148,4 +148,8 @@ class JaxRsClientSpockMethodRequestProcessingBodyBuilder extends SpockMethodRequ
 		blockBuilder.addLine("response.getHeaderString('$property') ${convertHeaderComparison(value)}")
 	}
 
+	@Override
+	protected String postProcessJsonPathCall(String jsonPath) {
+		return jsonPath.replace('$', '\\$')
+	}
 }

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/MessagingMethodBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/MessagingMethodBodyBuilder.groovy
@@ -82,7 +82,7 @@ abstract class MessagingMethodBodyBuilder extends MethodBodyBuilder {
 				if (outputMessage.headers) {
 					bb.addLine(addCommentSignIfRequired('and:')).startBlock()
 				}
-				validateResponseBodyBlock(bb, outputMessage.body.serverValue)
+				validateResponseBodyBlock(bb, outputMessage.matchers, outputMessage.body.serverValue)
 			}
 			if (outputMessage.assertThat) {
 				bb.addLine(outputMessage.assertThat.executionCommand)

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/MethodBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/MethodBodyBuilder.groovy
@@ -297,12 +297,7 @@ abstract class MethodBodyBuilder {
 	private void addJsonResponseBodyCheck(BlockBuilder bb, convertedResponseBody, BodyMatchers bodyMatchers) {
 		appendJsonPath(bb, getResponseAsString())
 		Object copiedBody = convertedResponseBody.clone()
-		if (bodyMatchers?.hasMatchers()) {
-			// remove all jsonpaths from the body - for those that remain we continue as usual
-			bodyMatchers.jsonPathMatchers().findAll { it.matchingType() != MatchingType.EQUALITY }.each { BodyMatcher matcher ->
-				JsonPath.parse(convertedResponseBody).delete(matcher.path())
-			}
-		}
+		convertedResponseBody = JsonToJsonPathsConverter.removeMatchingJsonPaths(convertedResponseBody, bodyMatchers)
 		JsonPaths jsonPaths = new JsonToJsonPathsConverter(configProperties).transformToJsonPathWithTestsSideValues(convertedResponseBody)
 		jsonPaths.each {
 			String method = it.method()

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/MethodBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/MethodBodyBuilder.groovy
@@ -16,9 +16,12 @@
 
 package org.springframework.cloud.contract.verifier.builder
 
+import com.jayway.jsonpath.JsonPath
+import groovy.json.JsonOutput
 import groovy.transform.PackageScope
 import groovy.transform.TypeChecked
 import org.apache.commons.lang3.StringEscapeUtils
+import org.assertj.core.api.Assertions
 import org.springframework.cloud.contract.spec.internal.*
 import org.springframework.cloud.contract.verifier.config.ContractVerifierConfigProperties
 import org.springframework.cloud.contract.verifier.util.ContentType
@@ -99,27 +102,27 @@ abstract class MethodBodyBuilder {
 	protected abstract String getResponseBodyPropertyComparisonString(String property, ExecutionProperty value)
 
 	/**
-	 * Appends to the {@link BlockBuilder} the assertion for the given body element
+	 * Appends to the {@link BlockBuilder} the assertion for the given body path
 	 */
 	protected abstract void processBodyElement(BlockBuilder blockBuilder, String property, ExecutionProperty exec)
 
 	/**
-	 * Appends to the {@link BlockBuilder} the assertion for the given body element
+	 * Appends to the {@link BlockBuilder} the assertion for the given body path
 	 */
 	protected abstract void processBodyElement(BlockBuilder blockBuilder, String property, Map.Entry entry)
 
 	/**
-	 * Appends to the {@link BlockBuilder} the assertion for the given header element
+	 * Appends to the {@link BlockBuilder} the assertion for the given header path
 	 */
 	protected abstract void processHeaderElement(BlockBuilder blockBuilder, String property, Pattern pattern)
 
 	/**
-	 * Appends to the {@link BlockBuilder} the assertion for the given header element
+	 * Appends to the {@link BlockBuilder} the assertion for the given header path
 	 */
 	protected abstract void processHeaderElement(BlockBuilder blockBuilder, String property, ExecutionProperty exec)
 
 	/**
-	 * Appends to the {@link BlockBuilder} the assertion for the given header element
+	 * Appends to the {@link BlockBuilder} the assertion for the given header path
 	 */
 	protected abstract void processHeaderElement(BlockBuilder blockBuilder, String property, String value)
 
@@ -258,8 +261,18 @@ abstract class MethodBodyBuilder {
 	/**
 	 * Builds the response body verification part. The code will differ depending on the
 	 * ContentType, type of response etc. The result will be appended to {@link BlockBuilder}
+	 * @deprecated - use {@link MethodBodyBuilder#validateResponseBodyBlock(org.springframework.cloud.contract.verifier.builder.BlockBuilder, org.springframework.cloud.contract.spec.internal.BodyMatchers, java.lang.Object)}
 	 */
+	@Deprecated
 	protected void validateResponseBodyBlock(BlockBuilder bb, Object responseBody) {
+		validateResponseBodyBlock(bb, null, responseBody)
+	}
+
+	/**
+	 * Builds the response body verification part. The code will differ depending on the
+	 * ContentType, type of response etc. The result will be appended to {@link BlockBuilder}
+	 */
+	protected void validateResponseBodyBlock(BlockBuilder bb, BodyMatchers bodyMatchers, Object responseBody) {
 		ContentType contentType = getResponseContentType()
 		Object convertedResponseBody = responseBody
 		if (convertedResponseBody instanceof GString) {
@@ -271,15 +284,7 @@ abstract class MethodBodyBuilder {
 			convertedResponseBody = StringEscapeUtils.escapeJava(convertedResponseBody.toString())
 		}
 		if (contentType == ContentType.JSON) {
-			appendJsonPath(bb, getResponseAsString())
-			JsonPaths jsonPaths = new JsonToJsonPathsConverter(configProperties).transformToJsonPathWithTestsSideValues(convertedResponseBody)
-			jsonPaths.each {
-				String method = it.method()
-				String postProcessedMethod = postProcessJsonPathCall(method)
-				bb.addLine("assertThatJson(parsedJson)" + postProcessedMethod)
-				addColonIfRequired(bb)
-			}
-			processBodyElement(bb, "", convertedResponseBody)
+			addJsonResponseBodyCheck(bb, convertedResponseBody, bodyMatchers)
 		} else if (contentType == ContentType.XML) {
 			bb.addLine(getParsedXmlResponseBodyString(getResponseAsString()))
 			addColonIfRequired(bb)
@@ -289,6 +294,50 @@ abstract class MethodBodyBuilder {
 			processText(bb, "", convertedResponseBody)
 			addColonIfRequired(bb)
 		}
+	}
+
+	private void addJsonResponseBodyCheck(BlockBuilder bb, convertedResponseBody, BodyMatchers bodyMatchers) {
+		appendJsonPath(bb, getResponseAsString())
+		Object copiedBody = convertedResponseBody.clone()
+		if (bodyMatchers) {
+			// remove all jsonpaths from the body - for those that remain we continue as usual
+			bodyMatchers.jsonPathMatchers().each {
+				JsonPath.parse(convertedResponseBody).delete(it.path())
+			}
+		}
+		JsonPaths jsonPaths = new JsonToJsonPathsConverter(configProperties).transformToJsonPathWithTestsSideValues(convertedResponseBody)
+		jsonPaths.each {
+			String method = it.method()
+			String postProcessedMethod = postProcessJsonPathCall(method)
+			bb.addLine("assertThatJson(parsedJson)" + postProcessedMethod)
+			addColonIfRequired(bb)
+			bb.endBlock()
+		}
+		if (bodyMatchers) {
+			bb.addLine(addCommentSignIfRequired('and:'))
+			bb.startBlock()
+			// for the rest we'll do JsonPath matching in brute force
+			bodyMatchers.jsonPathMatchers().each {
+				if (it.value()) {
+					String method = "assertThat(parsedJson.read(${quotedAndEscaped(it.path())}, String.class)).matches(${quotedAndEscaped(it.value())})"
+					bb.addLine(postProcessJsonPathCall(method))
+					addColonIfRequired(bb)
+				} else {
+					Object elementFromBody = JsonPath.parse(copiedBody).read(it.path())
+					if (!elementFromBody) {
+						throw new IllegalStateException("Entry for the provided JSON path [${it.path()}] doesn't exist in the body [${JsonOutput.toJson(copiedBody)}]")
+					}
+					String method = "assertThat((Object) parsedJson.read(${quotedAndEscaped(it.path())})).isExactlyInstanceOf(${elementFromBody.class.name}.class)"
+					bb.addLine(postProcessJsonPathCall(method))
+					addColonIfRequired(bb)
+				}
+			}
+		}
+		processBodyElement(bb, "", convertedResponseBody)
+	}
+
+	protected String quotedAndEscaped(String string) {
+		return '"' + StringEscapeUtils.escapeJava(string) + '"'
 	}
 
 	/**
@@ -324,13 +373,13 @@ abstract class MethodBodyBuilder {
 	}
 
 	/**
-	 * Appends to the {@link BlockBuilder} the assertion for the given header element
+	 * Appends to the {@link BlockBuilder} the assertion for the given header path
 	 */
 	protected void processHeaderElement(BlockBuilder blockBuilder, String property, Object value) {
 	}
 
 	/**
-	 * Appends to the {@link BlockBuilder} the assertion for the given body element
+	 * Appends to the {@link BlockBuilder} the assertion for the given body path
 	 */
 	protected void processBodyElement(BlockBuilder blockBuilder, String property, Object value) {
 	}
@@ -402,7 +451,7 @@ abstract class MethodBodyBuilder {
 
 
 	/**
-	 * Appends to the {@link BlockBuilder} the assertion for the given body element
+	 * Appends to the {@link BlockBuilder} the assertion for the given body path
 	 */
 	protected void processBodyElement(BlockBuilder blockBuilder, String property, Map map) {
 		map.each {
@@ -411,7 +460,7 @@ abstract class MethodBodyBuilder {
 	}
 
 	/**
-	 * Appends to the {@link BlockBuilder} the assertion for the given body element
+	 * Appends to the {@link BlockBuilder} the assertion for the given body path
 	 */
 	protected void processBodyElement(BlockBuilder blockBuilder, String property, List list) {
 		list.eachWithIndex { listElement, listIndex ->

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/MethodBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/MethodBodyBuilder.groovy
@@ -100,12 +100,12 @@ abstract class MethodBodyBuilder {
 	protected abstract String getResponseBodyPropertyComparisonString(String property, ExecutionProperty value)
 
 	/**
-	 * Appends to the {@link BlockBuilder} the assertion for the given body path
+	 * Appends to the {@link BlockBuilder} the assertion for the given body element
 	 */
 	protected abstract void processBodyElement(BlockBuilder blockBuilder, String property, ExecutionProperty exec)
 
 	/**
-	 * Appends to the {@link BlockBuilder} the assertion for the given body path
+	 * Appends to the {@link BlockBuilder} the assertion for the given body element
 	 */
 	protected abstract void processBodyElement(BlockBuilder blockBuilder, String property, Map.Entry entry)
 
@@ -340,7 +340,7 @@ abstract class MethodBodyBuilder {
 		addColonIfRequired(bb)
 	}
 
-
+	// we want to make the type more generic (e.g. not ArrayList but List)
 	protected Class classToCheck(Object elementFromBody) {
 		switch (elementFromBody.class) {
 			case List:
@@ -407,7 +407,7 @@ abstract class MethodBodyBuilder {
 	}
 
 	/**
-	 * Appends to the {@link BlockBuilder} the assertion for the given body path
+	 * Appends to the {@link BlockBuilder} the assertion for the given body element
 	 */
 	protected void processBodyElement(BlockBuilder blockBuilder, String property, Object value) {
 	}
@@ -479,7 +479,7 @@ abstract class MethodBodyBuilder {
 
 
 	/**
-	 * Appends to the {@link BlockBuilder} the assertion for the given body path
+	 * Appends to the {@link BlockBuilder} the assertion for the given body element
 	 */
 	protected void processBodyElement(BlockBuilder blockBuilder, String property, Map map) {
 		map.each {
@@ -488,7 +488,7 @@ abstract class MethodBodyBuilder {
 	}
 
 	/**
-	 * Appends to the {@link BlockBuilder} the assertion for the given body path
+	 * Appends to the {@link BlockBuilder} the assertion for the given body element
 	 */
 	protected void processBodyElement(BlockBuilder blockBuilder, String property, List list) {
 		list.eachWithIndex { listElement, listIndex ->

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/RequestProcessingMethodBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/RequestProcessingMethodBodyBuilder.groovy
@@ -145,7 +145,7 @@ abstract class RequestProcessingMethodBodyBuilder extends MethodBodyBuilder {
 		if (response.body) {
 			bb.endBlock()
 			bb.addLine(addCommentSignIfRequired('and:')).startBlock()
-			validateResponseBodyBlock(bb, response.body.serverValue)
+			validateResponseBodyBlock(bb, response.matchers, response.body.serverValue)
 		}
 	}
 

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/dsl/wiremock/WireMockRequestStubStrategy.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/dsl/wiremock/WireMockRequestStubStrategy.groovy
@@ -87,11 +87,7 @@ class WireMockRequestStubStrategy extends BaseWireMockStubStrategy {
 			}
 			if (request.matchers?.hasMatchers()) {
 				request.matchers.jsonPathMatchers().each {
-					String path = it.path()
-					int lastIndexOfDot = path.lastIndexOf(".")
-					String toLastDot = path.substring(0, lastIndexOfDot)
-					String fromLastDot = path.substring(lastIndexOfDot + 1)
-					String newPath = "${toLastDot}[?(@.${fromLastDot} =~ /(${it.value()})/)]"
+					String newPath = JsonToJsonPathsConverter.convertJsonPathAndRegexToAJsonPath(it.path(), it.value())
 					requestPattern.withRequestBody(WireMock.matchingJsonPath(newPath.replace("\\\\", "\\")))
 				}
 			}

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/util/JsonToJsonPathsConverter.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/util/JsonToJsonPathsConverter.groovy
@@ -58,6 +58,15 @@ class JsonToJsonPathsConverter {
 		}
 	}
 
+	/**
+	 * Removes from the parsed json any JSON path matching entries.
+	 * That way we remain with values that should be checked in the auto-generated
+	 * fashion.
+	 *
+	 * @param json - parsed JSON
+	 * @param bodyMatchers - the part of request / response that contains matchers
+	 * @return json with removed entries
+	 */
 	static def removeMatchingJsonPaths(def json, BodyMatchers bodyMatchers) {
 		if (bodyMatchers?.hasMatchers()) {
 			// remove all jsonpaths from the body - for those that remain we continue as usual
@@ -66,6 +75,24 @@ class JsonToJsonPathsConverter {
 			}
 		}
 		return json
+	}
+
+	/**
+	 * For the given JSON path and regex pattern converts it into a JSON path
+	 * that checks the Pattern
+	 *
+	 * @param path - JSON path
+	 * @param pattern - pattern to check for the last element of JSON path
+	 * @return JSON path that checks the regex for its last element
+	 */
+	static String convertJsonPathAndRegexToAJsonPath(String path, String pattern) {
+		if (!pattern) {
+			return path
+		}
+		int lastIndexOfDot = path.lastIndexOf(".")
+		String toLastDot = path.substring(0, lastIndexOfDot)
+		String fromLastDot = path.substring(lastIndexOfDot + 1)
+		return "${toLastDot}[?(@.${fromLastDot} =~ /(${pattern})/)]"
 	}
 
 	JsonPaths transformToJsonPathWithTestsSideValues(def json) {

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/util/JsonToJsonPathsConverter.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/util/JsonToJsonPathsConverter.groovy
@@ -21,7 +21,11 @@ import com.toomuchcoding.jsonassert.JsonAssertion
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 import groovy.util.logging.Slf4j
-import org.springframework.cloud.contract.spec.internal.*
+import org.springframework.cloud.contract.spec.internal.OptionalProperty
+import org.springframework.cloud.contract.spec.internal.BodyMatcher
+import org.springframework.cloud.contract.spec.internal.BodyMatchers
+import org.springframework.cloud.contract.spec.internal.MatchingType
+import org.springframework.cloud.contract.spec.internal.ExecutionProperty
 import org.springframework.cloud.contract.verifier.config.ContractVerifierConfigProperties
 
 import java.util.regex.Pattern

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MockMvcMethodBodyBuilderWithMatchersSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MockMvcMethodBodyBuilderWithMatchersSpec.groovy
@@ -1,0 +1,117 @@
+/*
+ *  Copyright 2013-2016 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.contract.verifier.builder
+
+import org.springframework.cloud.contract.spec.Contract
+import org.springframework.cloud.contract.verifier.config.ContractVerifierConfigProperties
+import org.springframework.cloud.contract.verifier.dsl.WireMockStubVerifier
+import org.springframework.cloud.contract.verifier.util.SyntaxChecker
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Specification
+
+class MockMvcMethodBodyBuilderWithMatchersSpec extends Specification implements WireMockStubVerifier {
+
+	@Shared ContractVerifierConfigProperties properties = new ContractVerifierConfigProperties(
+			assertJsonSize: true
+	)
+
+	@Issue('#185')
+	def "should allow to set dynamic values via stub / test matchers for [#methodBuilderName]"() {
+		given:
+			Contract contractDsl = Contract.make {
+				request {
+					method 'GET'
+					urlPath '/get'
+					body([
+							duck: 123,
+							alpha: "abc",
+							number: 123,
+							aBoolean: true,
+							date: "2017-01-01",
+							dateTime: "2017-01-01T01:23:45",
+							time: "01:02:34",
+							valueWithoutAMatcher: "foo",
+							valueWithTypeMatch: "string"
+					])
+					stubMatchers {
+						jsonPath('$.duck', byRegex("[0-9]{3}"))
+						jsonPath('$.alpha', byRegex(onlyAlphaUnicode()))
+						jsonPath('$.number', byRegex(number()))
+						jsonPath('$.aBoolean', byRegex(anyBoolean()))
+						jsonPath('$.date', byDate())
+						jsonPath('$.dateTime', byTimestamp())
+						jsonPath('$.time', byTime())
+						jsonPath('$.valueWithTypeMatch', byType())
+					}
+					headers {
+						contentType(applicationJson())
+					}
+				}
+				response {
+					status 200
+					body([
+							duck: 123,
+							alpha: "abc",
+							number: 123,
+							aBoolean: true,
+							date: "2017-01-01",
+							dateTime: "2017-01-01T01:23:45",
+							time: "01:02:34",
+							valueWithoutAMatcher: "foo",
+							valueWithTypeMatch: "string"
+					])
+					testMatchers {
+						jsonPath('$.duck', byRegex("[0-9]{3}"))
+						jsonPath('$.alpha', byRegex(onlyAlphaUnicode()))
+						jsonPath('$.number', byRegex(number()))
+						jsonPath('$.aBoolean', byRegex(anyBoolean()))
+						jsonPath('$.date', byDate())
+						jsonPath('$.dateTime', byTimestamp())
+						jsonPath('$.time', byTime())
+						jsonPath('$.valueWithTypeMatch', byType())
+					}
+					headers {
+						contentType(applicationJson())
+					}
+				}
+			}
+			MethodBodyBuilder builder = methodBuilder(contractDsl)
+			BlockBuilder blockBuilder = new BlockBuilder(" ")
+		when:
+			builder.appendTo(blockBuilder)
+			def test = blockBuilder.toString()
+		then:
+			test.contains('assertThat(parsedJson.read("' + rootElement + '.duck", String.class)).matches("[0-9]{3}")')
+			test.contains('assertThat(parsedJson.read("' + rootElement + '.alpha", String.class)).matches("[\\\\p{L}]*")')
+			test.contains('assertThat(parsedJson.read("' + rootElement + '.number", String.class)).matches("-?\\\\d*(\\\\.\\\\d+)?")')
+			test.contains('assertThat(parsedJson.read("' + rootElement + '.aBoolean", String.class)).matches("(true|false)")')
+			test.contains('assertThat(parsedJson.read("' + rootElement + '.date", String.class)).matches("(\\\\d\\\\d\\\\d\\\\d)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])")')
+			test.contains('assertThat(parsedJson.read("' + rootElement + '.dateTime", String.class)).matches("([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])")')
+			test.contains('assertThat(parsedJson.read("' + rootElement + '.time", String.class)).matches("(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])")')
+			test.contains('assertThat((Object) parsedJson.read("' + rootElement + '.valueWithTypeMatch")).isExactlyInstanceOf(java.lang.String.class)')
+			!test.contains('cursor')
+		and:
+			SyntaxChecker.tryToCompile(methodBuilderName, blockBuilder.toString())
+		where:
+			methodBuilderName           | methodBuilder                                                                           | rootElement
+			"MockMvcSpockMethodBuilder" | { Contract dsl -> new MockMvcSpockMethodRequestProcessingBodyBuilder(dsl, properties) } | '\\$'
+			"MockMvcJUnitMethodBuilder" | { Contract dsl -> new MockMvcJUnitMethodBodyBuilder(dsl, properties) }                  | '$'
+
+	}
+
+}

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MockMvcMethodBodyBuilderWithMatchersSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MockMvcMethodBodyBuilderWithMatchersSpec.groovy
@@ -33,6 +33,7 @@ class MockMvcMethodBodyBuilderWithMatchersSpec extends Specification implements 
 	@Issue('#185')
 	def "should allow to set dynamic values via stub / test matchers for [#methodBuilderName]"() {
 		given:
+		//tag::matchers[]
 			Contract contractDsl = Contract.make {
 				request {
 					method 'GET'
@@ -84,21 +85,28 @@ class MockMvcMethodBodyBuilderWithMatchersSpec extends Specification implements 
 							],
 					])
 					testMatchers {
+						// asserts the jsonpath value against manual regex
 						jsonPath('$.duck', byRegex("[0-9]{3}"))
+						// asserts the jsonpath value against some default regex
 						jsonPath('$.alpha', byRegex(onlyAlphaUnicode()))
 						jsonPath('$.number', byRegex(number()))
 						jsonPath('$.aBoolean', byRegex(anyBoolean()))
+						// asserts vs inbuilt time related regex
 						jsonPath('$.date', byDate())
 						jsonPath('$.dateTime', byTimestamp())
 						jsonPath('$.time', byTime())
+						// asserts that the resulting type is the same as in response body
 						jsonPath('$.valueWithTypeMatch', byType())
 						jsonPath('$.valueWithMin', byType {
+							// results in verification of size of array (min 1)
 							minOccurrence(1)
 						})
 						jsonPath('$.valueWithMax', byType {
+							// results in verification of size of array (max 3)
 							maxOccurrence(3)
 						})
 						jsonPath('$.valueWithMinMax', byType {
+							// results in verification of size of array (min 1 & max 3)
 							minOccurrence(1)
 							maxOccurrence(3)
 						})
@@ -108,6 +116,7 @@ class MockMvcMethodBodyBuilderWithMatchersSpec extends Specification implements 
 					}
 				}
 			}
+			//end::matchers[]
 			MethodBodyBuilder builder = methodBuilder(contractDsl)
 			BlockBuilder blockBuilder = new BlockBuilder(" ")
 		when:

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MockMvcMethodBodyBuilderWithMatchersSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MockMvcMethodBodyBuilderWithMatchersSpec.groovy
@@ -132,8 +132,8 @@ class MockMvcMethodBodyBuilderWithMatchersSpec extends Specification implements 
 			methodBuilderName                                    | methodBuilder                                                                                                                       | rootElement
 			"MockMvcSpockMethodBuilder"                          | { Contract dsl -> new MockMvcSpockMethodRequestProcessingBodyBuilder(dsl, properties) }                                             | '\\$'
 			"MockMvcJUnitMethodBuilder"                          | { Contract dsl -> new MockMvcJUnitMethodBodyBuilder(dsl, properties) }                                                              | '$'
-			"JaxRsClientSpockMethodRequestProcessingBodyBuilder" | { org.springframework.cloud.contract.spec.Contract dsl -> new JaxRsClientSpockMethodRequestProcessingBodyBuilder(dsl, properties) } | '\\$'
-			"JaxRsClientJUnitMethodBodyBuilder"                  | { org.springframework.cloud.contract.spec.Contract dsl -> new JaxRsClientJUnitMethodBodyBuilder(dsl, properties) }                  | '$'
+			"JaxRsClientSpockMethodRequestProcessingBodyBuilder" | { Contract dsl -> new JaxRsClientSpockMethodRequestProcessingBodyBuilder(dsl, properties) } | '\\$'
+			"JaxRsClientJUnitMethodBodyBuilder"                  | { Contract dsl -> new JaxRsClientJUnitMethodBodyBuilder(dsl, properties) }                  | '$'
 	}
 
 }

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MockMvcMethodBodyBuilderWithMatchersSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MockMvcMethodBodyBuilderWithMatchersSpec.groovy
@@ -72,7 +72,16 @@ class MockMvcMethodBodyBuilderWithMatchersSpec extends Specification implements 
 							dateTime: "2017-01-01T01:23:45",
 							time: "01:02:34",
 							valueWithoutAMatcher: "foo",
-							valueWithTypeMatch: "string"
+							valueWithTypeMatch: "string",
+							valueWithMin: [
+								1,2,3
+							],
+							valueWithMax: [
+								1,2,3
+							],
+							valueWithMinMax: [
+								1,2,3
+							],
 					])
 					testMatchers {
 						jsonPath('$.duck', byRegex("[0-9]{3}"))
@@ -83,6 +92,16 @@ class MockMvcMethodBodyBuilderWithMatchersSpec extends Specification implements 
 						jsonPath('$.dateTime', byTimestamp())
 						jsonPath('$.time', byTime())
 						jsonPath('$.valueWithTypeMatch', byType())
+						jsonPath('$.valueWithMin', byType {
+							minOccurrence(1)
+						})
+						jsonPath('$.valueWithMax', byType {
+							maxOccurrence(3)
+						})
+						jsonPath('$.valueWithMinMax', byType {
+							minOccurrence(1)
+							maxOccurrence(3)
+						})
 					}
 					headers {
 						contentType(applicationJson())
@@ -103,6 +122,9 @@ class MockMvcMethodBodyBuilderWithMatchersSpec extends Specification implements 
 			test.contains('assertThat(parsedJson.read("' + rootElement + '.dateTime", String.class)).matches("([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])")')
 			test.contains('assertThat(parsedJson.read("' + rootElement + '.time", String.class)).matches("(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])")')
 			test.contains('assertThat((Object) parsedJson.read("' + rootElement + '.valueWithTypeMatch")).isExactlyInstanceOf(java.lang.String.class)')
+			test.contains('assertThat(parsedJson.read("' + rootElement + '.valueWithMin", java.util.Collection.class).size()).isLessThanOrEqualTo(1)')
+			test.contains('assertThat(parsedJson.read("' + rootElement + '.valueWithMax", java.util.Collection.class).size()).isGreaterThanOrEqualTo(3)')
+			test.contains('assertThat(parsedJson.read("' + rootElement + '.valueWithMinMax", java.util.Collection.class).size()).isStrictlyBetween(1, 3)')
 			!test.contains('cursor')
 		and:
 			SyntaxChecker.tryToCompile(methodBuilderName, blockBuilder.toString())

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MockMvcMethodBodyBuilderWithMatchersSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MockMvcMethodBodyBuilderWithMatchersSpec.groovy
@@ -130,9 +130,12 @@ class MockMvcMethodBodyBuilderWithMatchersSpec extends Specification implements 
 			test.contains('assertThat(parsedJson.read("' + rootElement + '.date", String.class)).matches("(\\\\d\\\\d\\\\d\\\\d)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])")')
 			test.contains('assertThat(parsedJson.read("' + rootElement + '.dateTime", String.class)).matches("([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])")')
 			test.contains('assertThat(parsedJson.read("' + rootElement + '.time", String.class)).matches("(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])")')
-			test.contains('assertThat((Object) parsedJson.read("' + rootElement + '.valueWithTypeMatch")).isExactlyInstanceOf(java.lang.String.class)')
+			test.contains('assertThat((Object) parsedJson.read("' + rootElement + '.valueWithTypeMatch")).isInstanceOf(java.lang.String.class)')
+			test.contains('assertThat((Object) parsedJson.read("' + rootElement + '.valueWithMin")).isInstanceOf(java.util.List.class)')
 			test.contains('assertThat(parsedJson.read("' + rootElement + '.valueWithMin", java.util.Collection.class).size()).isLessThanOrEqualTo(1)')
+			test.contains('assertThat((Object) parsedJson.read("' + rootElement + '.valueWithMax")).isInstanceOf(java.util.List.class)')
 			test.contains('assertThat(parsedJson.read("' + rootElement + '.valueWithMax", java.util.Collection.class).size()).isGreaterThanOrEqualTo(3)')
+			test.contains('assertThat((Object) parsedJson.read("' + rootElement + '.valueWithMinMax")).isInstanceOf(java.util.List.class)')
 			test.contains('assertThat(parsedJson.read("' + rootElement + '.valueWithMinMax", java.util.Collection.class).size()).isStrictlyBetween(1, 3)')
 			!test.contains('cursor')
 		and:

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MockMvcMethodBodyBuilderWithMatchersSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MockMvcMethodBodyBuilderWithMatchersSpec.groovy
@@ -56,7 +56,6 @@ class MockMvcMethodBodyBuilderWithMatchersSpec extends Specification implements 
 						jsonPath('$.date', byDate())
 						jsonPath('$.dateTime', byTimestamp())
 						jsonPath('$.time', byTime())
-						jsonPath('$.valueWithTypeMatch', byType())
 					}
 					headers {
 						contentType(applicationJson())
@@ -108,10 +107,11 @@ class MockMvcMethodBodyBuilderWithMatchersSpec extends Specification implements 
 		and:
 			SyntaxChecker.tryToCompile(methodBuilderName, blockBuilder.toString())
 		where:
-			methodBuilderName           | methodBuilder                                                                           | rootElement
-			"MockMvcSpockMethodBuilder" | { Contract dsl -> new MockMvcSpockMethodRequestProcessingBodyBuilder(dsl, properties) } | '\\$'
-			"MockMvcJUnitMethodBuilder" | { Contract dsl -> new MockMvcJUnitMethodBodyBuilder(dsl, properties) }                  | '$'
-
+			methodBuilderName                                    | methodBuilder                                                                                                                       | rootElement
+			"MockMvcSpockMethodBuilder"                          | { Contract dsl -> new MockMvcSpockMethodRequestProcessingBodyBuilder(dsl, properties) }                                             | '\\$'
+			"MockMvcJUnitMethodBuilder"                          | { Contract dsl -> new MockMvcJUnitMethodBodyBuilder(dsl, properties) }                                                              | '$'
+			"JaxRsClientSpockMethodRequestProcessingBodyBuilder" | { org.springframework.cloud.contract.spec.Contract dsl -> new JaxRsClientSpockMethodRequestProcessingBodyBuilder(dsl, properties) } | '\\$'
+			"JaxRsClientJUnitMethodBodyBuilder"                  | { org.springframework.cloud.contract.spec.Contract dsl -> new JaxRsClientJUnitMethodBodyBuilder(dsl, properties) }                  | '$'
 	}
 
 }

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/util/JsonToJsonPathsConverterSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/util/JsonToJsonPathsConverterSpec.groovy
@@ -753,6 +753,21 @@ class JsonToJsonPathsConverterSpec extends Specification {
 			}
 	}
 
+	def "should convert a json path with regex to a regex checking json path"() {
+		given:
+			String jsonPath = '$.a.b.c.d'
+			String regexPattern = ".*"
+		expect:
+			'$.a.b.c[?(@.d =~ /(.*)/)]' == JsonToJsonPathsConverter.convertJsonPathAndRegexToAJsonPath(jsonPath, regexPattern)
+	}
+
+	def "should return the path if no regex pattern is provided"() {
+		given:
+			String jsonPath = '$.a.b.c.d'
+		expect:
+			'$.a.b.c.d' == JsonToJsonPathsConverter.convertJsonPathAndRegexToAJsonPath(jsonPath, null)
+	}
+
 	private void assertThatJsonPathsInMapAreValid(String json, JsonPaths pathAndValues) {
 		DocumentContext parsedJson = JsonPath.using(Configuration.builder().options(Option.ALWAYS_RETURN_LIST).build()).parse(json);
 		pathAndValues.each {


### PR DESCRIPTION
Without this change we're forcing users to embed their dynamic properties inside the body. For some this is natural and acceptable, but especially for the users coming from the Pact world this sounds bizarre. Also some other people have a problem with remembering who the consumer / producer is etc.

With this change we're introducing the `stubMatchers` and `testMatchers` section. Thanks to this one can separate the body from defining the dynamic properties. Especially for Pact users this is more natural. Speaking of which this is a prerequisite for https://github.com/spring-cloud/spring-cloud-contract/issues/96

fixes #185 