### PR TITLE
Tests for #398 - regex pattern fix

### DIFF
--- a/spring-cloud-contract-spec/src/test/groovy/org/springframework/cloud/contract/spec/internal/RegexPatternsSpec.groovy
+++ b/spring-cloud-contract-spec/src/test/groovy/org/springframework/cloud/contract/spec/internal/RegexPatternsSpec.groovy
@@ -233,6 +233,9 @@ class RegexPatternsSpec extends Specification {
 			'Not Empty'	|| true
 			''			|| false
 			'    '		|| false
+			'\nFoo\nBar\n'	|| true
+			'\r\n'			|| false
+			' \r\n\t\f' 	|| false
 	}
 
 	def "should generate a regex for a non empty string [#textToMatch] that should match [#shouldMatch]"() {
@@ -243,6 +246,9 @@ class RegexPatternsSpec extends Specification {
 			'Not Empty'	|| true
 			''			|| false
 			'  '		|| true
+			'\nFoo\nBar\n'	|| true
+			'\r\n'			|| true
+			' \r\n\t\f' 	|| true
 	}
 
 	def "should generate a regex for an enumerated value [#textToMatch] that should match [#shouldMatch]"(){


### PR DESCRIPTION
https://github.com/spring-cloud/spring-cloud-contract/pull/398:
The regex patterns NON_BLANK and NON_EMPTY are wrong.
Current NON_EMPTY (".+") does not match a string with a new-line character(s): "\n\n".
Current NON_BLANK (".(\S+|\R).|!^\R*$") does not match e.g. "Foo\nBar\n".