### PR TITLE
Fixed NON_EMPTY and NON_BLANK regex patterns

### DIFF
--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/RegexPatterns.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/RegexPatterns.groovy
@@ -44,8 +44,8 @@ class RegexPatterns {
 	protected static final Pattern ANY_DATE = Pattern.compile('(\\d\\d\\d\\d)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])')
 	protected static final Pattern ANY_DATE_TIME = Pattern.compile('([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])')
 	protected static final Pattern ANY_TIME = Pattern.compile('(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])')
-	protected static final Pattern NON_EMPTY = Pattern.compile(/.+/)
-	protected static final Pattern NON_BLANK = Pattern.compile(/.*(\S+|\R).*|!^\R*$/)
+	protected static final Pattern NON_EMPTY = Pattern.compile(/[\S\s]+/)
+	protected static final Pattern NON_BLANK = Pattern.compile(/^\s*\S[\S\s]*/)
 	protected static final Pattern ISO8601_WITH_OFFSET = Pattern.compile(/([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.\d{3})?(Z|[+-][01]\d:[0-5]\d)/)
 
 	protected static Pattern anyOf(String... values){


### PR DESCRIPTION
The regex patterns NON_BLANK and NON_EMPTY are wrong.
Current NON_EMPTY (".+") does not match a string with a new-line character(s): "\n\n".
Current NON_BLANK (".*(\S+|\R).*|!^\R*$") does not match e.g. "Foo\nBar\n".