### PR TITLE
Added support for referencing file contents in the contract

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1350,6 +1350,11 @@ started will be attached.
 Yes! With version 1.1.0 we've added such a possibility. On the HTTP stub server side we're providing support
 for this for WireMock. In case of other HTTP server stubs you'll have to implement the approach yourself.
 
+==== Can I reference text from file?
+
+Yes! With version 1.2.0 we've added such a possibility. It's enough to call `file(...)` method in the
+DSL and provide a path relative to where the contract lays.
+
 === Links
 
 Here you can find interesting links related to Spring Cloud Contract Verifier:

--- a/docs/src/main/asciidoc/verifier/contract.adoc
+++ b/docs/src/main/asciidoc/verifier/contract.adoc
@@ -67,6 +67,46 @@ or just set the `ignored` property on the contract itself:
 include::{contract_spec_path}/src/test/groovy/org/springframework/cloud/contract/spec/internal/ContractSpec.groovy[tags=ignored,indent=0]
 ----
 
+===== Passing values from files
+
+Starting with version `1.2.0` it's possible to pass values from files. Let's assume that we have
+the following resources in our project.
+
+[source,bash,indent=0]
+----
+└── src
+    └── test
+        └── resources
+            └── contracts
+                ├── readFromFile.groovy
+                ├── request.json
+                └── response.json
+----
+
+And our contract looks like this:
+
+[source,groovy,indent=0]
+----
+include::{verifier_core_path}/src/test/resources/classpath/readFromFile.groovy[indent=0]
+----
+
+and the json files look like this:
+
+*request.json*
+[source,json,indent=0]
+----
+include::{verifier_core_path}/src/test/resources/classpath/request.json[indent=0]
+----
+
+*response.json*
+[source,json,indent=0]
+----
+include::{verifier_core_path}/src/test/resources/classpath/response.json[indent=0]
+----
+
+When test / stub generation takes place then the contents of the file will be
+passed to the body of request / response.
+
 ==== HTTP Top-Level Elements
 
 Following methods can be called in the top-level closure of a contract definition. Request and response are mandatory, priority is optional.

--- a/docs/src/main/asciidoc/verifier/contract.adoc
+++ b/docs/src/main/asciidoc/verifier/contract.adoc
@@ -105,7 +105,9 @@ include::{verifier_core_path}/src/test/resources/classpath/response.json[indent=
 ----
 
 When test / stub generation takes place then the contents of the file will be
-passed to the body of request / response.
+passed to the body of request / response. All thanks to the `file(...)` method.
+The argument of that method needs to be a file with location relative to the
+folder in which the contract lays.
 
 ==== HTTP Top-Level Elements
 

--- a/docs/src/main/asciidoc/verifier/introduction.adoc
+++ b/docs/src/main/asciidoc/verifier/introduction.adoc
@@ -878,3 +878,8 @@ started will be attached.
 
 Yes! With version 1.1.0 we've added such a possibility. On the HTTP stub server side we're providing support
 for this for WireMock. In case of other HTTP server stubs you'll have to implement the approach yourself.
+
+==== Can I reference text from file?
+
+Yes! With version 1.2.0 we've added such a possibility. It's enough to call `file(...)` method in the
+DSL and provide a path relative to where the contract lays.

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/Common.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/Common.groovy
@@ -161,6 +161,14 @@ class Common {
 		return new ServerDslProperty(serverValue)
 	}
 
+	String file(String relativePath) {
+		URL resource = Thread.currentThread().getContextClassLoader().getResource(relativePath)
+		if (resource == null) {
+			throw new IllegalStateException("File [${relativePath}] is not present")
+		}
+		return new File(resource.toURI()).text
+	}
+
 	/**
 	 * Helper method to provide a better name for the producer side
 	 */

--- a/spring-cloud-contract-stub-runner/README.adoc
+++ b/spring-cloud-contract-stub-runner/README.adoc
@@ -248,7 +248,7 @@ That means that there were two stubs registered. `fraudDetectionServer` was regi
 and `loanIssuance` at port `12255`. If we take a look at one of the files we would see (for WireMock)
 mappings available for the given server:
 
-[souce,json]
+[source,json]
 ----
 [{
   "id" : "f9152eb9-bf77-4c38-8289-90be7d10d0d7",

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRepository.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRepository.java
@@ -155,7 +155,7 @@ class StubRepository {
 	}
 
 	@SuppressWarnings("unchecked")
-	private Collection<Contract> collectContractDescriptors(File descriptorsDirectory) {
+	private Collection<Contract> collectContractDescriptors(final File descriptorsDirectory) {
 		final List<Contract> contractDescriptors = new ArrayList<>();
 		try {
 			Files.walkFileTree(Paths.get(descriptorsDirectory.toURI()),
@@ -167,7 +167,7 @@ class StubRepository {
 							ContractConverter converter = contractConverter(file);
 							if (isContractDescriptor(file) && isStubPerConsumerPathMatching(file)) {
 								contractDescriptors
-								.addAll(ContractVerifierDslConverter.convertAsCollection(file));
+								.addAll(ContractVerifierDslConverter.convertAsCollection(file.getParentFile(), file));
 							} else if (converter != null && isStubPerConsumerPathMatching(file)) {
 								contractDescriptors.addAll(converter.convertFrom(file));
 							}

--- a/spring-cloud-contract-tools/spring-cloud-contract-converters/src/main/groovy/org/springframework/cloud/contract/verifier/wiremock/DslToWireMockConverter.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-converters/src/main/groovy/org/springframework/cloud/contract/verifier/wiremock/DslToWireMockConverter.groovy
@@ -17,10 +17,8 @@
 package org.springframework.cloud.contract.verifier.wiremock
 
 import groovy.transform.CompileStatic
-import org.springframework.cloud.contract.spec.Contract
-import org.springframework.cloud.contract.verifier.converter.StubGenerator
-import org.springframework.cloud.contract.verifier.util.ContractVerifierDslConverter
 
+import org.springframework.cloud.contract.verifier.converter.StubGenerator
 /**
  * WireMock implementation of the {@link StubGenerator}
  *
@@ -45,9 +43,5 @@ abstract class DslToWireMockConverter implements StubGenerator {
 			return inputFileName.substring(i + 1)
 		}
 		return ""
-	}
-
-	protected Collection<Contract> createGroovyDSLFromStringContent(String groovyDslAsString) {
-		return ContractVerifierDslConverter.convertAsCollection(groovyDslAsString)
 	}
 }

--- a/spring-cloud-contract-tools/spring-cloud-contract-converters/src/test/groovy/org/springframework/cloud/contract/verifier/wiremock/DslToWireMockClientConverterSpec.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-converters/src/test/groovy/org/springframework/cloud/contract/verifier/wiremock/DslToWireMockClientConverterSpec.groovy
@@ -65,7 +65,7 @@ class DslToWireMockClientConverterSpec extends Specification {
 """)
 		when:
 			String json = converter.convertContents("Test", new ContractMetadata(file.toPath(), false, 0, null,
-			ContractVerifierDslConverter.convertAsCollection(file))).values().first()
+			ContractVerifierDslConverter.convertAsCollection(new File("/"),file))).values().first()
 		then:
 		JSONAssert.assertEquals('''
 {"request":{"method":"PUT","urlPattern":"/[0-9]{2}"},"response":{"status":200}}
@@ -101,7 +101,7 @@ class DslToWireMockClientConverterSpec extends Specification {
 ''')
 		when:
 			Map<Contract, String> convertedContents = converter.convertContents("Test", new ContractMetadata(file.toPath(), false, 0, null,
-					ContractVerifierDslConverter.convertAsCollection(file)))
+					ContractVerifierDslConverter.convertAsCollection(new File("/"),file)))
 		then:
 			convertedContents.size() == 2
 			JSONAssert.assertEquals(jsonResponse(1), convertedContents.values().first(), false)
@@ -142,7 +142,7 @@ class DslToWireMockClientConverterSpec extends Specification {
 		when:
 			Map<Contract, String> convertedContents = converter.convertContents("Test",
 					new ContractMetadata(file.toPath(), false, 0, null,
-					ContractVerifierDslConverter.convertAsCollection(file)))
+					ContractVerifierDslConverter.convertAsCollection(new File("/"),file)))
 		then:
 			convertedContents.isEmpty()
 	}
@@ -167,7 +167,7 @@ class DslToWireMockClientConverterSpec extends Specification {
 """)
 		when:
 			String json = converter.convertContents("test", new ContractMetadata(file.toPath(), false, 0, null,
-					ContractVerifierDslConverter.convertAsCollection(file))).values().first()
+					ContractVerifierDslConverter.convertAsCollection(new File("/"),file))).values().first()
 		then:
 			JSONAssert.assertEquals('''
 {"request":{
@@ -236,7 +236,7 @@ class DslToWireMockClientConverterSpec extends Specification {
 """)
 		when:
 			String json = converter.convertContents("Test", new ContractMetadata(file.toPath(), false, 0, null,
-					ContractVerifierDslConverter.convertAsCollection(file))).values().first()
+					ContractVerifierDslConverter.convertAsCollection(new File("/"),file))).values().first()
 		then:
 		JSONAssert.assertEquals('''
 {
@@ -354,7 +354,7 @@ class DslToWireMockClientConverterSpec extends Specification {
 """)
 		when:
 			String json = converter.convertContents("test", new ContractMetadata(file.toPath(), false, 0, null,
-					ContractVerifierDslConverter.convertAsCollection(file))).values().first()
+					ContractVerifierDslConverter.convertAsCollection(new File("/"),file))).values().first()
 		then:
 			JSONAssert.assertEquals('''
 {"request":{"urlPath":"/foos","method":"GET"},"response":{"body":"[{\\"id\\":\\"123\\"},{\\"id\\":\\"567\\"}]"}}
@@ -393,7 +393,7 @@ class DslToWireMockClientConverterSpec extends Specification {
 """)
 		when:
 			String json = converter.convertContents("test", new ContractMetadata(file.toPath(), false, 0, null,
-					ContractVerifierDslConverter.convertAsCollection(file))).values().first()
+					ContractVerifierDslConverter.convertAsCollection(new File("/"),file))).values().first()
 		then:
 			noExceptionThrown()
 		and:
@@ -440,7 +440,7 @@ class DslToWireMockClientConverterSpec extends Specification {
 	''')
 		when:
 			String json = converter.convertContents("Test", new ContractMetadata(file.toPath(), false, 0, null,
-					ContractVerifierDslConverter.convertAsCollection(file))).values().first()
+					ContractVerifierDslConverter.convertAsCollection(new File("/"),file))).values().first()
 		then:
 			JSONAssert.assertEquals( // tag::wiremock[]
 '''
@@ -595,7 +595,7 @@ class DslToWireMockClientConverterSpec extends Specification {
 	''')
 		when:
 			String json = converter.convertContents("Test", new ContractMetadata(file.toPath(), false, 0, null,
-					ContractVerifierDslConverter.convertAsCollection(file))).values().first()
+					ContractVerifierDslConverter.convertAsCollection(new File("/"),file))).values().first()
 		then:
 			JSONAssert.assertEquals(//tag::matchers[]
 				'''
@@ -749,7 +749,7 @@ class DslToWireMockClientConverterSpec extends Specification {
 		''')
 		when:
 			String json = converter.convertContents("Test", new ContractMetadata(file.toPath(), false, 0, null,
-					ContractVerifierDslConverter.convertAsCollection(file))).values().first()
+					ContractVerifierDslConverter.convertAsCollection(new File("/"),file))).values().first()
 		then:
 			JSONAssert.assertEquals(
 					'''

--- a/spring-cloud-contract-tools/spring-cloud-contract-converters/src/test/groovy/org/springframework/cloud/contract/verifier/wiremock/WireMockToDslConverterSpec.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-converters/src/test/groovy/org/springframework/cloud/contract/verifier/wiremock/WireMockToDslConverterSpec.groovy
@@ -88,7 +88,7 @@ class WireMockToDslConverterSpec extends Specification {
 		when:
 			String groovyDsl = WireMockToDslConverter.fromWireMockStub(wireMockStub)
 		then:
-			def a = ContractVerifierDslConverter.convertAsCollection(
+			def a = ContractVerifierDslConverter.convertAsCollection(new File("/"),
 					"""org.springframework.cloud.contract.spec.Contract.make {
 				$groovyDsl
 			}""")
@@ -143,7 +143,7 @@ class WireMockToDslConverterSpec extends Specification {
 		when:
 			String groovyDsl = WireMockToDslConverter.fromWireMockStub(wireMockStub)
 		then:
-			def a = ContractVerifierDslConverter.convertAsCollection(
+			def a = ContractVerifierDslConverter.convertAsCollection(new File("/"),
 					"""org.springframework.cloud.contract.spec.Contract.make {
 					$groovyDsl
 				}""")
@@ -196,7 +196,7 @@ class WireMockToDslConverterSpec extends Specification {
 		when:
 			String groovyDsl = WireMockToDslConverter.fromWireMockStub(wireMockStub)
 		then:
-			ContractVerifierDslConverter.convertAsCollection(
+			ContractVerifierDslConverter.convertAsCollection(new File("/"),
 					"""org.springframework.cloud.contract.spec.Contract.make {
 				$groovyDsl
 			}""").first() == expectedGroovyDsl
@@ -253,7 +253,7 @@ class WireMockToDslConverterSpec extends Specification {
 		when:
 			String groovyDsl = WireMockToDslConverter.fromWireMockStub(wireMockStub)
 		then:
-			ContractVerifierDslConverter.convertAsCollection(
+			ContractVerifierDslConverter.convertAsCollection(new File("/"),
 					"""org.springframework.cloud.contract.spec.Contract.make {
 				$groovyDsl
 			}""").first() == expectedGroovyDsl
@@ -318,7 +318,7 @@ class WireMockToDslConverterSpec extends Specification {
 		when:
 			String groovyDsl = WireMockToDslConverter.fromWireMockStub(wireMockStub)
 		then:
-			ContractVerifierDslConverter.convertAsCollection(
+			ContractVerifierDslConverter.convertAsCollection(new File("/"),
 					"""org.springframework.cloud.contract.spec.Contract.make {
 				$groovyDsl
 			}""").first() == expectedGroovyDsl
@@ -356,7 +356,7 @@ class WireMockToDslConverterSpec extends Specification {
 		when:
 			String groovyDsl = WireMockToDslConverter.fromWireMockStub(wireMockStub)
 		then:
-			Contract evaluatedGroovyDsl = ContractVerifierDslConverter.convertAsCollection(
+			Contract evaluatedGroovyDsl = ContractVerifierDslConverter.convertAsCollection(new File("/"),
 					"""org.springframework.cloud.contract.spec.Contract.make {
 				$groovyDsl
 			}""").first()
@@ -396,7 +396,7 @@ class WireMockToDslConverterSpec extends Specification {
 		when:
 			String groovyDsl = WireMockToDslConverter.fromWireMockStub(wireMockStub)
 		then:
-			Contract evaluatedGroovyDsl = ContractVerifierDslConverter.convertAsCollection(
+			Contract evaluatedGroovyDsl = ContractVerifierDslConverter.convertAsCollection(new File("/"),
 					"""org.springframework.cloud.contract.spec.Contract.make {
 				$groovyDsl
 			}""").first()
@@ -437,7 +437,7 @@ class WireMockToDslConverterSpec extends Specification {
 		when:
 			String groovyDsl = WireMockToDslConverter.fromWireMockStub(wireMockStub)
 		then:
-			Contract evaluatedGroovyDsl = ContractVerifierDslConverter.convertAsCollection(
+			Contract evaluatedGroovyDsl = ContractVerifierDslConverter.convertAsCollection(new File("/"),
 					"""org.springframework.cloud.contract.spec.Contract.make {
 				$groovyDsl
 			}""").first()
@@ -477,7 +477,7 @@ class WireMockToDslConverterSpec extends Specification {
 		when:
 			String groovyDsl = WireMockToDslConverter.fromWireMockStub(wireMockStub)
 		then:
-			Contract evaluatedGroovyDsl = ContractVerifierDslConverter.convertAsCollection(
+			Contract evaluatedGroovyDsl = ContractVerifierDslConverter.convertAsCollection(new File("/"),
 					"""org.springframework.cloud.contract.spec.Contract.make {
 					$groovyDsl
 				}""").first()
@@ -517,7 +517,7 @@ class WireMockToDslConverterSpec extends Specification {
 		when:
 			String groovyDsl = WireMockToDslConverter.fromWireMockStub(wireMockStub)
 		then:
-			Contract evaluatedGroovyDsl = ContractVerifierDslConverter.convertAsCollection(
+			Contract evaluatedGroovyDsl = ContractVerifierDslConverter.convertAsCollection(new File("/"),
 					"""org.springframework.cloud.contract.spec.Contract.make {
 					$groovyDsl
 				}""").first()
@@ -555,7 +555,7 @@ class WireMockToDslConverterSpec extends Specification {
 		when:
 			String groovyDsl = WireMockToDslConverter.fromWireMockStub(wireMockStub)
 		then:
-			Contract evaluatedGroovyDsl = ContractVerifierDslConverter.convertAsCollection(
+			Contract evaluatedGroovyDsl = ContractVerifierDslConverter.convertAsCollection(new File("/"),
 					"""org.springframework.cloud.contract.spec.Contract.make {
 					$groovyDsl
 				}""").first()

--- a/spring-cloud-contract-tools/spring-cloud-contract-converters/src/test/groovy/org/springframework/cloud/contract/verifier/wiremock/WiremockScenarioConverterSpec.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-converters/src/test/groovy/org/springframework/cloud/contract/verifier/wiremock/WiremockScenarioConverterSpec.groovy
@@ -31,7 +31,7 @@ class WiremockScenarioConverterSpec extends Specification {
 			Path dsl = Paths.get(this.getClass().getResource("/converter/scenario/main_scenario/01_login.groovy").toURI())
 		when:
 			String content = converter.convertContents("Test", new ContractMetadata(dsl, false, 3, 0,
-					ContractVerifierDslConverter.convertAsCollection(dsl.toFile()))).values().first()
+					ContractVerifierDslConverter.convertAsCollection(new File("/"), dsl.toFile()))).values().first()
 		then:
 			content.contains('"requiredScenarioState" : "Started"')
 			content.contains('"newScenarioState" : "Step1"')
@@ -44,7 +44,7 @@ class WiremockScenarioConverterSpec extends Specification {
 			Path dsl = Paths.get(this.getClass().getResource("/converter/scenario/main_scenario/02_showCart.groovy").toURI())
 		when:
 			String content = converter.convertContents("Test", new ContractMetadata(dsl, false, 3, 1,
-					ContractVerifierDslConverter.convertAsCollection(dsl.toFile()))).values().first()
+					ContractVerifierDslConverter.convertAsCollection(new File("/"), dsl.toFile()))).values().first()
 		then:
 			content.contains('"requiredScenarioState" : "Step1"')
 			content.contains('"newScenarioState" : "Step2"')
@@ -57,7 +57,7 @@ class WiremockScenarioConverterSpec extends Specification {
 			Path dsl = Paths.get(this.getClass().getResource("/converter/scenario/main_scenario/03_logout.groovy").toURI())
 		when:
 			String content = converter.convertContents("Test", new ContractMetadata(dsl, false, 3, 2,
-					ContractVerifierDslConverter.convertAsCollection(dsl.toFile()))).values().first()
+					ContractVerifierDslConverter.convertAsCollection(new File("/"), dsl.toFile()))).values().first()
 		then:
 			content.contains('"requiredScenarioState" : "Step2"')
 			!content.contains('"newScenarioState"')

--- a/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/GenerateTestsMojo.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/GenerateTestsMojo.java
@@ -16,6 +16,8 @@
 package org.springframework.cloud.contract.maven.verifier;
 
 import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -191,23 +193,7 @@ public class GenerateTestsMojo extends AbstractMojo {
 				this.contractsPath, this.contractsRepositoryUrl, this.contractsWorkOffline, getLog(),
 				this.aetherStubDownloaderFactory, this.repoSession).downloadAndUnpackContractsIfRequired(config, this.contractsDirectory);
 		getLog().info("Directory with contract is present at [" + contractsDirectory + "]");
-		config.setContractsDslDir(contractsDirectory);
-		config.setGeneratedTestSourcesDir(this.generatedTestSourcesDir);
-		config.setTargetFramework(this.testFramework);
-		config.setTestMode(this.testMode);
-		config.setBasePackageForTests(this.basePackageForTests);
-		config.setBaseClassForTests(this.baseClassForTests);
-		config.setRuleClassForTests(this.ruleClassForTests);
-		config.setNameSuffixForTests(this.nameSuffixForTests);
-		config.setImports(this.imports);
-		config.setStaticImports(this.staticImports);
-		config.setIgnoredFiles(this.ignoredFiles);
-		config.setExcludedFiles(this.excludedFiles);
-		config.setAssertJsonSize(this.assertJsonSize);
-		config.setPackageWithBaseClasses(this.packageWithBaseClasses);
-		if (this.baseClassMappings != null) {
-			config.setBaseClassMappings(mappingsToMap());
-		}
+		setupConfig(config, contractsDirectory);
 		this.project.addTestCompileSourceRoot(this.generatedTestSourcesDir.getAbsolutePath());
 		if (getLog().isInfoEnabled()) {
 			getLog().info(
@@ -225,6 +211,35 @@ public class GenerateTestsMojo extends AbstractMojo {
 			throw new MojoExecutionException(
 					String.format("Spring Cloud Contract Verifier Plugin exception: %s",
 							e.getMessage()), e);
+		}
+	}
+
+	private void setupConfig(ContractVerifierConfigProperties config,
+			File contractsDirectory) {
+		config.setContractsDslDir(contractsDirectory);
+		config.setGeneratedTestSourcesDir(this.generatedTestSourcesDir);
+		config.setTargetFramework(this.testFramework);
+		config.setTestMode(this.testMode);
+		config.setBasePackageForTests(this.basePackageForTests);
+		config.setBaseClassForTests(this.baseClassForTests);
+		config.setRuleClassForTests(this.ruleClassForTests);
+		config.setNameSuffixForTests(this.nameSuffixForTests);
+		config.setImports(this.imports);
+		config.setStaticImports(this.staticImports);
+		config.setIgnoredFiles(this.ignoredFiles);
+		config.setExcludedFiles(this.excludedFiles);
+		config.setAssertJsonSize(this.assertJsonSize);
+		config.setPackageWithBaseClasses(this.packageWithBaseClasses);
+		if (this.baseClassMappings != null) {
+			config.setBaseClassMappings(mappingsToMap());
+		}
+	}
+
+	private URL fileToUrl(File contractsDirectory) {
+		try {
+			return contractsDirectory.toURI().toURL();
+		} catch (MalformedURLException e) {
+			throw new IllegalStateException(e);
 		}
 	}
 

--- a/spring-cloud-contract-tools/spring-cloud-contract-spec-pact/src/test/groovy/org/springframework/cloud/contract/verifier/spec/pact/PactContractConverterSpec.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-spec-pact/src/test/groovy/org/springframework/cloud/contract/verifier/spec/pact/PactContractConverterSpec.groovy
@@ -266,7 +266,7 @@ class PactContractConverterSpec extends Specification {
 		given:
 			Resource[] contractResources = new PathMatchingResourcePatternResolver().getResources("contracts/*.groovy")
 			Resource[] pactResources = new PathMatchingResourcePatternResolver().getResources("contracts/*.json")
-			Map<String, Collection<Contract>> contracts = contractResources.collectEntries { [(it.filename) : ContractVerifierDslConverter.convertAsCollection(it.file)] }
+			Map<String, Collection<Contract>> contracts = contractResources.collectEntries { [(it.filename) : ContractVerifierDslConverter.convertAsCollection(new File("/"), it.file)] }
 			Map<String, String> jsonPacts = pactResources.collectEntries { [(it.filename) : it.file.text] }
 		when:
 			Map<String, Pact> pacts = contracts.entrySet().collectEntries { [(it.key) : converter.convertTo(it.value)] }

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/file/ContractFileScanner.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/file/ContractFileScanner.groovy
@@ -97,7 +97,7 @@ class ContractFileScanner {
 				boolean contractFile = isContractFile(file)
 				boolean included = includeMatcher ? file.absolutePath.matches(includeMatcher) : true
 				if (contractFile && included) {
-					addContractToTestGeneration(result, files, file, index, ContractVerifierDslConverter.convertAsCollection(file))
+					addContractToTestGeneration(result, files, file, index, ContractVerifierDslConverter.convertAsCollection(baseDir, file))
 				} else if (!contractFile && included) {
 					addContractToTestGeneration(converters, result, files, file, index)
 				} else {

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/util/ContractVerifierDslConverterSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/util/ContractVerifierDslConverterSpec.groovy
@@ -71,28 +71,28 @@ class ContractVerifierDslConverterSpec extends Specification {
 
 	def "should convert file to a list of Contracts"() {
 		when:
-			List<Contract> contract = ContractVerifierDslConverter.convertAsCollection(multipleContracts)
+			List<Contract> contract = ContractVerifierDslConverter.convertAsCollection(new File("/"),multipleContracts)
 		then:
 			contract == expectedMultipleContracts
 	}
 
 	def "should convert text to a list of Contracts"() {
 		when:
-			Collection<Contract> contract = ContractVerifierDslConverter.convertAsCollection(multipleContracts.text)
+			Collection<Contract> contract = ContractVerifierDslConverter.convertAsCollection(new File("/"),multipleContracts.text)
 		then:
 			contract == expectedMultipleContracts
 	}
 
 	def "should throw an exception when an invalid file is parsed"() {
 		when:
-			ContractVerifierDslConverter.convertAsCollection(invalidContract.text)
+			ContractVerifierDslConverter.convertAsCollection(new File("/"),invalidContract.text)
 		then:
 			thrown(DslParseException)
 	}
 
 	def "should throw an exception with file path when an invalid file is parsed"() {
 		when:
-			ContractVerifierDslConverter.convertAsCollection(invalidContract)
+			ContractVerifierDslConverter.convertAsCollection(new File("/"),invalidContract)
 		then:
 			DslParseException e = thrown(DslParseException)
 			e.toString().contains("contract.yml")
@@ -100,7 +100,7 @@ class ContractVerifierDslConverterSpec extends Specification {
 
 	def "should throw an exception when a non existent file is parsed"() {
 		when:
-			ContractVerifierDslConverter.convertAsCollection(new File("/foo/bar/baz.foo"))
+			ContractVerifierDslConverter.convertAsCollection(new File("/"),new File("/foo/bar/baz.foo"))
 		then:
 			DslParseException e = thrown(DslParseException)
 			e.cause instanceof FileNotFoundException
@@ -108,14 +108,14 @@ class ContractVerifierDslConverterSpec extends Specification {
 
 	def "should convert file to a list of Contracts when there's only one declared contract"() {
 		when:
-			Collection<Contract> contract = ContractVerifierDslConverter.convertAsCollection(singleContract)
+			Collection<Contract> contract = ContractVerifierDslConverter.convertAsCollection(new File("/"),singleContract)
 		then:
 			contract == [expectedSingleContract]
 	}
 
 	def "should convert text to a list of Contracts when there's only one declared contract"() {
 		when:
-			Collection<Contract> contract = ContractVerifierDslConverter.convertAsCollection(singleContract.text)
+			Collection<Contract> contract = ContractVerifierDslConverter.convertAsCollection(new File("/"),singleContract.text)
 		then:
 			contract == [expectedSingleContract]
 	}

--- a/spring-cloud-contract-verifier/src/test/resources/classpath/readFromFile.groovy
+++ b/spring-cloud-contract-verifier/src/test/resources/classpath/readFromFile.groovy
@@ -1,0 +1,19 @@
+import org.springframework.cloud.contract.spec.Contract
+
+Contract.make {
+	request {
+		method('PUT')
+		headers {
+			contentType(applicationJson())
+		}
+		body(file("request.json"))
+		url("/1")
+	}
+	response {
+		status 200
+		body(file("response.json"))
+		headers {
+			contentType(textPlain())
+		}
+	}
+}

--- a/spring-cloud-contract-verifier/src/test/resources/classpath/request.json
+++ b/spring-cloud-contract-verifier/src/test/resources/classpath/request.json
@@ -1,0 +1,1 @@
+{ "status" : "REQUEST" }

--- a/spring-cloud-contract-verifier/src/test/resources/classpath/response.json
+++ b/spring-cloud-contract-verifier/src/test/resources/classpath/response.json
@@ -1,0 +1,1 @@
+{ "status" : "RESPONSE" }

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/restdocs/ContractDslSnippetTests.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/restdocs/ContractDslSnippetTests.java
@@ -1,10 +1,7 @@
 package org.springframework.cloud.contract.wiremock.restdocs;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -82,7 +79,7 @@ public class ContractDslSnippetTests {
 
 		then(file("/contracts/index.groovy")).exists();
 		then(file("/index/dsl-contract.adoc")).exists();
-		Collection<Contract> parsedContracts = ContractVerifierDslConverter.convertAsCollection(file("/contracts/index.groovy"));
+		Collection<Contract> parsedContracts = ContractVerifierDslConverter.convertAsCollection(new File("/"), file("/contracts/index.groovy"));
 		Contract parsedContract = parsedContracts.iterator().next();
 		then(parsedContract.getRequest().getHeaders().getEntries()).isNotNull();
 		then(headerNames(parsedContract.getRequest().getHeaders().getEntries())).doesNotContain
@@ -105,7 +102,7 @@ public class ContractDslSnippetTests {
 
 		then(file("/contracts/empty.groovy")).exists();
 		then(file("/empty/dsl-contract.adoc")).exists();
-		Collection<Contract> parsedContracts = ContractVerifierDslConverter.convertAsCollection(file("/contracts/empty.groovy"));
+		Collection<Contract> parsedContracts = ContractVerifierDslConverter.convertAsCollection(new File("/"), file("/contracts/empty.groovy"));
 		Contract parsedContract = parsedContracts.iterator().next();
 		then(parsedContract.getRequest().getHeaders()).isNull();
 		then(parsedContract.getRequest().getMethod().getClientValue()).isNotNull();


### PR DESCRIPTION
without this change large bodies can't be parsed by the compiler
with this change we allow those bodies to be read from files

fixes #357