### PR TITLE
Avoid body parsing for HEAD request

### DIFF
--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JaxRsClientJUnitMethodBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JaxRsClientJUnitMethodBodyBuilder.groovy
@@ -73,7 +73,9 @@ class JaxRsClientJUnitMethodBodyBuilder extends JUnitMethodBodyBuilder {
 		bb.unindent()
 
 		bb.addEmptyLine()
-		bb.addLine("String responseAsString = response.readEntity(String.class);")
+		if (expectsResponseBody()) {
+			bb.addLine("String responseAsString = response.readEntity(String.class);")
+		}
 	}
 
 	protected void appendUrlPathAndQueryParameters(BlockBuilder bb) {

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JaxRsClientSpockMethodRequestProcessingBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JaxRsClientSpockMethodRequestProcessingBodyBuilder.groovy
@@ -69,7 +69,9 @@ class JaxRsClientSpockMethodRequestProcessingBodyBuilder extends SpockMethodRequ
 		bb.unindent()
 
 		bb.addEmptyLine()
-		bb.addLine("String responseAsString = response.readEntity(String)")
+		if (expectsResponseBody()) {
+			bb.addLine("String responseAsString = response.readEntity(String)")
+		}
 	}
 
 	protected void appendRequestWithRequiredResponseContentType(BlockBuilder bb) {

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/RequestProcessingMethodBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/RequestProcessingMethodBodyBuilder.groovy
@@ -74,6 +74,13 @@ abstract class RequestProcessingMethodBodyBuilder extends MethodBodyBuilder {
 	}
 
 	/**
+	 * Returns {@code true} if a response body is expected
+	 */
+	protected boolean expectsResponseBody() {
+		return response.body != null;
+	}
+
+	/**
 	 * Returns {@code true} if the query parameter is allowed
 	 */
 	protected boolean allowedQueryParameter(QueryParameter param) {


### PR DESCRIPTION
Maybe this is behaviour more users would find helpful.

We had an issue with a failing build due to FindBugs running over the generated verifier tests (now added to the excluded packages).

In the case of `HEAD` the `responseAsString` was not used and FindBugs cried "unused variable" and failed.

Of course it could be improved upon. Something along the lines of ```IF assert on response THEN parse response```

But IMHO this would go against the spec for [HEAD](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD)