### PR TITLE
Support pattern properties in messaging contracts

### DIFF
--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/Input.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/Input.groovy
@@ -35,6 +35,8 @@ import java.util.regex.Pattern
 @ToString(includePackage = false, includeNames = true)
 class Input extends Common {
 
+	@Delegate ClientPatternValueDslProperty property = new ClientPatternValueDslProperty()
+
 	DslProperty<String> messageFrom
 	ExecutionProperty triggeredBy
 	Headers messageHeaders = new Headers()
@@ -110,6 +112,17 @@ class Input extends Common {
 		this.matchers = new BodyMatchers()
 		closure.delegate = this.matchers
 		closure()
+	}
+
+	@CompileStatic
+	@EqualsAndHashCode(includeFields = true)
+	@ToString(includePackage = false)
+	private class ClientPatternValueDslProperty extends PatternValueDslProperty<ClientDslProperty> {
+
+		@Override
+		protected ClientDslProperty createProperty(Pattern pattern, Object generatedValue) {
+			return new ClientDslProperty(pattern, generatedValue)
+		}
 	}
 }
 

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/OutputMessage.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/OutputMessage.groovy
@@ -29,6 +29,8 @@ import java.util.regex.Pattern
 @ToString(includePackage = false, includeNames = true)
 class OutputMessage extends Common {
 
+	@Delegate ServerPatternValueDslProperty property = new ServerPatternValueDslProperty()
+
 	DslProperty<String> sentTo
 	Headers headers
 	DslProperty body
@@ -81,6 +83,17 @@ class OutputMessage extends Common {
 		this.matchers = new ResponseBodyMatchers()
 		closure.delegate = this.matchers
 		closure()
+	}
+
+	@CompileStatic
+	@EqualsAndHashCode(includeFields = true)
+	@ToString(includePackage = false)
+	private class ServerPatternValueDslProperty extends PatternValueDslProperty<ServerDslProperty> {
+
+		@Override
+		protected ServerDslProperty createProperty(Pattern pattern, Object generatedValue) {
+			return new ServerDslProperty(pattern, generatedValue)
+		}
 	}
 }
 

--- a/spring-cloud-contract-spec/src/test/groovy/org/springframework/cloud/contract/spec/internal/ContractSpec.groovy
+++ b/spring-cloud-contract-spec/src/test/groovy/org/springframework/cloud/contract/spec/internal/ContractSpec.groovy
@@ -66,6 +66,36 @@ class ContractSpec extends Specification {
 			noExceptionThrown()
 	}
 
+	def 'should work for messaging with pattern properties'() {
+		when:
+			Contract.make {
+				input {
+					messageFrom('input')
+					messageBody([
+							foo: anyNonBlankString()
+					])
+					messageHeaders {
+						header([
+								foo: anyNumber()
+						])
+					}
+				}
+				outputMessage {
+					sentTo('output')
+					body([
+							foo2: anyNonEmptyString()
+					])
+					headers {
+						header([
+								foo2: anyIpAddress()
+						])
+					}
+				}
+			}
+		then:
+			noExceptionThrown()
+	}
+
 	def 'should generate a value if only regex is passed for client'() {
 		given:
 			Request request = new Request()


### PR DESCRIPTION
We found that we were unable to use pattern properties such as `anyAlphaUnicode()` in messaging contracts and were told to open a bug report. We believe these changes would resolve the issue.