### PR TITLE
Credential properties for pact broker

### DIFF
--- a/docs/src/main/asciidoc/verifier_contract.adoc
+++ b/docs/src/main/asciidoc/verifier_contract.adoc
@@ -1718,7 +1718,7 @@ properties
 
 .SCM Stub Downloader properties
 |===
-|Type of a property |Name of the property | Description
+|Name of a property |Default | Description
 |
 * `pactbroker.host` (plugin prop)
 
@@ -1770,7 +1770,7 @@ properties
 * `stubrunner.properties.pactbroker.auth.username` (system prop)
 
 * `STUBRUNNER_PROPERTIES_PACTBROKER_AUTH_USERNAME` (env prop)
-|
+|The username passed to `contractsRepositoryUsername` (maven) or `contractRepository.username` (gradle)
 |Username used to connect to the Pact Broker
 
 |
@@ -1779,7 +1779,7 @@ properties
 * `stubrunner.properties.pactbroker.auth.password` (system prop)
 
 * `STUBRUNNER_PROPERTIES_PACTBROKER_AUTH_PASSWORD` (env prop)
-|
+|The password passed to `contractsRepositoryPassword` (maven) or `contractRepository.password` (gradle)
 |Password used to connect to the Pact Broker
 
 |

--- a/spring-cloud-contract-tools/spring-cloud-contract-pact/src/main/groovy/org/springframework/cloud/contract/stubrunner/PactStubDownloaderBuilder.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-pact/src/main/groovy/org/springframework/cloud/contract/stubrunner/PactStubDownloaderBuilder.java
@@ -238,6 +238,8 @@ class PactStubDownloader implements StubDownloader {
 		Resource repo = this.stubRunnerOptions.getStubRepositoryRoot();
 		String schemeSpecificPart = schemeSpecificPart(repo.getURI());
 		URI pactBrokerUrl = URI.create(schemeSpecificPart);
+		String stubRunnerUsername = this.stubRunnerOptions.getUsername();
+		String stubRunnerPassword = this.stubRunnerOptions.getPassword();
 		return new PactBrokerLoader(new PactBroker() {
 
 			@Override public Class<? extends Annotation> annotationType() {
@@ -271,15 +273,15 @@ class PactStubDownloader implements StubDownloader {
 					}
 
 					@Override public String scheme() {
-						return resolver.resolveValue("pactbroker.auth.scheme:basic");
+						return resolver.resolveValue("pactbroker.auth.scheme:Basic");
 					}
 
 					@Override public String username() {
-						return resolver.resolveValue("pactbroker.auth.username:");
+						return resolver.resolveValue("pactbroker.auth.username:" + stubRunnerUsername);
 					}
 
 					@Override public String password() {
-						return resolver.resolveValue("pactbroker.auth.password:");
+						return resolver.resolveValue("pactbroker.auth.password:" + stubRunnerPassword);
 					}
 				};
 			}

--- a/spring-cloud-contract-tools/spring-cloud-contract-pact/src/main/groovy/org/springframework/cloud/contract/stubrunner/PactStubDownloaderBuilder.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-pact/src/main/groovy/org/springframework/cloud/contract/stubrunner/PactStubDownloaderBuilder.java
@@ -59,6 +59,7 @@ import org.springframework.util.StringUtils;
  * Allows downloading of Pact files from the Pact Broker.
  *
  * @author Marcin Grzejszczak
+ * @author Tim Ysewyn
  * @since 2.0.0
  */
 public final class PactStubDownloaderBuilder implements StubDownloaderBuilder {

--- a/spring-cloud-contract-tools/spring-cloud-contract-pact/src/test/groovy/org/springframework/cloud/contract/stubrunner/PactStubDownloaderBuilderSpec.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-pact/src/test/groovy/org/springframework/cloud/contract/stubrunner/PactStubDownloaderBuilderSpec.groovy
@@ -15,6 +15,7 @@ import org.springframework.cloud.contract.verifier.spec.pact.PactContractConvert
 
 /**
  * @author Marcin Grzejszczak
+ * @author Tim Ysewyn
  */
 class PactStubDownloaderBuilderSpec extends Specification {
 
@@ -111,4 +112,28 @@ class PactStubDownloaderBuilderSpec extends Specification {
 	//			throw new RuntimeException(e)
 	//		}
 	//	}
+
+	def "should retrieve pacts from broker using stubrunner options"() throws IOException {
+		given:
+			StubRunnerOptions options = new StubRunnerOptionsBuilder()
+					.withStubRepositoryRoot("pact://https://test.pact.dius.com.au:443")
+					.withUsername("dXfltyFMgNOFZAxr8io9wJ37iUpY42M")
+					.withPassword("O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1")
+					.build()
+			PactStubDownloader downloader = new PactStubDownloader(options)
+		when:
+			Map.Entry<StubConfiguration, File> entry = downloader
+					.downloadAndUnpackStubJar(new StubConfiguration("com.example:bobby:+:classifier"))
+		then:
+			entry != null
+			entry.getValue().exists()
+			File contracts = new File(entry.getValue(), "com/example/bobby/contracts")
+			contracts.exists()
+			contracts.list() != null
+			contracts.list().size() > 0
+			File mappings = new File(entry.getValue(), "com/example/bobby/mappings")
+			mappings.exists()
+			mappings.list() != null
+			mappings.list().size() > 0
+	}
 }


### PR DESCRIPTION
Fallback to `contractsRepositoryUsername` and `contractsRepositoryPassword` (maven) or `contractRepository.username` and `contractRepository.password` (gradle) in case the pact broker options for the username and password are not set.

Closes #636