### PR TITLE
snapshotCheckSkip javadoc enhancement

### DIFF
--- a/docs/src/main/asciidoc/verifier_setup.adoc
+++ b/docs/src/main/asciidoc/verifier_setup.adoc
@@ -261,7 +261,7 @@ closure to set it up.
 * *contractsMode*: Specifies the mode of downloading contracts (whether the
 JAR is available offline, remotely etc.)
 * *contractsSnapshotCheckSkip*: If set to `true` will not assert whether the
-downloaded stubs / contract JAR was downloaded from a remote location or a local one
+downloaded stubs / contract JAR was downloaded from a remote location or a local one(only applicable to Maven repos, not Git or Pact).
 * *deleteStubsAfterTest*: If set to `false` will not remove any downloaded
 contracts from temporary directories
 

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerOptions.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerOptions.java
@@ -103,7 +103,7 @@ public class StubRunnerOptions {
 
 	/**
 	 * If set to {@code true} will not assert whether the downloaded stubs / contract
-	 * JAR was downloaded from a remote location or a local one
+	 * JAR was downloaded from a remote location or a local one(only applicable to Maven repos, not Git or Pact)
 	 */
 	private boolean snapshotCheckSkip;
 

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/junit/StubRunnerRuleOptions.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/junit/StubRunnerRuleOptions.java
@@ -97,7 +97,7 @@ interface StubRunnerRuleOptions {
 
 	/**
 	 * If set to {@code true} will not assert whether the downloaded stubs / contract
-	 * JAR was downloaded from a remote location or a local one
+	 * JAR was downloaded from a remote location or a local one(only applicable to Maven repos, not Git or Pact)
 	 */
 	StubRunnerRule withSnapshotCheckSkip(boolean snapshotCheckSkip);
 

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/AutoConfigureStubRunner.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/AutoConfigureStubRunner.java
@@ -111,7 +111,7 @@ public @interface AutoConfigureStubRunner {
 
 	/**
 	 * If set to {@code true} will not assert whether the downloaded stubs / contract
-	 * JAR was downloaded from a remote location or a local one
+	 * JAR was downloaded from a remote location or a local one(only applicable to Maven repos, not Git or Pact)
 	 */
 	boolean snapshotCheckSkip() default false;
 

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerProperties.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerProperties.java
@@ -101,7 +101,7 @@ public class StubRunnerProperties {
 
 	/**
 	 * If set to {@code true} will not assert whether the downloaded stubs / contract
-	 * JAR was downloaded from a remote location or a local one
+	 * JAR was downloaded from a remote location or a local one(only applicable to Maven repos, not Git or Pact)
 	 */
 	private boolean snapshotCheckSkip;
 

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/ContractVerifierExtension.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/ContractVerifierExtension.groovy
@@ -174,7 +174,7 @@ class ContractVerifierExtension {
 
 	/**
 	 * If set to {@code true} will not assert whether the downloaded stubs / contract
-	 * JAR was downloaded from a remote location or a local one
+	 * JAR was downloaded from a remote location or a local one(only applicable to Maven repos, not Git or Pact)
 	 */
 	boolean contractsSnapshotCheckSkip = false
 


### PR DESCRIPTION
@marcingrzejszczak, I will start small:)

Do you think it can be useful? Otherwise it can be confusing because stubs jar will still be in the local repo even when Git is used.