### PR TITLE
Remove unnecessary host entry from Spring REST Docs contract generation

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-wiremock.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-wiremock.adoc
@@ -323,15 +323,13 @@ import org.springframework.cloud.contract.spec.Contract
 Contract.make {
     request {
         method 'POST'
-        url 'http://localhost:8080/foo'
+        url '/foo'
         body('''
             {"foo": 23 }
         ''')
         headers {
             header('''Accept''', '''application/json''')
             header('''Content-Type''', '''application/json''')
-            header('''Host''', '''localhost:8080''')
-            header('''Content-Length''', '''12''')
         }
     }
     response {

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/restdocs/ContractDslSnippetTests.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/restdocs/ContractDslSnippetTests.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -14,8 +16,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.contract.spec.Contract;
+import org.springframework.cloud.contract.spec.internal.Header;
 import org.springframework.cloud.contract.verifier.util.ContractVerifierDslConverter;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.JUnitRestDocumentation;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -80,9 +84,12 @@ public class ContractDslSnippetTests {
 		String contract = readFromFile(file("/contracts/index.groovy"));
 		// try to parse the contract
 		Contract parsedContract = ContractVerifierDslConverter.convert(contract);
-		then(parsedContract.getRequest().getHeaders().getEntries()).isNotEmpty();
+		then(parsedContract.getRequest().getHeaders().getEntries()).isNotNull();
+		then(headerNames(parsedContract.getRequest().getHeaders().getEntries())).doesNotContain
+				(HttpHeaders.HOST, HttpHeaders.CONTENT_LENGTH);
 		then(parsedContract.getRequest().getMethod().getClientValue()).isNotNull();
 		then(parsedContract.getRequest().getUrl().getClientValue()).isNotNull();
+		then(parsedContract.getRequest().getUrl().getClientValue().toString()).startsWith("/");
 		then(parsedContract.getRequest().getBody().getClientValue()).isNotNull();
 		then(parsedContract.getResponse().getStatus().getClientValue()).isNotNull();
 		then(parsedContract.getResponse().getHeaders().getEntries()).isNotEmpty();
@@ -101,14 +108,23 @@ public class ContractDslSnippetTests {
 		String contract = readFromFile(file("/contracts/empty.groovy"));
 		// try to parse the contract
 		Contract parsedContract = ContractVerifierDslConverter.convert(contract);
-		then(parsedContract.getRequest().getHeaders().getEntries()).isNotEmpty();
+		then(parsedContract.getRequest().getHeaders()).isNull();
 		then(parsedContract.getRequest().getMethod().getClientValue()).isNotNull();
 		then(parsedContract.getRequest().getUrl().getClientValue()).isNotNull();
+		then(parsedContract.getRequest().getUrl().getClientValue().toString()).startsWith("/");
 		then(parsedContract.getRequest().getBody()).isNull();
 		then(parsedContract.getResponse().getStatus().getClientValue()).isNotNull();
 		then(parsedContract.getResponse().getHeaders()).isNull();
 		then(parsedContract.getResponse().getBody()).isNull();
 		then(parsedContract.getResponse().getMatchers()).isNull();
+	}
+
+	private Set<String> headerNames(Set<Header> headers) {
+		Set<String> names = new HashSet<>();
+		for (Header header : headers) {
+			names.add(header.getName());
+		}
+		return names;
 	}
 
 	private File file(String name) throws URISyntaxException {


### PR DESCRIPTION
This PR removes unnecessary host entries from Spring REST Docs-generated request contracts:

1. scheme, host and port parts of the url
2. Host header
3. Content-Length header
All seem not be needed and could just cause problems with the contract.

This PR is the same as #292 but with fixes applied and targeted at 1.0.x branch.

Issue #290 was already closed (by mistake I guess) and it is still valid.

Closes #290