### PR TITLE
Fix typo in the docs, add links to MockMvc and RestAssured docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -198,7 +198,8 @@ Spring Boot container if there is one.
 
 https://projects.spring.io/spring-restdocs[Spring RestDocs] can be
 used to generate documentation (e.g. in asciidoctor format) for an
-HTTP API with Spring MockMvc or RestEasy. At the same time as you
+HTTP API with https://docs.spring.io/spring/docs/current/spring-framework-reference/html/integration-testing.html#spring-mvc-test-framework[Spring MockMvc]
+or http://rest-assured.io/[RestAssured]. At the same time as you
 generate documentation for your API, you can also generate WireMock
 stubs, by using Spring Cloud Contract WireMock. Just write your normal
 RestDocs test cases and use `@AutoConfigureRestDocs` to have stubs


### PR DESCRIPTION
The `RestAssured` framework mistakenly named `RestEasy` in the documentation. :-)