### PR TITLE
Fix the order of version and classifier

### DIFF
--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerProperties.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerProperties.java
@@ -50,7 +50,7 @@ public class StubRunnerProperties {
 	private Resource repositoryRoot;
 
 	/**
-	 * The ids of the stubs to run in "ivy" notation ([groupId]:artifactId:[classifier]:[version][:port]).
+	 * The ids of the stubs to run in "ivy" notation ([groupId]:artifactId:[version]:[classifier][:port]).
 	 * {@code groupId}, {@code classifier}, {@code version} and {@code port} can be optional.
 	 */
 	private String[] ids = new String[0];


### PR DESCRIPTION
Fixes a minor typo - order of version and classifier in javadoc.