### PR TITLE
Changing the default layout of stubs

### DIFF
--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/ContractsCopyTask.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/ContractsCopyTask.groovy
@@ -23,10 +23,11 @@ class ContractsCopyTask extends ConventionTask {
 		ContractVerifierConfigProperties props = ExtensionToProperties.fromExtension(getExtension())
 		File file = getDownloader().downloadAndUnpackContractsIfRequired(getExtension(), props)
 		String antPattern = "${props.includedRootFolderAntPattern}*.*"
+		String root = OutputFolderBuilder.buildRootPath(project)
 		ext.contractVerifierConfigProperties = props
 		File outputContractsFolder = getExtension().stubsOutputDir != null ?
-				project.file("${getExtension().stubsOutputDir}/contracts") :
-				project.file("${project.buildDir}/stubs/contracts")
+				project.file("${getExtension().stubsOutputDir}/${root}/contracts") :
+				project.file("${project.buildDir}/stubs/${root}/contracts")
 		ext.contractsDslDir = outputContractsFolder
 		project.logger.info("Downloading and unpacking files from [$file] to [$outputContractsFolder]. The inclusion ant pattern is [$antPattern]")
 		project.copy {

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/GenerateWireMockClientStubsFromDslTask.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/GenerateWireMockClientStubsFromDslTask.groovy
@@ -48,8 +48,10 @@ class GenerateWireMockClientStubsFromDslTask extends ConventionTask {
 		logger.info("Spring Cloud Contract Verifier Plugin: Invoking DSL to client stubs conversion")
 		props.contractsDslDir = contractsDslDir
 		props.includedContracts = ".*"
-		File outMappingsDir = getStubsOutputDir() != null ? new File(getStubsOutputDir(), DEFAULT_MAPPINGS_FOLDER)
-				: new File(project.buildDir, "stubs/$DEFAULT_MAPPINGS_FOLDER")
+		String root = OutputFolderBuilder.buildRootPath(project)
+		File outMappingsDir = getStubsOutputDir() != null ?
+				new File(getStubsOutputDir(), "${root}/${DEFAULT_MAPPINGS_FOLDER}")
+				: new File(project.buildDir, "stubs/${root}/${DEFAULT_MAPPINGS_FOLDER}")
 		logger.info("Contracts dir is [${contractsDslDir}] output stubs dir is [${outMappingsDir}]")
 		RecursiveFilesConverter converter = new RecursiveFilesConverter(
 				props, outMappingsDir)

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/OutputFolderBuilder.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/OutputFolderBuilder.groovy
@@ -1,0 +1,20 @@
+package org.springframework.cloud.contract.verifier.plugin
+
+import groovy.transform.CompileStatic
+import groovy.transform.PackageScope
+import org.gradle.api.Project
+
+/**
+ * @author Marcin Grzejszczak
+ */
+@CompileStatic
+@PackageScope
+class OutputFolderBuilder {
+	
+	static String buildRootPath(Project project) {
+		String groupId = project.group as String
+		String artifactId = project.name
+		String version = project.version
+		return "META-INF/${groupId}/${artifactId}/${version}"
+	}
+}

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/test/resources/functionalTest/bootSimple/build.gradle
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/test/resources/functionalTest/bootSimple/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	testCompile "com.jayway.restassured:rest-assured:$restAssuredVersion"
 	testCompile "com.jayway.restassured:spring-mock-mvc:$restAssuredVersion"
 	testCompile "ch.qos.logback:logback-classic:1.1.2"
+	testCompile "org.springframework.cloud:spring-cloud-contract-verifier:${verifierVersion}"
 }
 
 contracts {

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/test/resources/functionalTest/bootSimple/gradle.properties
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/test/resources/functionalTest/bootSimple/gradle.properties
@@ -15,5 +15,5 @@
 #
 wiremockVersion=2.5.1
 jsonAssertVersion=0.4.8
-
+verifierVersion=1.1.0.BUILD-SNAPSHOT
 

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/test/resources/functionalTest/sampleJerseyProject/build.gradle
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/test/resources/functionalTest/sampleJerseyProject/build.gradle
@@ -49,6 +49,7 @@ subprojects {
 		testCompile 'junit:junit:4.12'
 		testCompile "com.github.tomakehurst:wiremock:${wiremockVersion}"
 		testCompile "com.toomuchcoding.jsonassert:jsonassert:${jsonAssertVersion}"
+		testCompile "org.springframework.cloud:spring-cloud-contract-verifier:${verifierVersion}"
 	}
 }
 

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/test/resources/functionalTest/sampleJerseyProject/gradle.properties
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/test/resources/functionalTest/sampleJerseyProject/gradle.properties
@@ -15,5 +15,4 @@
 #
 wiremockVersion=2.5.1
 jsonAssertVersion=0.4.8
-
-
+verifierVersion=1.1.0.BUILD-SNAPSHOT

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/test/resources/functionalTest/sampleProject/build.gradle
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/test/resources/functionalTest/sampleProject/build.gradle
@@ -47,6 +47,7 @@ subprojects {
 		testCompile("junit:junit:4.12")
 		testCompile "com.github.tomakehurst:wiremock:${wiremockVersion}"
 		testCompile "com.toomuchcoding.jsonassert:jsonassert:${jsonAssertVersion}"
+		testCompile "org.springframework.cloud:spring-cloud-contract-verifier:${verifierVersion}"
 	}
 }
 

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/test/resources/functionalTest/sampleProject/gradle.properties
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/test/resources/functionalTest/sampleProject/gradle.properties
@@ -15,5 +15,4 @@
 #
 wiremockVersion=2.5.1
 jsonAssertVersion=0.4.8
-
-
+verifierVersion=1.1.0.BUILD-SNAPSHOT

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/test/resources/functionalTest/scenarioProject/build.gradle
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/test/resources/functionalTest/scenarioProject/build.gradle
@@ -49,6 +49,7 @@ subprojects {
 		testCompile "com.github.tomakehurst:wiremock:${wiremockVersion}"
 		testCompile "com.toomuchcoding.jsonassert:jsonassert:${jsonAssertVersion}"
 		testCompile "org.assertj:assertj-core:2.4.1"
+		testCompile "org.springframework.cloud:spring-cloud-contract-verifier:${verifierVersion}"
 	}
 }
 
@@ -134,7 +135,7 @@ configure(project(':loanApplicationService')) {
 	task copyCollaboratorStubs(type: Copy) {
 		File fraudBuildDir = project(':fraudDetectionService').buildDir
 		from(new File(fraudBuildDir, "/production/${project(':fraudDetectionService').name}-stubs/"))
-		into "src/test/resources/"
+		into "src/test/resources/mappings"
 	}
 
 	generateContractTests.dependsOn('copyCollaboratorStubs')

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/test/resources/functionalTest/scenarioProject/gradle.properties
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/test/resources/functionalTest/scenarioProject/gradle.properties
@@ -15,5 +15,5 @@
 #
 wiremockVersion=2.5.1
 jsonAssertVersion=0.4.8
-
+verifierVersion=1.1.0.BUILD-SNAPSHOT
 

--- a/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/ConvertMojo.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/ConvertMojo.java
@@ -41,10 +41,10 @@ import org.springframework.cloud.contract.verifier.converter.RecursiveFilesConve
  */
 @Mojo(name = "convert", requiresProject = false,
 		defaultPhase = LifecyclePhase.PROCESS_TEST_RESOURCES)
-public class ConvertMojo extends AbstractMojo {
+public class  ConvertMojo extends AbstractMojo {
 
-	public static final String DEFAULT_STUBS_DIR = "${project.build.directory}/stubs/";
-	public static final String MAPPINGS_PATH = "mappings";
+	static final String DEFAULT_STUBS_DIR = "${project.build.directory}/stubs/";
+	static final String MAPPINGS_PATH = "/mappings";
 
 	@Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
 	private RepositorySystemSession repoSession;
@@ -126,13 +126,16 @@ public class ConvertMojo extends AbstractMojo {
 	}
 
 	public void execute() throws MojoExecutionException, MojoFailureException {
-
 		if (this.skip) {
 			getLog().info(String.format(
 					"Skipping Spring Cloud Contract Verifier execution: spring.cloud.contract.verifier.skip=%s",
 					this.skip));
 			return;
 		}
+		String groupId = this.project.getGroupId();
+		String artifactId = this.project.getArtifactId();
+		String version = this.project.getVersion();
+		String rootPath = "META-INF/" + groupId + "/" + artifactId + "/" + version;
 		// download contracts, unzip them and pass as output directory
 		ContractVerifierConfigProperties config = new ContractVerifierConfigProperties();
 		config.setExcludeBuildFolders(this.excludeBuildFolders);
@@ -142,11 +145,11 @@ public class ConvertMojo extends AbstractMojo {
 		getLog().info("Directory with contract is present at [" + contractsDirectory + "]");
 
 		new CopyContracts(this.project, this.mavenSession, this.mavenResourcesFiltering, config)
-				.copy(contractsDirectory, this.stubsDirectory);
+				.copy(contractsDirectory, this.stubsDirectory, rootPath);
 
 		config.setContractsDslDir(isInsideProject() ? contractsDirectory : this.source);
 		config.setStubsOutputDir(
-				isInsideProject() ? new File(this.stubsDirectory, MAPPINGS_PATH) : this.destination);
+				isInsideProject() ? new File(this.stubsDirectory, rootPath + MAPPINGS_PATH) : this.destination);
 
 		getLog().info(
 				"Converting from Spring Cloud Contract Verifier contracts to WireMock stubs mappings");

--- a/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/CopyContracts.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/CopyContracts.java
@@ -31,14 +31,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cloud.contract.verifier.config.ContractVerifierConfigProperties;
 
 class CopyContracts {
-	private static final Logger log = LoggerFactory
-			.getLogger(MethodHandles.lookup().lookupClass());
+	private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+	private static final String CONTRACTS_PATH = "/contracts";
 	private final MavenProject project;
 	private final MavenSession mavenSession;
 	private final MavenResourcesFiltering mavenResourcesFiltering;
 	private final ContractVerifierConfigProperties config;
 
-	public CopyContracts(MavenProject project, MavenSession mavenSession,
+	CopyContracts(MavenProject project, MavenSession mavenSession,
 			MavenResourcesFiltering mavenResourcesFiltering,
 			ContractVerifierConfigProperties config) {
 		this.project = project;
@@ -47,7 +47,7 @@ class CopyContracts {
 		this.config = config;
 	}
 
-	public void copy(File contractsDirectory, File outputDirectory)
+	public void copy(File contractsDirectory, File outputDirectory, String rootPath)
 			throws MojoExecutionException {
 		log.info("Copying Spring Cloud Contract Verifier contracts. Only files matching "
 				+ "[" + this.config.getIncludedContracts() + "] pattern will end up in "
@@ -61,7 +61,7 @@ class CopyContracts {
 		resource.setDirectory(contractsDirectory.getAbsolutePath());
 		MavenResourcesExecution execution = new MavenResourcesExecution();
 		execution.setResources(Collections.singletonList(resource));
-		execution.setOutputDirectory(new File(outputDirectory, "contracts"));
+		execution.setOutputDirectory(new File(outputDirectory, rootPath + CONTRACTS_PATH));
 		execution.setMavenProject(this.project);
 		execution.setEncoding("UTF-8");
 		execution.setMavenSession(this.mavenSession);

--- a/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/test/java/org/springframework/cloud/contract/maven/verifier/PluginUnitTest.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/test/java/org/springframework/cloud/contract/maven/verifier/PluginUnitTest.java
@@ -43,30 +43,30 @@ public class PluginUnitTest {
 	public void shouldGenerateWireMockStubsInDefaultLocation() throws Exception {
 		File basedir = this.resources.getBasedir("basic");
 		this.maven.executeMojo(basedir, "convert");
-		assertFilesPresent(basedir, "target/stubs/mappings/Sample.json".replace("/", File.separator));
-		assertFilesNotPresent(basedir, "target/stubs/mappings/Messaging.json".replace("/", File.separator));
+		assertFilesPresent(basedir, "target/stubs/META-INF/org.springframework.cloud.verifier.sample/sample-project/0.1/mappings/Sample.json".replace("/", File.separator));
+		assertFilesNotPresent(basedir, "target/stubs/META-INF/org.springframework.cloud.verifier.sample/sample-project/0.1/mappings/Messaging.json".replace("/", File.separator));
 	}
 
 	@Test
 	public void shouldGenerateWireMockFromStubsDirectory() throws Exception {
 		File basedir = this.resources.getBasedir("withStubs");
 		this.maven.executeMojo(basedir, "convert", newParameter("contractsDirectory", "src/test/resources/stubs"));
-		assertFilesPresent(basedir, "target/stubs/mappings/Sample.json".replace("/", File.separator));
+		assertFilesPresent(basedir, "target/stubs/META-INF/org.springframework.cloud.verifier.sample/sample-project/0.1/mappings/Sample.json".replace("/", File.separator));
 	}
 
 	@Test
 	public void shouldCopyContracts() throws Exception {
 		File basedir = this.resources.getBasedir("basic");
 		this.maven.executeMojo(basedir, "convert");
-		assertFilesPresent(basedir, "target/stubs/contracts/Sample.groovy".replace("/", File.separator));
-		assertFilesPresent(basedir, "target/stubs/contracts/Messaging.groovy".replace("/", File.separator));
+		assertFilesPresent(basedir, "target/stubs/META-INF/org.springframework.cloud.verifier.sample/sample-project/0.1/contracts/Sample.groovy".replace("/", File.separator));
+		assertFilesPresent(basedir, "target/stubs/META-INF/org.springframework.cloud.verifier.sample/sample-project/0.1/contracts/Messaging.groovy".replace("/", File.separator));
 	}
 
 	@Test
 	public void shouldGenerateWireMockStubsInSelectedLocation() throws Exception {
 		File basedir = this.resources.getBasedir("basic");
 		this.maven.executeMojo(basedir, "convert", newParameter("stubsDirectory", "target/foo"));
-		assertFilesPresent(basedir, "target/foo/mappings/Sample.json");
+		assertFilesPresent(basedir, "target/foo/META-INF/org.springframework.cloud.verifier.sample/sample-project/0.1/mappings/Sample.json");
 	}
 
 	@Test
@@ -141,16 +141,16 @@ public class PluginUnitTest {
 	public void shouldGenerateStubsByDownloadingContractsFromARepo() throws Exception {
 		File basedir = this.resources.getBasedir("basic-remote-contracts");
 		this.maven.executeMojo(basedir, "convert", newParameter("contractsRepositoryUrl", "file://" + PluginUnitTest.class.getClassLoader().getResource("m2repo/repository").getFile().replace("/", File.separator)));
-		assertFilesPresent(basedir, "target/stubs/mappings/com/example/server/client1/contracts/shouldMarkClientAsFraud.json");
+		assertFilesPresent(basedir, "target/stubs/META-INF/com.example/server/0.1.BUILD-SNAPSHOT/mappings/com/example/server/client1/contracts/shouldMarkClientAsFraud.json");
 	}
 
 	@Test
 	public void shouldGenerateStubsByDownloadingContractsFromARepoWhenCustomPathIsProvided() throws Exception {
 		File basedir = this.resources.getBasedir("complex-remote-contracts");
 		this.maven.executeMojo(basedir, "convert", newParameter("contractsRepositoryUrl", "file://" + PluginUnitTest.class.getClassLoader().getResource("m2repo/repository").getFile().replace("/", File.separator)));
-		assertFilesPresent(basedir, "target/stubs/mappings/com/example/server/client1/contracts/shouldMarkClientAsFraud.json");
-		assertFilesNotPresent(basedir, "target/stubs/mappings/com/foo/bar/baz/shouldBeIgnoredByPlugin.json");
-		assertFilesNotPresent(basedir, "target/stubs/contracts/com/foo/bar/baz/shouldBeIgnoredByPlugin.groovy");
+		assertFilesPresent(basedir, "target/stubs/META-INF/com.example.foo.bar.baz/someartifact/0.1.BUILD-SNAPSHOT/mappings/com/example/server/client1/contracts/shouldMarkClientAsFraud.json");
+		assertFilesNotPresent(basedir, "target/stubs/META-INF/com.example.foo.bar.baz/someartifact/0.1.BUILD-SNAPSHOT/mappings/com/foo/bar/baz/shouldBeIgnoredByPlugin.json");
+		assertFilesNotPresent(basedir, "target/stubs/META-INF/com.example.foo.bar.baz/someartifact/0.1.BUILD-SNAPSHOT/contracts/com/foo/bar/baz/shouldBeIgnoredByPlugin.groovy");
 	}
 
 	@Test
@@ -237,13 +237,13 @@ public class PluginUnitTest {
 
 		this.maven.executeMojo(basedir, "convert", newParameter("stubsDirectory", "target/foo"));
 
-		String firstFile = "target/foo/mappings/com/hello/v1/should post a user.json";
+		String firstFile = "target/foo/META-INF/org.springframework.cloud.verifier.sample/sample-project/0.1/mappings/com/hello/v1/should post a user.json";
 		File test = new File(basedir, firstFile);
-		assertFilesPresent(basedir, "target/foo/mappings/com/hello/v1/1_WithList.json");
+		assertFilesPresent(basedir, "target/foo/META-INF/org.springframework.cloud.verifier.sample/sample-project/0.1/mappings/com/hello/v1/1_WithList.json");
 		then(FileUtils.readFileToString(test)).contains("/users/1");
-		String secondFile = "target/foo/mappings/com/hello/v1/1_WithList.json";
+		String secondFile = "target/foo/META-INF/org.springframework.cloud.verifier.sample/sample-project/0.1/mappings/com/hello/v1/1_WithList.json";
 		File test2 = new File(basedir, secondFile);
-		assertFilesPresent(basedir, "target/foo/mappings/com/hello/v1/should post a user.json");
+		assertFilesPresent(basedir, "target/foo/META-INF/org.springframework.cloud.verifier.sample/sample-project/0.1/mappings/com/hello/v1/should post a user.json");
 		then(FileUtils.readFileToString(test2)).contains("/users/2");
 	}
 
@@ -255,9 +255,9 @@ public class PluginUnitTest {
 
 		assertFilesNotPresent(basedir, "target/generated-test-sources/contracts/");
 		// there will be no stubs cause all files are copied to `target` folder
-		assertFilesNotPresent(basedir, "target/stubs/mappings/");
-		assertFilesPresent(basedir, "target/stubs/contracts/consumer1/Messaging.groovy");
-		assertFilesPresent(basedir, "target/stubs/contracts/pom.xml");
+		assertFilesNotPresent(basedir, "target/stubs/META-INF/org.springframework.cloud.verifier.sample/common-repo/0.1/mappings/");
+		assertFilesPresent(basedir, "target/stubs/META-INF/org.springframework.cloud.verifier.sample/common-repo/0.1/contracts/consumer1/Messaging.groovy");
+		assertFilesPresent(basedir, "target/stubs/META-INF/org.springframework.cloud.verifier.sample/common-repo/0.1/contracts/pom.xml");
 	}
 
 	@Test


### PR DESCRIPTION
without this change the stubs are just placed under the contracts|mappings folders. If you have many of these JARs on the classpath then you might have a problem to say which stubs belong to which server.
with this change we're changing the default location to META-INF/groupid/artifactid/version/contract|mappings . That way you can easily discern stubs

fixes #54