### PR TITLE
Unable to download stubs from repository via HTTPS

### DIFF
--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
@@ -115,16 +115,12 @@ public class AetherStubDownloader implements StubDownloader {
 		final List<RemoteRepository> remoteRepos = new ArrayList<>();
 		for (int i = 0; i < repos.length; i++) {
 			if(StringUtils.hasText(repos[i])) {
-				final RemoteRepository.Builder builder = new RemoteRepository.Builder("remote" + i, "default", repos[i])
-						.setAuthentication(new AuthenticationBuilder()
-								.addUsername(stubRunnerOptions.username)
-								.addPassword(stubRunnerOptions.password)
-								.build());
+				final RemoteRepository.Builder builder = remoteRepository(stubRunnerOptions,
+						"remote" + i, "default", repos[i]);
 				if(stubRunnerOptions.getProxyOptions() != null) {
 					final StubRunnerProxyOptions p = stubRunnerOptions.getProxyOptions();
 					builder.setProxy(new Proxy(null, p.getProxyHost(), p.getProxyPort()));
 				}
-
 				remoteRepos.add(builder.build());
 			}
 		}
@@ -132,6 +128,26 @@ public class AetherStubDownloader implements StubDownloader {
 			log.debug("Using the following remote repos " + remoteRepos);
 		}
 		return remoteRepos;
+	}
+
+	/**
+	 * Method that allow you to fully customize the way you setup your connection
+	 * to the remote repository
+	 *
+	 * @param options - options from Stub Runner
+	 * @param id -  id of the repo
+	 * @param type - type of the repo
+	 * @param url - url to which the repo is pointing
+	 * @return builder for the remote repository
+	 */
+	protected RemoteRepository.Builder remoteRepository(StubRunnerOptions options, String id,
+			String type, String url) {
+		return new RemoteRepository.Builder(id, type, url)
+				.setAuthentication(new AuthenticationBuilder()
+						.addUsername(options.username)
+						.addPassword(options.password)
+						.addPrivateKey(options.privateKeyPathname, options.privateKeyPassphrase)
+						.build());
 	}
 
 	private File unpackedJar(String resolvedVersion, String stubsGroup,

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerOptions.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerOptions.java
@@ -71,6 +71,16 @@ public class StubRunnerOptions {
 	final String password;
 
 	/**
+	 * The optional (absolute) path to the private key file
+	 */
+	final String privateKeyPathname;
+
+	/**
+	 * The optional passphrase protecting the private key
+	 */
+	final String privateKeyPassphrase;
+
+	/**
 	 * Optional proxy settings
 	 */
 	private final StubRunnerProxyOptions stubRunnerProxyOptions;
@@ -78,8 +88,8 @@ public class StubRunnerOptions {
 	StubRunnerOptions(Integer minPortValue, Integer maxPortValue,
 			String stubRepositoryRoot, boolean workOffline, String stubsClassifier,
 			Collection<StubConfiguration> dependencies,
-			Map<StubConfiguration, Integer> stubIdsToPortMapping,
-			String username, String password, final StubRunnerProxyOptions stubRunnerProxyOptions) {
+			Map<StubConfiguration, Integer> stubIdsToPortMapping, String username, String password,
+			String privateKeyPathname, String privateKeyPassphrase, final StubRunnerProxyOptions stubRunnerProxyOptions) {
 		this.minPortValue = minPortValue;
 		this.maxPortValue = maxPortValue;
 		this.stubRepositoryRoot = stubRepositoryRoot;
@@ -89,6 +99,8 @@ public class StubRunnerOptions {
 		this.stubIdsToPortMapping = stubIdsToPortMapping;
 		this.username = username;
 		this.password = password;
+		this.privateKeyPathname = privateKeyPathname;
+		this.privateKeyPassphrase = privateKeyPassphrase;
 		this.stubRunnerProxyOptions = stubRunnerProxyOptions;
 	}
 

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerOptionsBuilder.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerOptionsBuilder.java
@@ -16,15 +16,15 @@
 
 package org.springframework.cloud.contract.stubrunner;
 
-import org.springframework.cloud.contract.stubrunner.util.StubsParser;
-import org.springframework.util.StringUtils;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+
+import org.springframework.cloud.contract.stubrunner.util.StubsParser;
+import org.springframework.util.StringUtils;
 
 public class StubRunnerOptionsBuilder {
 
@@ -40,6 +40,8 @@ public class StubRunnerOptionsBuilder {
 	private String username;
 	private String password;
 	private StubRunnerOptions.StubRunnerProxyOptions stubRunnerProxyOptions;
+	private String privateKeyPathname;
+	private String privateKeyPassphrase;
 
 	public StubRunnerOptionsBuilder() {
 	}
@@ -97,6 +99,16 @@ public class StubRunnerOptionsBuilder {
 		return this;
 	}
 
+	public StubRunnerOptionsBuilder withPrivateKeyPathname(String privateKeyPathname) {
+		this.privateKeyPathname = privateKeyPathname;
+		return this;
+	}
+
+	public StubRunnerOptionsBuilder withPrivateKeyPassphrase(String privateKeyPassphrase) {
+		this.privateKeyPassphrase = privateKeyPassphrase;
+		return this;
+	}
+
 	/**
 	 * @deprecated there is no context path for the stub server
 	 */
@@ -117,7 +129,8 @@ public class StubRunnerOptionsBuilder {
 	public StubRunnerOptions build() {
 		return new StubRunnerOptions(this.minPortValue, this.maxPortValue, this.stubRepositoryRoot,
 				this.workOffline, this.stubsClassifier, buildDependencies(), this.stubIdsToPortMapping,
-				this.username, this.password, this.stubRunnerProxyOptions);
+				this.username, this.password, this.privateKeyPathname, this.privateKeyPassphrase,
+				this.stubRunnerProxyOptions);
 	}
 
 	private Collection<StubConfiguration> buildDependencies() {

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerConfiguration.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerConfiguration.java
@@ -92,7 +92,9 @@ public class StubRunnerConfiguration {
 					.withStubsClassifier(this.props.getClassifier())
 					.withStubs(this.props.getIds())
 					.withUsername(this.props.getUsername())
-					.withPassword(this.props.getPassword());
+					.withPassword(this.props.getPassword())
+					.withPrivateKeyPathname(this.props.getPrivateKeyPathname())
+					.withPrivateKeyPassphrase(this.props.getPrivateKeyPassphrase());
 	}
 
 	private String uriStringOrEmpty(Resource stubRepositoryRoot) throws IOException {

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerProperties.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerProperties.java
@@ -76,6 +76,16 @@ public class StubRunnerProperties {
 	private String password;
 
 	/**
+	 * The optional (absolute) path to the private key file
+	 */
+	private String privateKeyPathname;
+
+	/**
+	 * The optional passphrase protecting the private key
+	 */
+	private String privateKeyPassphrase;
+
+	/**
 	 * Repository proxy port
 	 */
 	private Integer proxyPort;
@@ -171,6 +181,22 @@ public class StubRunnerProperties {
 
 	public void setContextPath(String contextPath) {
 		this.contextPath = contextPath;
+	}
+
+	public String getPrivateKeyPathname() {
+		return this.privateKeyPathname;
+	}
+
+	public void setPrivateKeyPathname(String privateKeyPathname) {
+		this.privateKeyPathname = privateKeyPathname;
+	}
+
+	public String getPrivateKeyPassphrase() {
+		return this.privateKeyPassphrase;
+	}
+
+	public void setPrivateKeyPassphrase(String privateKeyPassphrase) {
+		this.privateKeyPassphrase = privateKeyPassphrase;
 	}
 
 	@Override public String toString() {


### PR DESCRIPTION
without this change you can't specify the location of your private key. also without this change it's impossible to override the aether's behaviour in a meaningful way.
with this change we're adding two properties to pass the private key's location and passwod. Also the aether's repo setup logic is customizable.

fixes #195