### PR TITLE
Improve docs on contract priority

### DIFF
--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/Contract.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/Contract.groovy
@@ -37,7 +37,7 @@ class Contract {
 	/**
 	 * You can set the level of priority of this contract. If there are two contracts
 	 * mapped for example to the same endpoint, then the one with greater priority should
-	 * take precedence
+	 * take precedence. A priority of 1 is highest and takes precedence over a priority of 2.
 	 */
 	Integer priority
 	/**


### PR DESCRIPTION
Ultra minor change.

The wording of `greater priority` led to an issue in a project where a contract with `priority(999)` (supposedly match first) and `priority(888)` (supposedly match second) was created. The example how `priority(1)` would match before `priority(2)` would have resolved this I guess :)