### PR TITLE
when contract is ignored, should not generate empty json, empty json is invalid.

### DIFF
--- a/spring-cloud-contract-tools/spring-cloud-contract-converters/src/main/groovy/org/springframework/cloud/contract/verifier/converter/RecursiveFilesConverter.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-converters/src/main/groovy/org/springframework/cloud/contract/verifier/converter/RecursiveFilesConverter.groovy
@@ -95,10 +95,12 @@ class RecursiveFilesConverter {
 						convertedContent.entrySet().eachWithIndex { Map.Entry<Contract, String> content, int index ->
 							Contract dsl = content.key
 							String converted = content.value
-							Path absoluteTargetPath = createAndReturnTargetDirectory(sourceFile)
-							File newJsonFile = createTargetFileWithProperName(stubGenerator, absoluteTargetPath,
-									sourceFile, contractsSize, index, dsl)
-							newJsonFile.setText(converted, StandardCharsets.UTF_8.toString())
+                            if (converted) {
+							    Path absoluteTargetPath = createAndReturnTargetDirectory(sourceFile)
+							    File newJsonFile = createTargetFileWithProperName(stubGenerator, absoluteTargetPath,
+							    		sourceFile, contractsSize, index, dsl)
+							    newJsonFile.setText(converted, StandardCharsets.UTF_8.toString())
+                            }
 						}
 					}
 				} catch (Exception e) {

--- a/spring-cloud-contract-tools/spring-cloud-contract-converters/src/test/groovy/org/springframework/cloud/contract/verifier/converter/RecursiveFilesConverterSpec.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-converters/src/test/groovy/org/springframework/cloud/contract/verifier/converter/RecursiveFilesConverterSpec.groovy
@@ -130,6 +130,34 @@ class RecursiveFilesConverterSpec extends Specification {
 			tmpFolder.root.list().toList().containsAll("foo", "bar")
 	}
 
+    def "should not create stub file when generated stub is empty"() {
+        given:
+            def sourceFile = tmpFolder.newFile("test.groovy")
+            sourceFile.text = """
+			    org.springframework.cloud.contract.spec.Contract.make {
+				    request {
+					    url "/baz"
+					    method "GET"
+				    }
+				    response {
+					    status 200
+				    }
+			    }
+			    """
+        and:
+            StubGenerator stubGenerator = stubGenerator("")
+        and:
+            ContractVerifierConfigProperties properties = new ContractVerifierConfigProperties()
+            properties.contractsDslDir = tmpFolder.root
+            properties.stubsOutputDir = tmpFolder.newFolder("target")
+        and:
+            RecursiveFilesConverter recursiveFilesConverter = new RecursiveFilesConverter(properties, new StubGeneratorProvider([stubGenerator]))
+        when:
+            recursiveFilesConverter.processFiles()
+        then:
+            properties.stubsOutputDir.list().toList().isEmpty()
+    }
+
 	private static Set<Path> getRelativePathsForFilesInDirectory(Collection<File> createdFiles, File targetRootDirectory) {
 		Path rootSourcePath = Paths.get(targetRootDirectory.toURI())
 		Set<Path> relativizedCreatedFiles = createdFiles.collect { File file ->


### PR DESCRIPTION
When I work on writing contracts, I have found when I use [Contract.ignored](https://github.com/spring-cloud/spring-cloud-contract/blob/master/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/Contract.groovy#L81) to ignore **Contract**, it's still generate the empty stub json file. this is invalid [json format](http://www.ietf.org/rfc/rfc4627.tx), and this also will cause [WireMockStubMapping. buildFrom](https://github.com/spring-cloud/spring-cloud-contract/blob/master/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockStubMapping.java#L9) failed to parse the **stub json** and run the mock server.

```
		if (!request || !response) {
			return ''
		}

		if (groovyDsl.ignored || contract.ignored) {
			return ''
		}
```
https://github.com/spring-cloud/spring-cloud-contract/blob/master/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/dsl/wiremock/WireMockStubStrategy.groovy#L74 , as the above code, it will return a default empty when contract `ignored`


So this **PR** is trying to fix this by skip to generate the **stub json file** when the generate contract is empty.