### PR TITLE
Make headers matches in generated jUnit code escape regex '\'s.

### DIFF
--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JUnitMessagingMethodBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JUnitMessagingMethodBodyBuilder.groovy
@@ -30,6 +30,7 @@ import org.springframework.cloud.contract.verifier.util.MapConverter
 
 import java.util.regex.Pattern
 
+import static groovy.json.StringEscapeUtils.escapeJava
 import static org.springframework.cloud.contract.verifier.config.TestFramework.JUNIT
 
 /**
@@ -220,7 +221,8 @@ class JUnitMessagingMethodBodyBuilder extends MessagingMethodBodyBuilder {
 	}
 
 	protected String createHeaderComparison(Pattern headerValue) {
-		return "matches(\"$headerValue\");"
+		String escapedJavaHeader = escapeJava(headerValue.toString())
+		return "matches(\"$escapedJavaHeader\");"
 	}
 
 	private String patternText(Pattern value) {

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MessagingMethodBodyBuilderSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MessagingMethodBodyBuilderSpec.groovy
@@ -527,7 +527,7 @@ Contract.make {
 			builder.appendTo(blockBuilder)
 			def test = blockBuilder.toString()
 		then:
-    		test.contains('assertThat(response.getHeader("processId").toString()).matches("\\d+");')
+    		test.contains('assertThat(response.getHeader("processId").toString()).matches("\\\\d+");')
 	}
 
 
@@ -634,21 +634,12 @@ Contract.make {
 			builder.appendTo(blockBuilder)
 			def test = blockBuilder.toString()
 		then:
-			String expectedMsg =
-				'''
-  // when:
-  requestIsCalled();
-
- // then:
-  ContractVerifierMessage response = contractVerifierMessaging.receive("topic.rateablequote");
-  assertThat(response).isNotNull();
-  assertThat(response.getHeader("processId")).isNotNull();
-  assertThat(response.getHeader("processId").toString()).matches("[\\S\\s]+");
- // and:
-  DocumentContext parsedJson = JsonPath.parse(contractVerifierObjectMapper.writeValueAsString(response.getPayload()));
-  assertThatJson(parsedJson).field("['eventId']").matches("[\\S\\s]+");
-'''
-		stripped(test) == stripped(expectedMsg)
+			test.contains('ContractVerifierMessage response = contractVerifierMessaging.receive("topic.rateablequote")')
+			test.contains('assertThat(response).isNotNull()')
+			test.contains('assertThat(response.getHeader("processId")).isNotNull()')
+			test.contains('assertThat(response.getHeader("processId").toString()).matches("[\\\\S\\\\s]+")')
+			test.contains('DocumentContext parsedJson = JsonPath.parse(contractVerifierObjectMapper.writeValueAsString(response.getPayload()))')
+			test.contains('assertThatJson(parsedJson).field("[\'eventId\']").matches("[\\\\S\\\\s]+")')
 	}
 
 	@Issue("336")


### PR DESCRIPTION
+ Update tests to reflect desired behavior.

re: https://github.com/spring-cloud/spring-cloud-contract/issues/587