### PR TITLE
Clarifying behaviour of Aether artifact downloader for transitive dependencies

### DIFF
--- a/docs/src/main/asciidoc/verifier_setup.adoc
+++ b/docs/src/main/asciidoc/verifier_setup.adoc
@@ -902,7 +902,7 @@ In order to fix this issue, provide the following section in your `pom.xml`:
 
 === Stubs and Transitive Dependencies
 
-The Maven and Gradle plugin that add the tasks that create the stubs jar for you. One
+The Maven or Gradle plugin should be used to add the tasks that create the stubs jar for you. One
 problem that arises is that, when reusing the stubs, you can mistakenly import all of
 that stub's dependencies. When building a Maven artifact, even though you have a couple
 of different jars, all of them share one pom:
@@ -919,6 +919,8 @@ of different jars, all of them share one pom:
 ├── ...
 └── ...
 ----
+NOTE: Stub Runner will not load transitive dependencies by default, so if you are not
+adding stubs directly, you have nothing to worry about.
 
 There are three possibilities of working with those dependencies so as not to have any
 issues with transitive dependencies:
@@ -930,8 +932,7 @@ issues with transitive dependencies:
 *Mark all application dependencies as optional*
 
 If, in the `github-webhook` application, you mark all of your dependencies as optional,
-when you include the `github-webhook` stubs in another application (or when that
-dependency gets downloaded by Stub Runner) then, since all of the dependencies are
+when you include the `github-webhook` stubs in another application then, since all of the dependencies are
 optional, they will not get downloaded.
 
 *Create a separate `artifactid` for the stubs*


### PR DESCRIPTION
@marcingrzejszczak , my suggestion here might be wrong, but I was not able to reproduce transitive dependencies loading and wanted to grab your attention to this peace of documentation.

My steps: I'm adding some absolutely random dependencies to my producer. I build a producer with its stubs. Afterwards I clean-up .m2.
Naturally, the next step is to build a consumer. And when I do so, I don't find the dependencies needed for producer downloaded into .m2.

I'm not an expert in Aether, but it will probably require a bit more logic to download transitive dependencies, like in this [example](http://wiki.eclipse.org/Aether/Resolving_Dependencies). And, luckily, I don't see any code akin to this anywhere in `spring-cloud-contract`.

This part of documentation can do with a bit of improvement anyway. Let me know if my suggestion is wrong, so that I can at least refactor what is already there.