### PR TITLE
Tests fail to compile when the contract contains a long value

### DIFF
--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/util/DelegatingJsonVerifiable.java
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/util/DelegatingJsonVerifiable.java
@@ -174,7 +174,11 @@ class DelegatingJsonVerifiable implements MethodBufferingJsonVerifiable {
 		if (this.delegate.isAssertingAValueInArray() && containsAMatcher) {
 			readyToCheck.methodsBuffer.offer(".value()");
 		} else {
-			readyToCheck.appendMethodWithValue("isEqualTo", String.valueOf(value));
+			if(value instanceof Long) {
+				readyToCheck.appendMethodWithValue("isEqualTo", String.valueOf(value).concat("L"));
+			} else {
+				readyToCheck.appendMethodWithValue("isEqualTo", String.valueOf(value));
+			}
 		}
 		return readyToCheck;
 	}

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/util/DelegatingJsonVerifiable.java
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/util/DelegatingJsonVerifiable.java
@@ -174,11 +174,7 @@ class DelegatingJsonVerifiable implements MethodBufferingJsonVerifiable {
 		if (this.delegate.isAssertingAValueInArray() && containsAMatcher) {
 			readyToCheck.methodsBuffer.offer(".value()");
 		} else {
-			if(value instanceof Long) {
-				readyToCheck.appendMethodWithValue("isEqualTo", String.valueOf(value).concat("L"));
-			} else {
-				readyToCheck.appendMethodWithValue("isEqualTo", String.valueOf(value));
-			}
+			readyToCheck.appendMethodWithValue("isEqualTo",  value instanceof Long ? String.valueOf(value).concat("L") : String.valueOf(value));
 		}
 		return readyToCheck;
 	}

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MethodBodyBuilderSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MethodBodyBuilderSpec.groovy
@@ -308,9 +308,11 @@ DocumentContext parsedJson = JsonPath.parse(json);
 		and:
 			stubMappingIsValidWireMockStub(contractDsl)
 		where:
-			methodBuilderName           | methodBuilder
-			"MockMvcSpockMethodBuilder" | { Contract dsl -> new MockMvcSpockMethodRequestProcessingBodyBuilder(dsl, properties) }
-			"MockMvcJUnitMethodBuilder" | { Contract dsl -> new MockMvcJUnitMethodBodyBuilder(dsl, properties) }
+			methodBuilderName           						 | methodBuilder
+			"MockMvcSpockMethodBuilder" 						 | { Contract dsl -> new MockMvcSpockMethodRequestProcessingBodyBuilder(dsl, properties) }
+			"MockMvcJUnitMethodBuilder" 						 | { Contract dsl -> new MockMvcJUnitMethodBodyBuilder(dsl, properties) }
+			"JaxRsClientSpockMethodRequestProcessingBodyBuilder" | { Contract dsl -> new JaxRsClientSpockMethodRequestProcessingBodyBuilder(dsl, properties) }
+			"JaxRsClientJUnitMethodBodyBuilder"                  | { Contract dsl -> new JaxRsClientJUnitMethodBodyBuilder(dsl, properties) }
 	}
 
 }


### PR DESCRIPTION
without this change when a contract contains a long value inside the body, then the code fails to compile since the provided number is assumed to be an integer.
with this change we're appending an `L` literal to that value for the compiler to assume that it's a long value.