### PR TITLE
Move YamlContractConverter list of available contract converters.

### DIFF
--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/file/ContractFileScanner.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/file/ContractFileScanner.groovy
@@ -88,6 +88,7 @@ class ContractFileScanner {
 	 */
 	private void appendRecursively(File baseDir, ListMultimap<Path, ContractMetadata> result) {
 		List<ContractConverter> converters = converters()
+		converters.add(YamlContractConverter.INSTANCE)
 		if (log.isTraceEnabled()) {
 			log.trace("Found the following contract converters ${converters}")
 		}
@@ -104,8 +105,6 @@ class ContractFileScanner {
 				boolean included = includeMatcher ? file.absolutePath.matches(includeMatcher) : true
 				if (contractFile && included) {
 					addContractToTestGeneration(result, files, file, i, ContractVerifierDslConverter.convertAsCollection(baseDir, file))
-				} else if (YamlContractConverter.INSTANCE.isAccepted(file) && included) {
-					addContractToTestGeneration(result, files, file, i, YamlContractConverter.INSTANCE.convertFrom(file))
 				} else if (!contractFile && included) {
 					addContractToTestGeneration(converters, result, files, file, i)
 				} else {

--- a/spring-cloud-contract-verifier/src/test/resources/directory/with/custom/yml/custom.yml
+++ b/spring-cloud-contract-verifier/src/test/resources/directory/with/custom/yml/custom.yml
@@ -1,0 +1,16 @@
+custom_format: 1.0
+outbound:
+  request:
+    url: /foo
+    method: PUT
+    headers:
+      foo: bar
+    body:
+      foo: bar
+inbound:
+  response:
+    status: 200
+    headers:
+      foo2: bar
+    body:
+      foo2: bar


### PR DESCRIPTION
Currently, the YamlContractConverter is used for any file that ends with .yaml or .yml. However, if I specify my custom converter for yaml files - like Swagger or OpenAPI or any other custom format - the YamlContractConverter is chosen as first option.

Whether or not it makes sense to write a custom converter for other yaml formats, Spring Cloud Contract should be flexible and extensible. 