### PR TITLE
Fix disabling of publish task when env property is set

### DIFF
--- a/docker/spring-cloud-contract-docker/project/build.gradle
+++ b/docker/spring-cloud-contract-docker/project/build.gradle
@@ -105,7 +105,9 @@ String publishArtifacts = getProp("PUBLISH_ARTIFACTS") ?: "true"
 boolean publishEnabled = Boolean.parseBoolean(publishArtifacts)
 publish.setEnabled(publishEnabled)
 
-project.tasks.findAll { it.name.startsWith('publish') }*.setEnabled(publishEnabled)
+gradle.taskGraph.whenReady { graph ->
+    graph.allTasks.findAll { it.name.startsWith("publish") }*.setEnabled(publishEnabled)
+}
 
 String getProp(String propName) {
 	return hasProperty(propName) ?


### PR DESCRIPTION
Because of Gradle's project lifecycle, disabling tasks in the script doesn't
work as expected, ./gradlew publish will still try to execute
:publishMavenJavaPublicationToMavenRepository and fail even if PUBLISH_ARTIFACTS
is set to false. To avoid that and make sure all publish tasks are disabled
script need to listen for tasks graph event to be ready and then disable the tasks.