### PR TITLE
Added composite child support.

### DIFF
--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockConfiguration.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockConfiguration.java
@@ -123,8 +123,10 @@ public class WireMockConfiguration implements SmartLifecycle {
 				}
 			}
 		}
-		ResourcesFileSource fileSource = new ResourcesFileSource(resources.toArray(new Resource[0]));
-		factory.fileSource(fileSource);
+		if (!resources.isEmpty()) {
+			ResourcesFileSource fileSource = new ResourcesFileSource(resources.toArray(new Resource[0]));
+			factory.fileSource(fileSource);
+		}
 	}
 
 	@Override

--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockConfiguration.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockConfiguration.java
@@ -111,20 +111,20 @@ public class WireMockConfiguration implements SmartLifecycle {
 	}
 
 	private void registerFiles(com.github.tomakehurst.wiremock.core.WireMockConfiguration factory) throws IOException {
+		List<Resource> resources = new ArrayList<>();
 		for (String files : this.wireMock.getFiles()) {
 			if (StringUtils.hasText(files)) {
 				PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver(
 						this.resourceLoader);
-				List<Resource> resources = new ArrayList<>();
 				for (Resource resource : resolver.getResources(files)) {
 					if (resource.exists()) {
 						resources.add(resource);
 					}
 				}
-				ResourcesFileSource fileSource = new ResourcesFileSource(resources.toArray(new Resource[0]));
-				factory.fileSource(fileSource);
 			}
 		}
+		ResourcesFileSource fileSource = new ResourcesFileSource(resources.toArray(new Resource[0]));
+		factory.fileSource(fileSource);
 	}
 
 	@Override

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/AutoConfigureWireMockStubsAndMultipleFilesApplicationTests.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/AutoConfigureWireMockStubsAndMultipleFilesApplicationTests.java
@@ -13,7 +13,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes=WiremockTestsApplication.class, properties="app.baseUrl=http://localhost:${wiremock.server.port}", webEnvironment=WebEnvironment.NONE)
 @DirtiesContext
-@AutoConfigureWireMock(port=0, files={"classpath:/nonexistent/", "classpath:/root/"}, stubs="file:src/test/resources/io.stubs/mappings")
+@AutoConfigureWireMock(port=0, files={"classpath:/", "classpath:/root/", "classpath:/nonexistent/"}, stubs="file:src/test/resources/io.stubs/mappings")
 public class AutoConfigureWireMockStubsAndMultipleFilesApplicationTests {
 
 	@Autowired


### PR DESCRIPTION
If specified subDirectoryName exists in more the one FileSource, return another instance of ResourcesFileSource containing all matched FileSources.