### PR TITLE
Fixed unnecessary slash

### DIFF
--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockConfiguration.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockConfiguration.java
@@ -97,9 +97,6 @@ public class WireMockConfiguration implements SmartLifecycle {
 						this.resourceLoader);
 				String pattern = stubs;
 				if (!pattern.contains("*")) {
-					if (!pattern.endsWith("/")) {
-						pattern = pattern + "/";
-					}
 					pattern = pattern + "**/*.json";
 				}
 				for (Resource resource : resolver.getResources(pattern)) {
@@ -115,12 +112,8 @@ public class WireMockConfiguration implements SmartLifecycle {
 			if (StringUtils.hasText(files)) {
 				PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver(
 						this.resourceLoader);
-				String pattern = files;
-				if (!pattern.endsWith("/")) {
-					pattern = pattern + "/";
-				}
 				List<Resource> resources = new ArrayList<>();
-				for (Resource resource : resolver.getResources(pattern)) {
+				for (Resource resource : resolver.getResources(files)) {
 					if (resource.exists()) {
 						resources.add(resource);
 					}

--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockConfiguration.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockConfiguration.java
@@ -97,6 +97,9 @@ public class WireMockConfiguration implements SmartLifecycle {
 						this.resourceLoader);
 				String pattern = stubs;
 				if (!pattern.contains("*")) {
+					if (!pattern.endsWith("/")) {
+						pattern = pattern + "/";
+					}
 					pattern = pattern + "**/*.json";
 				}
 				for (Resource resource : resolver.getResources(pattern)) {

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/AutoConfigureWireMockFilesApplicationWithoutSlashTests.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/AutoConfigureWireMockFilesApplicationWithoutSlashTests.java
@@ -1,0 +1,27 @@
+package org.springframework.cloud.contract.wiremock;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes=WiremockTestsApplication.class, properties="app.baseUrl=http://localhost:${wiremock.server.port}", webEnvironment=WebEnvironment.NONE)
+@DirtiesContext
+@AutoConfigureWireMock(port=0, files="classpath:root")
+public class AutoConfigureWireMockFilesApplicationWithoutSlashTests {
+
+	@Autowired
+	private Service service;
+
+	@Test
+	public void contextLoads() throws Exception {
+		assertThat(this.service.go()).isEqualTo("{\"message\":\"Hello Root\"}");
+	}
+
+}

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/AutoConfigureWireMockStubsApplicationWithSlashTests.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/AutoConfigureWireMockStubsApplicationWithSlashTests.java
@@ -1,0 +1,27 @@
+package org.springframework.cloud.contract.wiremock;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes=WiremockTestsApplication.class, properties="app.baseUrl=http://localhost:${wiremock.server.port}", webEnvironment=WebEnvironment.NONE)
+@DirtiesContext
+@AutoConfigureWireMock(port=0, stubs="file:src/test/resources/io.stubs/mappings/")
+public class AutoConfigureWireMockStubsApplicationWithSlashTests {
+
+	@Autowired
+	private Service service;
+
+	@Test
+	public void contextLoads() throws Exception {
+		assertThat(this.service.go()).isEqualTo("Hello World");
+	}
+
+}


### PR DESCRIPTION
without this change the pattern for stubs contains an unnecessary / which corrupts the location search (e.g. /_files is converted to //_files and there is no such path)
with this change we're removing that value

fixes #216