### PR TITLE
Fixed a typo in docs

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-wiremock.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-wiremock.adoc
@@ -183,7 +183,7 @@ public class ApplicationTests {
 	public void contextLoads() throws Exception {
 		mockMvc.perform(post("/resource")
                 .content("{\"id\":\"123456\",\"message\":\"Hello World\"}"))
-				.andExpect(status.isOk())
+				.andExpect(status().isOk())
 				.andDo(verify().jsonPath("$.id")
                         .stub("resource"));
 	}
@@ -206,7 +206,7 @@ created stub. Example:
 	public void contextLoads() throws Exception {
 		mockMvc.perform(post("/resource")
                 .content("{\"id\":\"123456\",\"message\":\"Hello World\"}"))
-				.andExpect(status.isOk())
+				.andExpect(status().isOk())
 				.andDo(verify()
 						.wiremock(WireMock.post(
 							urlPathEquals("/resource"))


### PR DESCRIPTION
Fixed the code example typo: from "status" to "status()"