### PR TITLE
Adding an option to validate children nodes in an array

### DIFF
--- a/docs/src/main/asciidoc/verifier/contract.adoc
+++ b/docs/src/main/asciidoc/verifier/contract.adoc
@@ -342,7 +342,7 @@ assertions and the one from matchers with an `and` section):
     assertThat((Object) parsedJson.read("$.valueWithMax")).isInstanceOf(java.util.List.class);
     assertThat(parsedJson.read("$.valueWithMax", java.util.Collection.class).size()).isLessThanOrEqualTo(3);
     assertThat((Object) parsedJson.read("$.valueWithMinMax")).isInstanceOf(java.util.List.class);
-    assertThat(parsedJson.read("$.valueWithMinMax", java.util.Collection.class).size()).isStrictlyBetween(1, 3);
+    assertThat(parsedJson.read("$.valueWithMinMax", java.util.Collection.class).size()).isBetween(1, 3);
 ----
 
 and the WireMock stub like this:

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/MatchingType.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/MatchingType.groovy
@@ -39,4 +39,11 @@ enum MatchingType {
 	 * provided regex
 	 */
 	REGEX
+
+	static boolean regexRelated(MatchingType type) {
+		if (type == EQUALITY || type == TYPE ) {
+			return false
+		}
+		return true
+	}
 }

--- a/spring-cloud-contract-spec/src/test/groovy/org/springframework/cloud/contract/spec/internal/MatchingTypeSpec.groovy
+++ b/spring-cloud-contract-spec/src/test/groovy/org/springframework/cloud/contract/spec/internal/MatchingTypeSpec.groovy
@@ -1,0 +1,22 @@
+package org.springframework.cloud.contract.spec.internal
+
+import spock.lang.Specification
+
+/**
+ * @author Marcin Grzejszczak
+ */
+class MatchingTypeSpec extends Specification {
+	def "should return [#expected] for type [#type]"() {
+		expect:
+			MatchingType.regexRelated(type) == expected
+		where:
+			type                   | expected
+			MatchingType.EQUALITY  | false
+			MatchingType.TYPE      | false
+			MatchingType.REGEX     | true
+			MatchingType.DATE      | true
+			MatchingType.TIME      | true
+			MatchingType.TIMESTAMP | true
+
+	}
+}

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/BlockBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/BlockBuilder.groovy
@@ -90,13 +90,28 @@ class BlockBuilder {
 	}
 
 	BlockBuilder addAtTheEnd(String toAdd) {
-		if (builder.charAt(builder.length() - 1) as String == '\n') {
+		String lastChar = builder.charAt(builder.length() - 1) as String
+		String secondLastChar = builder.length() >= 2 ? builder.charAt(builder.length() - 2) as String : ""
+		if (endsWithNewLine(lastChar) && aSpecialSign(secondLastChar, toAdd)) {
+			return this
+		} else if (endsWithNewLine(lastChar) && !aSpecialSign(secondLastChar, toAdd)) {
 			builder.replace(builder.length() - 1, builder.length(), toAdd)
 			builder << '\n'
 		} else {
 			builder << toAdd
 		}
 		return this
+	}
+
+	private boolean endsWithNewLine(String character) {
+		return character as String == '\n'
+	}
+
+	private boolean aSpecialSign(String character, String toAdd) {
+		if (!character) {
+			return false
+		}
+		return character == "{" || character == toAdd
 	}
 
 	@Override

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/MethodBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/MethodBodyBuilder.groovy
@@ -395,7 +395,7 @@ abstract class MethodBodyBuilder {
 
 	protected String sizeCheckMethod(BodyMatcher bodyMatcher) {
 		if (bodyMatcher.minTypeOccurrence() != null && bodyMatcher.maxTypeOccurrence() != null) {
-			return "isStrictlyBetween(${bodyMatcher.minTypeOccurrence()}, ${bodyMatcher.maxTypeOccurrence()})"
+			return "isBetween(${bodyMatcher.minTypeOccurrence()}, ${bodyMatcher.maxTypeOccurrence()})"
 		} else if (bodyMatcher.minTypeOccurrence() != null ) {
 			return "isGreaterThanOrEqualTo(${bodyMatcher.minTypeOccurrence()})"
 		} else if (bodyMatcher.maxTypeOccurrence() != null) {

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/util/JsonToJsonPathsConverter.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/util/JsonToJsonPathsConverter.groovy
@@ -74,7 +74,13 @@ class JsonToJsonPathsConverter {
 		DocumentContext context = JsonPath.parse(jsonCopy)
 		if (bodyMatchers?.hasMatchers()) {
 			bodyMatchers.jsonPathMatchers().each { BodyMatcher matcher ->
-				context.delete(matcher.path())
+				try {
+					context.delete(matcher.path())
+				} catch (RuntimeException e) {
+					if (log.isDebugEnabled()) {
+						log.debug("Exception occurred while trying to delete path [${matcher.path()}]", e)
+					}
+				}
 			}
 		}
 		return jsonCopy

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MockMvcMethodBodyBuilderWithMatchersSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MockMvcMethodBodyBuilderWithMatchersSpec.groovy
@@ -153,7 +153,7 @@ class MockMvcMethodBodyBuilderWithMatchersSpec extends Specification implements 
 			test.contains('assertThat((Object) parsedJson.read("' + rootElement + '.valueWithMax")).isInstanceOf(java.util.List.class)')
 			test.contains('assertThat(parsedJson.read("' + rootElement + '.valueWithMax", java.util.Collection.class).size()).isLessThanOrEqualTo(3)')
 			test.contains('assertThat((Object) parsedJson.read("' + rootElement + '.valueWithMinMax")).isInstanceOf(java.util.List.class)')
-			test.contains('assertThat(parsedJson.read("' + rootElement + '.valueWithMinMax", java.util.Collection.class).size()).isStrictlyBetween(1, 3)')
+			test.contains('assertThat(parsedJson.read("' + rootElement + '.valueWithMinMax", java.util.Collection.class).size()).isBetween(1, 3)')
 			test.contains('assertThat((Object) parsedJson.read("' + rootElement + '.valueWithMinEmpty")).isInstanceOf(java.util.List.class)')
 			test.contains('assertThat(parsedJson.read("' + rootElement + '.valueWithMinEmpty", java.util.Collection.class).size()).isGreaterThanOrEqualTo(0)')
 			test.contains('assertThat((Object) parsedJson.read("' + rootElement + '.valueWithMaxEmpty")).isInstanceOf(java.util.List.class)')


### PR DESCRIPTION
without this change it's impossible to assert with response matchers all elements of an array
with this change we're using AssertJs conditions in case the pattern contains [*]

fixes #217