### PR TITLE
bump camel version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 	<properties>
 		<activemq.version>5.12.1</activemq.version>
-		<camel.version>2.18.3</camel.version>
+		<camel.version>2.21.2</camel.version>
 		<checkstyle.version>2.17</checkstyle.version>
 		<spring-cloud-build.version>1.3.10.RELEASE</spring-cloud-build.version>
 		<spring-cloud-zookeeper.version>1.2.2.BUILD-SNAPSHOT</spring-cloud-zookeeper.version>

--- a/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/messaging/camel/CamelStubMessages.java
+++ b/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/messaging/camel/CamelStubMessages.java
@@ -64,7 +64,7 @@ public class CamelStubMessages implements MessageVerifier<Message> {
 
 	@Override
 	public <T> void send(T payload, Map<String, Object> headers, String destination) {
-		send(this.builder.create(payload, headers), destination);
+		send(this.builder.create(this.context, payload, headers), destination);
 	}
 
 	@Override

--- a/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/messaging/camel/ContractVerifierCamelMessageBuilder.java
+++ b/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/messaging/camel/ContractVerifierCamelMessageBuilder.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.contract.verifier.messaging.camel;
 
 import java.util.Map;
 
+import org.apache.camel.CamelContext;
 import org.apache.camel.Message;
 import org.apache.camel.impl.DefaultMessage;
 
@@ -26,8 +27,8 @@ import org.apache.camel.impl.DefaultMessage;
  */
 class ContractVerifierCamelMessageBuilder {
 
-	public <T> Message create(T payload, Map<String, Object> headers) {
-		DefaultMessage message = new DefaultMessage();
+	public <T> Message create(CamelContext camelContext, T payload, Map<String, Object> headers) {
+		DefaultMessage message = new DefaultMessage(camelContext);
 		message.setBody(payload);
 		message.setHeaders(headers);
 		return message;


### PR DESCRIPTION
Spring Cloud Contract can not be used with new version of Camel due to usage of deprecated constructor of DefaultMessage, which as of now requires an instance of CamelContext.