### PR TITLE
Iterate over stub runner downloader builders

### DIFF
--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloaderBuilder.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloaderBuilder.java
@@ -1,0 +1,21 @@
+package org.springframework.cloud.contract.stubrunner;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.cloud.contract.stubrunner.spring.StubRunnerProperties;
+
+/**
+ * @author Marcin Grzejszczak
+ * @since 2.0.0
+ */
+public class AetherStubDownloaderBuilder implements StubDownloaderBuilder {
+	private static final Log log = LogFactory.getLog(AetherStubDownloaderBuilder.class);
+
+	@Override public StubDownloader build(StubRunnerOptions stubRunnerOptions) {
+		if (stubRunnerOptions.stubsMode == StubRunnerProperties.StubsMode.CLASSPATH) {
+			return null;
+		}
+		log.info("Will download stubs from classpath");
+		return new AetherStubDownloader(stubRunnerOptions);
+	}
+}

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/BatchStubRunnerFactory.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/BatchStubRunnerFactory.java
@@ -41,7 +41,7 @@ public class BatchStubRunnerFactory {
 
 	private static StubDownloader aetherStubDownloader(StubRunnerOptions stubRunnerOptions) {
 		StubDownloaderBuilderProvider provider = new StubDownloaderBuilderProvider();
-		return provider.getOrDefaultDownloader(stubRunnerOptions);
+		return provider.get(stubRunnerOptions);
 	}
 
 	public BatchStubRunnerFactory(StubRunnerOptions stubRunnerOptions, StubDownloader stubDownloader) {

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/ClasspathStubProvider.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/ClasspathStubProvider.java
@@ -3,7 +3,6 @@ package org.springframework.cloud.contract.stubrunner;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.AbstractMap;
@@ -18,6 +17,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.cloud.contract.stubrunner.spring.StubRunnerProperties;
 import org.springframework.cloud.contract.stubrunner.util.StringUtils;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
@@ -53,7 +53,7 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 public class ClasspathStubProvider implements StubDownloaderBuilder {
 
 	private static final Log log = LogFactory
-			.getLog(MethodHandles.lookup().lookupClass());
+			.getLog(ClasspathStubProvider.class);
 
 	private static final int TEMP_DIR_ATTEMPTS = 10000;
 	private final PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver(
@@ -61,6 +61,10 @@ public class ClasspathStubProvider implements StubDownloaderBuilder {
 
 	@Override
 	public StubDownloader build(final StubRunnerOptions stubRunnerOptions) {
+		if (stubRunnerOptions.stubsMode != StubRunnerProperties.StubsMode.CLASSPATH) {
+			return null;
+		}
+		log.info("Will download stubs from classpath");
 		return new StubDownloader() {
 			@Override
 			public Map.Entry<StubConfiguration, File> downloadAndUnpackStubJar(
@@ -133,7 +137,7 @@ public class ClasspathStubProvider implements StubDownloaderBuilder {
 							+ groupAndArtifactResult.group(3);
 				}
 				else {
-					throw new IllegalArgumentException("Illegal uri [${uri}]");
+					throw new IllegalArgumentException("Illegal uri [" + uri + "]");
 				}
 			}
 		};

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/CompositeStubDownloaderBuilder.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/CompositeStubDownloaderBuilder.java
@@ -1,0 +1,58 @@
+package org.springframework.cloud.contract.stubrunner;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * @author Marcin Grzejszczak
+ * @since 2.0.0
+ */
+class CompositeStubDownloaderBuilder implements StubDownloaderBuilder {
+
+	private final List<StubDownloaderBuilder> builders;
+
+	CompositeStubDownloaderBuilder(List<StubDownloaderBuilder> builders) {
+		this.builders = builders;
+	}
+
+	@Override public StubDownloader build(StubRunnerOptions stubRunnerOptions) {
+		if (this.builders == null) {
+			return null;
+		}
+		return new CompositeStubDownloader(this.builders, stubRunnerOptions);
+	}
+}
+
+class CompositeStubDownloader implements StubDownloader {
+
+	private static final Log log = LogFactory.getLog(CompositeStubDownloader.class);
+
+	private final List<StubDownloaderBuilder> builders;
+	private final StubRunnerOptions stubRunnerOptions;
+
+	CompositeStubDownloader(List<StubDownloaderBuilder> builders,
+			StubRunnerOptions stubRunnerOptions) {
+		this.builders = builders;
+		this.stubRunnerOptions = stubRunnerOptions;
+	}
+
+	@Override public Map.Entry<StubConfiguration, File> downloadAndUnpackStubJar(
+			StubConfiguration stubConfiguration) {
+		for (StubDownloaderBuilder builder : this.builders) {
+			StubDownloader downloader = builder.build(this.stubRunnerOptions);
+			if (downloader == null) {
+				continue;
+			}
+			Map.Entry<StubConfiguration, File> entry = downloader
+					.downloadAndUnpackStubJar(stubConfiguration);
+			if (entry != null) {
+				return entry;
+			}
+		}
+		return null;
+	}
+}

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubDownloader.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubDownloader.java
@@ -35,5 +35,5 @@ public interface StubDownloader {
 	 * Returns a mapping of updated StubConfiguration (it will contain the resolved version) and the location of the downloaded JAR.
 	 * If there was no artifact this method will return {@code null}.
 	 */
-	Map.Entry<StubConfiguration,File> downloadAndUnpackStubJar(StubConfiguration stubConfiguration);
+	Map.Entry<StubConfiguration, File> downloadAndUnpackStubJar(StubConfiguration stubConfiguration);
 }

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubDownloaderBuilder.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubDownloaderBuilder.java
@@ -28,5 +28,8 @@ package org.springframework.cloud.contract.stubrunner;
  */
 public interface StubDownloaderBuilder {
 
+	/**
+	 * @return {@link StubDownloader} instance of {@code null} if current parameters don't allow building the instance
+	 */
 	StubDownloader build(StubRunnerOptions stubRunnerOptions);
 }

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerOptions.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerOptions.java
@@ -141,7 +141,7 @@ public class StubRunnerOptions {
 				.withMinPort(Integer.valueOf(System.getProperty("stubrunner.port.range.min", "10000")))
 				.withMaxPort(Integer.valueOf(System.getProperty("stubrunner.port.range.max", "15000")))
 				.withStubRepositoryRoot(System.getProperty("stubrunner.repository.root", ""))
-				.withStubsMode(System.getProperty("stubrunner.stubs-mode", "CLASSPATH"))
+				.withStubsMode(System.getProperty("stubrunner.stubs-mode", "LOCAL"))
 				.withStubsClassifier(System.getProperty("stubrunner.classifier", "stubs"))
 				.withStubs(System.getProperty("stubrunner.ids", ""))
 				.withUsername(System.getProperty("stubrunner.username"))

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerConfiguration.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerConfiguration.java
@@ -74,7 +74,7 @@ public class StubRunnerConfiguration {
 		}
 		StubRunnerOptions stubRunnerOptions = builder.build();
 		BatchStubRunner batchStubRunner = new BatchStubRunnerFactory(stubRunnerOptions,
-				this.provider.getOrDefaultDownloader(stubRunnerOptions),
+				this.provider.get(stubRunnerOptions),
 				this.contractVerifierMessaging != null ? this.contractVerifierMessaging
 						: new NoOpStubMessages()).buildBatchStubRunner();
 		// TODO: Consider running it in a separate thread

--- a/spring-cloud-contract-stub-runner/src/test/java/org/springframework/cloud/contract/stubrunner/ClasspathStubProviderTest.java
+++ b/spring-cloud-contract-stub-runner/src/test/java/org/springframework/cloud/contract/stubrunner/ClasspathStubProviderTest.java
@@ -1,0 +1,19 @@
+package org.springframework.cloud.contract.stubrunner;
+
+import org.junit.Test;
+import org.springframework.cloud.contract.stubrunner.spring.StubRunnerProperties;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+/**
+ * @author Marcin Grzejszczak
+ */
+public class ClasspathStubProviderTest {
+
+	@Test public void should_return_null_if_stub_mode_is_not_classpath() {
+		StubDownloader stubDownloader = new ClasspathStubProvider().build(new StubRunnerOptionsBuilder().withStubsMode(
+				StubRunnerProperties.StubsMode.REMOTE).build());
+
+		then(stubDownloader).isNull();
+	}
+}

--- a/spring-cloud-contract-stub-runner/src/test/java/org/springframework/cloud/contract/stubrunner/CompositeStubDownloaderBuilderTests.java
+++ b/spring-cloud-contract-stub-runner/src/test/java/org/springframework/cloud/contract/stubrunner/CompositeStubDownloaderBuilderTests.java
@@ -1,0 +1,88 @@
+package org.springframework.cloud.contract.stubrunner;
+
+import java.io.File;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.assertj.core.api.BDDAssertions;
+import org.junit.Test;
+
+/**
+ * @author Marcin Grzejszczak
+ */
+public class CompositeStubDownloaderBuilderTests {
+
+	@Test public void should_delegate_work_to_other_stub_downloaders() {
+		EmptyStubDownloaderBuilder emptyStubDownloaderBuilder = new EmptyStubDownloaderBuilder();
+		ImpossibleToBuildStubDownloaderBuilder impossible = new ImpossibleToBuildStubDownloaderBuilder();
+		List<StubDownloaderBuilder> builders = Arrays.asList(emptyStubDownloaderBuilder, impossible, new SomeStubDownloaderBuilder());
+		CompositeStubDownloaderBuilder builder = new CompositeStubDownloaderBuilder(builders);
+		StubDownloader downloader = builder.build(new StubRunnerOptionsBuilder().build());
+
+		Map.Entry<StubConfiguration, File> entry = downloader
+				.downloadAndUnpackStubJar(new StubConfiguration("a:b:v"));
+
+		BDDAssertions.then(entry).isNotNull();
+		BDDAssertions.then(emptyStubDownloaderBuilder.downloaderCalled()).isTrue();
+		BDDAssertions.then(impossible.called).isTrue();
+	}
+
+	@Test public void should_return_null_if_no_builders_were_passed() {
+		CompositeStubDownloaderBuilder builder = new CompositeStubDownloaderBuilder(null);
+
+		StubDownloader downloader = builder.build(new StubRunnerOptionsBuilder().build());
+
+		BDDAssertions.then(downloader).isNull();
+	}
+}
+
+class EmptyStubDownloaderBuilder implements StubDownloaderBuilder {
+
+	EmptyStubDownloader emptyStubDownloader;
+
+	@Override public StubDownloader build(StubRunnerOptions stubRunnerOptions) {
+		this.emptyStubDownloader = new EmptyStubDownloader();
+		return this.emptyStubDownloader;
+	}
+
+	boolean downloaderCalled() {
+		return this.emptyStubDownloader.called;
+	}
+}
+
+class ImpossibleToBuildStubDownloaderBuilder implements StubDownloaderBuilder {
+
+	boolean called;
+
+	@Override public StubDownloader build(StubRunnerOptions stubRunnerOptions) {
+		this.called = true;
+		return null;
+	}
+
+}
+
+class EmptyStubDownloader implements StubDownloader {
+	boolean called;
+
+	@Override public Map.Entry<StubConfiguration, File> downloadAndUnpackStubJar(
+			StubConfiguration stubConfiguration) {
+		this.called = true;
+		return null;
+	}
+}
+
+class SomeStubDownloaderBuilder implements StubDownloaderBuilder {
+
+	@Override public StubDownloader build(StubRunnerOptions stubRunnerOptions) {
+		return new SomeStubDownloader();
+	}
+}
+
+class SomeStubDownloader implements StubDownloader {
+	@Override public Map.Entry<StubConfiguration, File> downloadAndUnpackStubJar(
+			StubConfiguration stubConfiguration) {
+		return new AbstractMap.SimpleEntry<>(stubConfiguration, new File("."));
+	}
+}

--- a/spring-cloud-contract-stub-runner/src/test/java/org/springframework/cloud/contract/stubrunner/StubDownloaderBuilderProviderTests.java
+++ b/spring-cloud-contract-stub-runner/src/test/java/org/springframework/cloud/contract/stubrunner/StubDownloaderBuilderProviderTests.java
@@ -1,0 +1,37 @@
+package org.springframework.cloud.contract.stubrunner;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.BDDMockito;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author Marcin Grzejszczak
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class StubDownloaderBuilderProviderTests {
+
+	@Mock StubDownloaderBuilder one;
+	@Mock StubDownloaderBuilder two;
+	@Mock StubDownloaderBuilder three;
+
+	@Test public void should_get_providers_from_factories_default_and_additional_ones() {
+		StubDownloaderBuilderProvider provider = new StubDownloaderBuilderProvider(Collections.singletonList(one)) {
+			@Override List<StubDownloaderBuilder> defaultStubDownloaderBuilders() {
+				return Collections.singletonList(two);
+			}
+		};
+		StubRunnerOptions options = new StubRunnerOptionsBuilder().build();
+
+		provider.get(options, three)
+				.downloadAndUnpackStubJar(new StubConfiguration("a:b:c"));
+
+		BDDMockito.then(one).should().build(options);
+		BDDMockito.then(two).should().build(options);
+		BDDMockito.then(three).should().build(options);
+	}
+}

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/GradleContractsDownloader.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/GradleContractsDownloader.groovy
@@ -87,7 +87,7 @@ class GradleContractsDownloader {
 		if (extension.contractRepository.proxyPort) {
 			options = options.withProxy(extension.contractRepository.proxyHost, extension.contractRepository.proxyPort)
 		}
-		return provider.getOrDefaultDownloader(options.build())
+		return provider.get(options.build())
 	}
 
 	@PackageScope StubConfiguration stubConfiguration(ContractVerifierExtension.Dependency contractDependency) {

--- a/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/ConvertMojo.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/ConvertMojo.java
@@ -181,8 +181,8 @@ public class  ConvertMojo extends AbstractMojo {
 		config.setExcludeBuildFolders(this.excludeBuildFolders);
 		File contractsDirectory = new MavenContractsDownloader(this.project, this.contractDependency,
 				this.contractsPath, this.contractsRepositoryUrl, this.contractsMode, getLog(),
-				this.aetherStubDownloaderFactory, this.repoSession, this.contractsRepositoryUsername,
-				this.contractsRepositoryPassword, this.contractsRepositoryProxyHost, this.contractsRepositoryProxyPort,
+				this.contractsRepositoryUsername, this.contractsRepositoryPassword,
+				this.contractsRepositoryProxyHost, this.contractsRepositoryProxyPort,
 				this.contractsSnapshotCheckSkip, this.deleteStubsAfterTest)
 				.downloadAndUnpackContractsIfRequired(config, this.contractsDirectory);
 		getLog().info("Directory with contract is present at [" + contractsDirectory + "]");

--- a/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/GenerateTestsMojo.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/GenerateTestsMojo.java
@@ -230,7 +230,6 @@ public class GenerateTestsMojo extends AbstractMojo {
 		// download contracts, unzip them and pass as output directory
 		File contractsDirectory = new MavenContractsDownloader(this.project, this.contractDependency,
 				this.contractsPath, this.contractsRepositoryUrl, this.contractsMode, getLog(),
-				this.aetherStubDownloaderFactory, this.repoSession,
 				this.contractsRepositoryUsername, this.contractsRepositoryPassword,
 				this.contractsRepositoryProxyHost, this.contractsRepositoryProxyPort,
 				this.contractsSnapshotCheckSkip, this.deleteStubsAfterTest).downloadAndUnpackContractsIfRequired(config, this.contractsDirectory);

--- a/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/stubrunner/AetherStubDownloaderFactory.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/stubrunner/AetherStubDownloaderFactory.java
@@ -19,15 +19,21 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.springframework.cloud.contract.stubrunner.AetherStubDownloader;
 import org.springframework.cloud.contract.stubrunner.StubDownloader;
+import org.springframework.cloud.contract.stubrunner.StubDownloaderBuilder;
+import org.springframework.cloud.contract.stubrunner.StubRunnerOptions;
 
 @Named
 @Singleton
 public class AetherStubDownloaderFactory {
+	private static final Log log = LogFactory.getLog(AetherStubDownloaderFactory.class);
+
 	private final MavenProject project;
 	private final RepositorySystem repoSystem;
 
@@ -38,8 +44,13 @@ public class AetherStubDownloaderFactory {
 		this.project = project;
 	}
 
-	public StubDownloader build(RepositorySystemSession repoSession) {
-		return new AetherStubDownloader(this.repoSystem,
-				this.project.getRemoteProjectRepositories(), repoSession);
+	public StubDownloaderBuilder build(final RepositorySystemSession repoSession) {
+		return new StubDownloaderBuilder() {
+			@Override public StubDownloader build(StubRunnerOptions stubRunnerOptions) {
+				log.info("Will download contracts using current build's Maven repository setup");
+				return new AetherStubDownloader(AetherStubDownloaderFactory.this.repoSystem,
+						AetherStubDownloaderFactory.this.project.getRemoteProjectRepositories(), repoSession);
+			}
+		};
 	}
 }

--- a/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/stubrunner/RemoteStubRunner.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/stubrunner/RemoteStubRunner.java
@@ -39,7 +39,7 @@ public class RemoteStubRunner {
 	}
 
 	public BatchStubRunner run(StubRunnerOptions options, RepositorySystemSession repositorySystemSession) {
-		StubDownloader stubDownloader = this.aetherStubDownloaderFactory.build(repositorySystemSession);
+		StubDownloader stubDownloader = this.aetherStubDownloaderFactory.build(repositorySystemSession).build(options);
 		try {
 			if (log.isDebugEnabled()) {
 				log.debug("Launching StubRunner with args: " + options);


### PR DESCRIPTION
with this change we try to retrieve a list of builders of stub runner downloaders. The idea is that if a builder can't build a stub runner downloader, it returns null. If a stub runner downloader can't download an artifact it returns null. That way we can iterate over builders and try to point to unpacked stubs when applicable. No longer do we pick only one applicatble builder. We pick the first matching one.

first attempt to work with #580 