### PR TITLE
Introduced adding of custom WireMock extensions

### DIFF
--- a/docs/src/main/asciidoc/verifier_contract.adoc
+++ b/docs/src/main/asciidoc/verifier_contract.adoc
@@ -536,6 +536,33 @@ proper values. Additionally, it registers two helper functions:
 * `escapejsonbody`: Escapes the request body in a format that can be embedded in a JSON.
 * `jsonpath`: For a given parameter, find an object in the request body.
 
+==== Registering your own WireMock extension
+
+WireMock allows to register custom extensions. Spring Cloud Contract by default
+registers the transformer that allows you to reference request from response.
+If you want to provide your own extensions it's enough to register an implementation
+of the `org.springframework.cloud.contract.verifier.dsl.wiremock.WireMockExtensions`
+interface. Since, we're using the `spring.factories` extension approach, just create
+an entry in `META-INF/spring.factories` file similar to this:
+
+[source,groovy,indent=0]
+----
+include::{stubrunner_core_path}/src/test/resources/META-INF/spring.factories[indent=0]
+----
+
+Here you have the example of a custom extension.
+
+.TestWireMockExtensions.groovy
+[source,groovy,indent=0]
+----
+include::{stubrunner_core_path}/src/test/groovy/org/springframework/cloud/contract/verifier/dsl/wiremock/TestWireMockExtensions.groovy[indent=0]
+----
+
+IMPORTANT: Remember to override the `applyGlobally()` method and set it to `false` if you
+want the transformation to be applied only for a mapping that explicitly
+requires it!
+
+
 ==== Dynamic Properties in the Matchers Sections
 
 If you work with https://docs.pact.io/[Pact], the following discussion may seem familiar.

--- a/docs/src/main/asciidoc/verifier_contract.adoc
+++ b/docs/src/main/asciidoc/verifier_contract.adoc
@@ -536,21 +536,21 @@ proper values. Additionally, it registers two helper functions:
 * `escapejsonbody`: Escapes the request body in a format that can be embedded in a JSON.
 * `jsonpath`: For a given parameter, find an object in the request body.
 
-==== Registering your own WireMock extension
+==== Registering Your Own WireMock Extension
 
-WireMock allows to register custom extensions. Spring Cloud Contract by default
-registers the transformer that allows you to reference request from response.
-If you want to provide your own extensions it's enough to register an implementation
-of the `org.springframework.cloud.contract.verifier.dsl.wiremock.WireMockExtensions`
-interface. Since, we're using the `spring.factories` extension approach, just create
-an entry in `META-INF/spring.factories` file similar to this:
+WireMock lets you register custom extensions. By default, Spring Cloud Contract registers
+the transformer, which lets you reference a request from a response. If you want to
+provide your own extensions, you can register an implementation of the
+`org.springframework.cloud.contract.verifier.dsl.wiremock.WireMockExtensions` interface.
+Since we use the spring.factories extension approach, you can create an entry in
+`META-INF/spring.factories` file similar to the following:
 
 [source,groovy,indent=0]
 ----
 include::{stubrunner_core_path}/src/test/resources/META-INF/spring.factories[indent=0]
 ----
 
-Here you have the example of a custom extension.
+The following is an example of a custom extension:
 
 .TestWireMockExtensions.groovy
 [source,groovy,indent=0]
@@ -559,9 +559,7 @@ include::{stubrunner_core_path}/src/test/groovy/org/springframework/cloud/contra
 ----
 
 IMPORTANT: Remember to override the `applyGlobally()` method and set it to `false` if you
-want the transformation to be applied only for a mapping that explicitly
-requires it!
-
+want the transformation to be applied only for a mapping that explicitly requires it.
 
 ==== Dynamic Properties in the Matchers Sections
 

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/provider/wiremock/TestWireMockExtensions.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/provider/wiremock/TestWireMockExtensions.groovy
@@ -1,0 +1,56 @@
+package org.springframework.cloud.contract.stubrunner.provider.wiremock
+
+import com.github.tomakehurst.wiremock.common.FileSource
+import com.github.tomakehurst.wiremock.extension.Extension
+import com.github.tomakehurst.wiremock.extension.Parameters
+import com.github.tomakehurst.wiremock.extension.ResponseTransformer
+import com.github.tomakehurst.wiremock.http.Request
+import com.github.tomakehurst.wiremock.http.Response
+
+import org.springframework.cloud.contract.verifier.dsl.wiremock.DefaultResponseTransformer
+import org.springframework.cloud.contract.verifier.dsl.wiremock.WireMockExtensions
+
+/**
+ * Extension that registers the default response transformer and a custom one too
+ */
+class TestWireMockExtensions implements WireMockExtensions {
+	@Override
+	List<Extension> extensions() {
+		return [
+				new DefaultResponseTransformer(),
+				new CustomExtension()
+		]
+	}
+}
+
+class CustomExtension extends ResponseTransformer {
+
+	/**
+	 * We expect the mapping to contain "foo-transformer" in the list
+	 * of "response-transformers" in the stub mapping
+	 */
+	@Override
+	String getName() {
+		return "foo-transformer"
+	}
+
+	/**
+	 * Transformer returns the "surprise!" body regardless of what you
+	 * the stub mapping returns
+	 */
+	@Override
+	Response transform(Request request, Response response, FileSource files, Parameters parameters) {
+		return new Response(response.status, response.statusMessage,
+				"surprise!", response.headers, response.wasConfigured(), response.fault, response.fromProxy)
+	}
+
+	/**
+	 * We don't want this extension to be applied to every single mapping.
+	 * We just want this to take place when a mapping explicitly expresses that in the
+	 * "response-transformers" section
+	 */
+	@Override
+	boolean applyGlobally() {
+		return false
+	}
+}

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/provider/wiremock/WireMockHttpServerStubSpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/provider/wiremock/WireMockHttpServerStubSpec.groovy
@@ -23,31 +23,35 @@ import spock.lang.Specification
 
 import org.springframework.boot.test.rule.OutputCapture
 import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.web.client.RestTemplate
 
 class WireMockHttpServerStubSpec extends Specification {
 	public static
-	final File MAPPING_DESCRIPTOR = new File('src/test/resources/repository/mappings/spring/cloud/ping/ping.json')
+	final File MAPPING_DESCRIPTOR = new File('src/test/resources/transformers.json')
 
 	@Rule OutputCapture capture = new OutputCapture()
 
 	def 'should describe stub mapping'() {
 		given:
-		WireMockHttpServerStub mappingDescriptor = new WireMockHttpServerStub().start() as WireMockHttpServerStub
-
+			WireMockHttpServerStub mappingDescriptor = new WireMockHttpServerStub().start() as WireMockHttpServerStub
 		when:
-		StubMapping mapping = mappingDescriptor.getMapping(MAPPING_DESCRIPTOR)
-
+			StubMapping mapping = mappingDescriptor.getMapping(MAPPING_DESCRIPTOR)
 		then:
-		with(mapping) {
-			assert request.method == RequestMethod.GET
-			assert request.url == '/ping'
-			assert response.status == 200
-			assert response.body == 'pong'
-			assert response.headers.contentTypeHeader.mimeTypePart() == 'text/plain'
-		}
-
+			with(mapping) {
+				assert request.method == RequestMethod.GET
+				assert request.url == '/ping'
+				assert response.status == 200
+				assert response.body == 'pong'
+				assert response.headers.contentTypeHeader.mimeTypePart() == 'text/plain'
+			}
+		when:
+			mappingDescriptor.registerMappings([MAPPING_DESCRIPTOR])
+		then:
+			noExceptionThrown()
+		expect:
+			"surprise!" == new RestTemplate().getForObject("http://localhost:" + mappingDescriptor.port() + "/ping", String.class)
 		cleanup:
-		mappingDescriptor.stop()
+			mappingDescriptor.stop()
 	}
 
 	def 'should make WireMock print out logs on INFO'() {

--- a/spring-cloud-contract-stub-runner/src/test/resources/META-INF/spring.factories
+++ b/spring-cloud-contract-stub-runner/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.cloud.contract.verifier.dsl.wiremock.WireMockExtensions=\
+org.springframework.cloud.contract.stubrunner.provider.wiremock.TestWireMockExtensions

--- a/spring-cloud-contract-stub-runner/src/test/resources/transformers.json
+++ b/spring-cloud-contract-stub-runner/src/test/resources/transformers.json
@@ -1,0 +1,14 @@
+{
+    "request": {
+        "method": "GET",
+        "url": "/ping"
+    },
+    "response": {
+        "status": 200,
+        "body": "pong",
+        "headers": {
+            "Content-Type": "text/plain"
+        },
+        "transformers" : [ "response-template", "foo-transformer" ]
+    }
+}

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/dsl/wiremock/DefaultResponseTransformer.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/dsl/wiremock/DefaultResponseTransformer.groovy
@@ -1,0 +1,39 @@
+package org.springframework.cloud.contract.verifier.dsl.wiremock
+
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer
+import wiremock.com.github.jknack.handlebars.Helper
+
+import org.springframework.cloud.contract.verifier.builder.handlebars.HandlebarsEscapeHelper
+import org.springframework.cloud.contract.verifier.builder.handlebars.HandlebarsJsonPathHelper
+
+/**
+ * Default implementation of {@link ResponseTemplateTransformer} that contains
+ * default set of handlebars helpers
+ *
+ * @author Marcin Grzejszczak
+ * @since 1.2.0
+ */
+class DefaultResponseTransformer extends ResponseTemplateTransformer {
+	DefaultResponseTransformer() {
+		super(false, defaultHelpers())
+	}
+
+	DefaultResponseTransformer(boolean global) {
+		super(global)
+	}
+
+	DefaultResponseTransformer(boolean global, String helperName, Helper helper) {
+		super(global, helperName, helper)
+	}
+
+	DefaultResponseTransformer(boolean global, Map<String, Helper> helpers) {
+		super(global, helpers)
+	}
+
+	private static Map<String, Helper> defaultHelpers() {
+		Map<String, Helper> helpers = new HashMap<>()
+		helpers.put(HandlebarsJsonPathHelper.NAME, new HandlebarsJsonPathHelper())
+		helpers.put(HandlebarsEscapeHelper.NAME, new HandlebarsEscapeHelper())
+		return helpers
+	}
+}

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/dsl/wiremock/WireMockExtensions.java
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/dsl/wiremock/WireMockExtensions.java
@@ -1,0 +1,16 @@
+package org.springframework.cloud.contract.verifier.dsl.wiremock;
+
+import java.util.List;
+
+import com.github.tomakehurst.wiremock.extension.Extension;
+
+/**
+ * Contract that describes a list of {@link Extension} extensions
+ * that should be applied to the response
+ *
+ * @author Marcin Grzejszczak
+ * @since 1.2.0
+ */
+public interface WireMockExtensions {
+	List<Extension> extensions();
+}

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/dsl/WireMockGroovyDslSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/dsl/WireMockGroovyDslSpec.groovy
@@ -78,7 +78,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 				"headers" : {
 				  "Content-Type" : "application/json"
 				},
-				"transformers" : [ "response-template" ]
+				"transformers" : [ "response-template", "foo-transformer" ]
 			  }
 			}
 			''', wireMockStub)
@@ -126,7 +126,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
   "response" : {
 	"status" : 200,
 	"body" : "{\\"ingredients\\":[{\\"quantity\\":100,\\"type\\":\\"MALT\\"},{\\"quantity\\":200,\\"type\\":\\"WATER\\"},{\\"quantity\\":300,\\"type\\":\\"HOP\\"},{\\"quantity\\":400,\\"type\\":\\"YIEST\\"}]}",
-	"transformers" : [ "response-template" ]
+	"transformers" : [ "response-template", "foo-transformer" ]
   }
 }
 ''', wireMockStub)
@@ -180,7 +180,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 	"response": {
 		"status": 204,
 		"body": "{\\"foundExistingPayment\\":false,\\"paymentId\\":\\"4\\"}",
-		"transformers" : [ "response-template" ]
+		"transformers" : [ "response-template", "foo-transformer" ]
 	}
 }
 ''', wireMockStub)
@@ -227,7 +227,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 	"headers" : {
 	  "Content-Type" : "application/json"
 	},
-	"transformers" : [ "response-template" ]
+	"transformers" : [ "response-template", "foo-transformer" ]
   }
 }
 ''')
@@ -284,7 +284,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 	"headers" : {
 	  "Content-Type" : "application/json"
 	},
-	"transformers" : [ "response-template" ]
+	"transformers" : [ "response-template", "foo-transformer" ]
   }
 }
 ''', wireMockStub)
@@ -335,7 +335,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
   },
   "response" : {
 	"status" : 200,
-	"transformers" : [ "response-template" ]
+	"transformers" : [ "response-template", "foo-transformer" ]
   }
 }
 			'''), wireMockStub)
@@ -381,7 +381,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
   },
   "response" : {
 	"status" : 200,
-	"transformers" : [ "response-template" ]
+	"transformers" : [ "response-template", "foo-transformer" ]
   }
 }
 			'''), json)
@@ -427,7 +427,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 					},
 					"response": {
 						"status": 200,
-						"transformers" : [ "response-template" ]
+						"transformers" : [ "response-template", "foo-transformer" ]
 					}
 				}
 				'''), json)
@@ -465,7 +465,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 						},
 						"response": {
 							"status": 200,
-							"transformers" : [ "response-template" ]
+							"transformers" : [ "response-template", "foo-transformer" ]
 						}
 					}
 					'''), json)
@@ -499,7 +499,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 							"response": {
 								"status": 200,
 								"body":"<user><name>Jozo</name><jobId>&lt;test&gt;</jobId></user>",
-								"transformers" : [ "response-template" ]
+								"transformers" : [ "response-template", "foo-transformer" ]
 							}
 						}
 						'''), json)
@@ -535,7 +535,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 					},
 					"response": {
 						"status": 200,
-						"transformers" : [ "response-template" ]
+						"transformers" : [ "response-template", "foo-transformer" ]
 					}
 				}
 				'''), json)
@@ -573,7 +573,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 						},
 						"response": {
 							"status": 200,
-							"transformers" : [ "response-template" ]
+							"transformers" : [ "response-template", "foo-transformer" ]
 						}
 					}
 					'''), json)
@@ -624,7 +624,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 	"headers" : {
 	  "Content-Type" : "application/json"
 	},
-	"transformers" : [ "response-template" ]
+	"transformers" : [ "response-template", "foo-transformer" ]
   }
 }
 '''), wireMockStub)
@@ -687,7 +687,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 	"headers" : {
 	  "Content-Type" : "application/vnd.fraud.v1+json"
 	},
-	"transformers" : [ "response-template" ]
+	"transformers" : [ "response-template", "foo-transformer" ]
   }
 }
 '''), wireMockStub)
@@ -754,7 +754,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 				},
 				"response": {
 					"status": 200,
-					"transformers" : [ "response-template" ]
+					"transformers" : [ "response-template", "foo-transformer" ]
 				}
 			}
 			'''), json)
@@ -793,7 +793,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 			  },
 			  "response" : {
 				"status" : 200,
-				"transformers" : [ "response-template" ]
+				"transformers" : [ "response-template", "foo-transformer" ]
 			  }
 			}
 			'''), json)
@@ -834,7 +834,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 				},
 				"response": {
 					"status": 200,
-					"transformers" : [ "response-template" ]
+					"transformers" : [ "response-template", "foo-transformer" ]
 				}
 			}
 			'''), json)
@@ -865,7 +865,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 					},
 					"response": {
 						"status": 200,
-						"transformers" : [ "response-template" ]
+						"transformers" : [ "response-template", "foo-transformer" ]
 					}
 				}
 				'''), json)
@@ -895,7 +895,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 					},
 					"response": {
 						"status": 200,
-						"transformers" : [ "response-template" ]
+						"transformers" : [ "response-template", "foo-transformer" ]
 					}
 				}
 				'''), json)
@@ -1049,7 +1049,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 					},
 					"response": {
 						"status": 200,
-						"transformers" : [ "response-template" ]
+						"transformers" : [ "response-template", "foo-transformer" ]
 					}
 				}
 				'''), json)
@@ -1123,7 +1123,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 	"headers" : {
 	  "Content-Type" : "application/json"
 	},
-	"transformers" : [ "response-template" ]
+	"transformers" : [ "response-template", "foo-transformer" ]
   }
 }
 			'''), wireMockStub)
@@ -1184,7 +1184,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 	"headers" : {
 	  "Content-Type" : "application/json"
 	},
-	"transformers" : [ "response-template" ]
+	"transformers" : [ "response-template", "foo-transformer" ]
   }
 }
 				'''), json)
@@ -1218,7 +1218,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 		},
 		"response": {
 		  "status": 406,
-		  "transformers" : [ "response-template" ]
+		  "transformers" : [ "response-template", "foo-transformer" ]
 		}
 			}
 '''), json)
@@ -1248,7 +1248,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 					},
 					"response": {
 						"status": 406,
-						"transformers" : [ "response-template" ]
+						"transformers" : [ "response-template", "foo-transformer" ]
 					}
 				}
 			'''), json)
@@ -1282,7 +1282,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
   },
   "response" : {
 	"status" : 200,
-	"transformers" : [ "response-template" ]
+	"transformers" : [ "response-template", "foo-transformer" ]
   }
 }
 			'''), wireMockStub)
@@ -1320,7 +1320,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 					},
 					"response": {
 						"status": 200,
-						"transformers" : [ "response-template" ]
+						"transformers" : [ "response-template", "foo-transformer" ]
 					}
 				}
 			'''), wireMockStub)
@@ -1379,7 +1379,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 			"headers" : {
 			  "Content-Type" : "application/json"
 			},
-			"transformers" : [ "response-template" ]
+			"transformers" : [ "response-template", "foo-transformer" ]
 		  },
 		  "priority" : 1
 		}
@@ -1425,7 +1425,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 		  },
 		  "response" : {
 			"status" : 422,
-			"transformers" : [ "response-template" ]
+			"transformers" : [ "response-template", "foo-transformer" ]
 		  }
 		}
 			'''), wireMockStub)
@@ -1460,7 +1460,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 				"headers" : {
 				  "Content-Type" : "application/json"
 				},
-				"transformers" : [ "response-template" ]
+				"transformers" : [ "response-template", "foo-transformer" ]
 			  },
 			  "priority" : 1
 			}
@@ -1592,7 +1592,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 		  },
 		  "response" : {
 			"status" : 200,
-			"transformers" : [ "response-template" ]
+			"transformers" : [ "response-template", "foo-transformer" ]
 		  }
 		}
 			'''
@@ -1673,7 +1673,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 				  "response" : {
 					"status" : 200,
 					"body" : "{\\"number\\":0,\\"last\\":true,\\"numberOfElements\\":1,\\"size\\":1,\\"totalPages\\":1,\\"sort\\":[{\\"nullHandling\\":\\"NATIVE\\",\\"ignoreCase\\":false,\\"property\\":\\"id\\",\\"ascending\\":true,\\"direction\\":\\"ASC\\"}],\\"content\\":[{\\"id\\":\\"00000000-0000-0000-0000-000000000000\\",\\"state\\":\\"ACTIVE\\",\\"type\\":\\"Extraordinary\\"}],\\"first\\":true,\\"totalElements\\":1}",
-					"transformers" : [ "response-template" ]
+					"transformers" : [ "response-template", "foo-transformer" ]
 				  }
 				}
 				'''), json)
@@ -1802,7 +1802,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 						"headers" : {
 						  "Authorization" : "{{{request.headers.Authorization.[0]}}};foo"
 						},
-						"transformers" : [ "response-template" ]
+						"transformers" : [ "response-template", "foo-transformer" ]
 					  }
 					}
 					'''), json)
@@ -1932,7 +1932,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 				  "response" : {
 					"status" : 200,
 					"body" : "{\\"code\\":91015,\\"payload\\":null,\\"description\\":\\"订单已失效\\",\\"lastUpdateTime\\":\\"0\\"}",
-					"transformers" : [ "response-template" ]
+					"transformers" : [ "response-template", "foo-transformer" ]
 				  }
 				}
 				''', wireMockStub)

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/dsl/wiremock/TestWireMockExtensions.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/dsl/wiremock/TestWireMockExtensions.groovy
@@ -1,0 +1,24 @@
+package org.springframework.cloud.contract.verifier.dsl.wiremock
+
+import com.github.tomakehurst.wiremock.extension.Extension
+
+/**
+ * Extension that registers the default transformer and the custom one
+ */
+class TestWireMockExtensions implements WireMockExtensions {
+	@Override
+	List<Extension> extensions() {
+		return [
+				new DefaultResponseTransformer(),
+				new CustomExtension()
+		]
+	}
+}
+
+class CustomExtension implements Extension {
+
+	@Override
+	String getName() {
+		return "foo-transformer"
+	}
+}

--- a/spring-cloud-contract-verifier/src/test/resources/META-INF/spring.factories
+++ b/spring-cloud-contract-verifier/src/test/resources/META-INF/spring.factories
@@ -1,3 +1,8 @@
 # Converters
 org.springframework.cloud.contract.spec.ContractConverter=\
 org.springframework.cloud.contract.verifier.converter.YamlContractConverter
+
+# tag::extension[]
+org.springframework.cloud.contract.verifier.dsl.wiremock.WireMockExtensions=\
+org.springframework.cloud.contract.verifier.dsl.wiremock.TestWireMockExtensions
+# end::extension[]


### PR DESCRIPTION
without this change we set only a single extension "response-transformer" without an option to provide any other ones
with this change we introduce the "spring.factories" based extension model. It's enough to provide your own implementation of `org.springframework.cloud.contract.verifier.dsl.wiremock.WireMockExtensions` and register it in `spring.factories`. That way you can control all extensions (request / response).

fixes #425

@Buzzardo could you please check out the docs I've added here?
@maverick1601 can you build this locally and check if this suits your needs?