### PR TITLE
gh-290: Remove unnecessary host entry from REST Docs contract generation

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-wiremock.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-wiremock.adoc
@@ -323,14 +323,13 @@ import org.springframework.cloud.contract.spec.Contract
 Contract.make {
     request {
         method 'POST'
-        url 'http://localhost:8080/foo'
+        url '/foo'
         body('''
             {"foo": 23 }
         ''')
         headers {
             header('''Accept''', '''application/json''')
             header('''Content-Type''', '''application/json''')
-            header('''Host''', '''localhost:8080''')
             header('''Content-Length''', '''12''')
         }
     }


### PR DESCRIPTION
This PR removes unnecessary host entries from Spring REST Docs-generated request contracts:
1. scheme, host and port parts of the url
2. Host header

Both seem not be needed and could just cause problems with the contract.

Issue #290 was already closed (by mistake I guess) and it is still valid.

Closes #290 