### PR TITLE
Stop backslashes from being stripped from regex patterns in header matches in JUnit messaging tests

### DIFF
--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JUnitMessagingMethodBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JUnitMessagingMethodBodyBuilder.groovy
@@ -220,8 +220,7 @@ class JUnitMessagingMethodBodyBuilder extends MessagingMethodBodyBuilder {
 	}
 
 	protected String createHeaderComparison(Pattern headerValue) {
-		String escapedHeader = convertUnicodeEscapesIfRequired("$headerValue")
-		return "matches(\"$escapedHeader\");"
+		return "matches(\"$headerValue\");"
 	}
 
 	private String patternText(Pattern value) {


### PR DESCRIPTION
We do this by completely avoiding the call to `convertUnicodeEscapesIfRequired` in `createHeaderComparison`. I'm not completely sure what this call achieves, so I don't know if it's safe to remove it. Please review!