### PR TITLE
Adding an option to override file extension

### DIFF
--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/FileSaver.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/FileSaver.groovy
@@ -17,8 +17,10 @@
 package org.springframework.cloud.contract.verifier
 
 import groovy.transform.CompileStatic
+import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
-import org.springframework.cloud.contract.verifier.config.TestFramework
+import org.springframework.cloud.contract.verifier.builder.SingleTestGenerator
+import org.springframework.cloud.contract.verifier.config.ContractVerifierConfigProperties
 
 import java.nio.file.Files
 import java.nio.file.Path
@@ -30,22 +32,25 @@ import static org.springframework.cloud.contract.verifier.util.NamesUtil.capital
 import static org.springframework.cloud.contract.verifier.util.NamesUtil.packageToDirectory
 
 @CompileStatic
+@PackageScope
 @Slf4j
 class FileSaver {
 
-	File targetDirectory
-	TestFramework framework
+	private final File targetDirectory
+	private final SingleTestGenerator generator
+	private final ContractVerifierConfigProperties properties
 
-	FileSaver(File targetDirectory, TestFramework framework) {
+	FileSaver(File targetDirectory, SingleTestGenerator generator, ContractVerifierConfigProperties properties) {
 		this.targetDirectory = targetDirectory
-		this.framework = framework
+		this.generator = generator
+		this.properties = properties
 	}
 
 	void saveClassFile(String fileName, String basePackageClass, String includedDirectoryRelativePath, byte[] classBytes) {
 		Path testBaseDir = Paths.get(targetDirectory.absolutePath, packageToDirectory(basePackageClass),
 				beforeLast(includedDirectoryRelativePath, File.separator))
 		Files.createDirectories(testBaseDir)
-		Path classPath = Paths.get(testBaseDir.toString(), capitalize(fileName) + framework.classExtension).toAbsolutePath()
+		Path classPath = Paths.get(testBaseDir.toString(), capitalize(fileName) + generator.fileExtension(this.properties)).toAbsolutePath()
 		log.info("Creating new class file [$classPath]")
 		Files.write(classPath, classBytes, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
 	}

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/TestGenerator.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/TestGenerator.groovy
@@ -48,7 +48,7 @@ class TestGenerator {
 
 	TestGenerator(ContractVerifierConfigProperties configProperties) {
 		this(configProperties, singleTestGenerator(),
-				new FileSaver(configProperties.generatedTestSourcesDir, configProperties.targetFramework))
+				new FileSaver(configProperties.generatedTestSourcesDir, singleTestGenerator(), configProperties))
 	}
 
 	private static SingleTestGenerator singleTestGenerator() {

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JavaTestGenerator.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JavaTestGenerator.groovy
@@ -109,6 +109,11 @@ class JavaTestGenerator implements SingleTestGenerator {
 		return clazz.build()
 	}
 
+	@Override
+	String fileExtension(ContractVerifierConfigProperties properties) {
+		return properties.targetFramework.classExtension
+	}
+
 	private Map<ParsedDsl, TestType> mapContractsToTheirTestTypes(Collection<ContractMetadata> listOfFiles) {
 		Map<ParsedDsl, TestType> dsls = [:]
 		listOfFiles.each { ContractMetadata metadata ->

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/SingleTestGenerator.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/SingleTestGenerator.groovy
@@ -16,16 +16,13 @@
 
 package org.springframework.cloud.contract.verifier.builder
 
-import groovy.transform.CompileStatic
 import org.springframework.cloud.contract.verifier.config.ContractVerifierConfigProperties
 import org.springframework.cloud.contract.verifier.file.ContractMetadata
-
 /**
  * Builds a single test.
  *
  * @since 1.1.0
  */
-@CompileStatic
 interface SingleTestGenerator {
 
 	/**
@@ -41,4 +38,11 @@ interface SingleTestGenerator {
 	 */
 	String buildClass(ContractVerifierConfigProperties properties, Collection<ContractMetadata> listOfFiles,
 					  String className, String classPackage, String includedDirectoryRelativePath)
+
+	/**
+	 * Extension that should be appended to the generated test class. E.g. {@code .java} or {@code .php}
+	 *
+	 * @param properties - properties passed to the plugin
+	 */
+	String fileExtension(ContractVerifierConfigProperties properties)
 }

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/config/TestFramework.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/config/TestFramework.groovy
@@ -25,13 +25,14 @@ package org.springframework.cloud.contract.verifier.config
  */
 enum TestFramework {
 	JUNIT("public ", "public void ", ";", ".java", "Test", "org.junit.Ignore", ["org.junit.FixMethodOrder", "org.junit.runners.MethodSorters"], "@FixMethodOrder(MethodSorters.NAME_ASCENDING)"),
-	SPOCK("", "def ", "", ".groovy", "Spec", "spock.lang.Ignore", ["spock.lang.Stepwise"], "@Stepwise")
+	SPOCK("", "def ", "", ".groovy", "Spec", "spock.lang.Ignore", ["spock.lang.Stepwise"], "@Stepwise"),
+	CUSTOM("", "", "", "", "", "", [], "")
 
 	private final String classModifier
 	private final String methodModifier
 	private final String lineSuffix
-	private final String classExtension;
-	private final String classNameSuffix;
+	private final String classExtension
+	private final String classNameSuffix
 	private final String ignoreClass
 	private final List<String> orderAnnotationImports
 	private final String orderAnnotation


### PR DESCRIPTION
without this change it's impossible to change the generated file extension
with this change you can do it. E.g. provide your own test generator that will store files in `.php` file

fixes #253