### PR TITLE
gh-258: Added logging config for debugging to FAQ

### DIFF
--- a/docs/src/main/asciidoc/verifier/introduction.adoc
+++ b/docs/src/main/asciidoc/verifier/introduction.adoc
@@ -817,3 +817,27 @@ The rest of the flow looks the same.
 
 Yes! Check out the https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html#_different_base_classes_for_contracts[Different base classes for contracts] sections
 of either Gradle or Maven plugins.
+
+==== How can I debug the request/response being sent by the generated tests client?
+
+The generated tests all boil down to RestAssured in some form or fashion which relies on https://hc.apache.org/httpcomponents-client-ga/[Apache HttpClient].  HttpClient has a facility called https://hc.apache.org/httpcomponents-client-ga/logging.html#Wire_Logging[wire logging] which logs the entire request and response to HttpClient.  An example log4j2.xml configurtion could look like this
+[source,xml,indent=0]
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{ISO8601} [%t] %-5p %c - %m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger name="org.apache.http.wire" level="debug" additivity="false">
+      <appender-ref ref="console" level="debug"/>
+    </Logger>
+    <Root level="INFO" additivity="false">
+      <AppenderRef ref="console"/>
+    </Root>
+  </Loggers>
+</Configuration>
+
+----

--- a/docs/src/main/asciidoc/verifier/introduction.adoc
+++ b/docs/src/main/asciidoc/verifier/introduction.adoc
@@ -820,24 +820,8 @@ of either Gradle or Maven plugins.
 
 ==== How can I debug the request/response being sent by the generated tests client?
 
-The generated tests all boil down to RestAssured in some form or fashion which relies on https://hc.apache.org/httpcomponents-client-ga/[Apache HttpClient].  HttpClient has a facility called https://hc.apache.org/httpcomponents-client-ga/logging.html#Wire_Logging[wire logging] which logs the entire request and response to HttpClient.  An example log4j2.xml configurtion could look like this
-[source,xml,indent=0]
+The generated tests all boil down to RestAssured in some form or fashion which relies on https://hc.apache.org/httpcomponents-client-ga/[Apache HttpClient].  HttpClient has a facility called https://hc.apache.org/httpcomponents-client-ga/logging.html#Wire_Logging[wire logging] which logs the entire request and response to HttpClient.  Spring Boot has a logging https://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html[common application property] for doing this sort of thing, just add this to your application properties
+[source,properties,indent=0]
 ----
-<?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN">
-  <Appenders>
-    <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{ISO8601} [%t] %-5p %c - %m%n"/>
-    </Console>
-  </Appenders>
-  <Loggers>
-    <Logger name="org.apache.http.wire" level="debug" additivity="false">
-      <appender-ref ref="console" level="debug"/>
-    </Logger>
-    <Root level="INFO" additivity="false">
-      <AppenderRef ref="console"/>
-    </Root>
-  </Loggers>
-</Configuration>
-
+logging.level.org.apache.http.wire=DEBUG
 ----


### PR DESCRIPTION
Per the conversation in Gitter today, a PR with a FAQ update.  I don't know how to test the generated documentation outside of just looking at the adoc rendering in Intellij, so just a heads up incase I've done something that formats terribly ;)