### PR TITLE
Avoid quoting of floating point numbers

### DIFF
--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/dsl/wiremock/BaseWireMockStubStrategy.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/dsl/wiremock/BaseWireMockStubStrategy.groovy
@@ -173,7 +173,7 @@ abstract class BaseWireMockStubStrategy {
 			Map convertedMap = MapConverter.transformValues(value) {
 				it instanceof GString ? it.toString() : it
 			} as Map
-			return new JSONObject(convertedMap).toString()
+			return new JSONObject(new JsonBuilder(convertedMap).toString())
 		}
 		return new JsonBuilder(value).toString()
 	}

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/dsl/wiremock/WireMockResponseStubStrategySpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/dsl/wiremock/WireMockResponseStubStrategySpec.groovy
@@ -1,0 +1,26 @@
+package org.springframework.cloud.contract.verifier.dsl.wiremock
+
+import org.springframework.cloud.contract.spec.Contract
+import spock.lang.Specification
+
+class WireMockResponseStubStrategySpec extends Specification {
+	def "should not quote floating point numbers"() {
+		given:
+			def irrelevantStatus = 200
+			def contract = Contract.make {
+				request {
+				}
+				response {
+					status irrelevantStatus
+					body([
+						value: 1.5
+					])
+				}
+			}
+		when:
+			def subject = new WireMockResponseStubStrategy(contract)
+			def content = subject.buildClientResponseContent()
+		then:
+			'{"value":1.5}'.equals(content.body)
+	}
+}


### PR DESCRIPTION
# Bug

```
        body([
            coordinate: [
                lat: 48.5,
                lng: 9.5
            ]
        ])
```

leads to

```json
{"coordinate":{"lng":"9.5","lat":"48.5"}}
```

instead of

```json
{"coordinate":{"lng":9.5,"lat":48.5}}
```

so instead of `9.5` we have `"9.5"`

# Fix
The fix in the PR is probably not the proper way of doing things. I just wanted to get the discussion started.

using 

```java
new JsonBuilder(convertedMap).toString()
```

would be enough for the provided test but then we get test fails related to JSON ordering e.g.

```
[ERROR]   WireMockGroovyDslSpec.should convert groovy dsl stub with GString and regexp:164 response.body
Expected: {"foundExistingPayment":false,"paymentId":"4"}
     got: {"paymentId":"4","foundExistingPayment":false}
```

To get the expected order back I just double wrapped it:

```java
return new JSONObject(new JsonBuilder(convertedMap).toString())
```

If you want I could make the tests order independent, as json usually is

Aside from that, thanks a bunch for the project, really makes life easier 👍 