### PR TITLE
Improved spring-cloud-wiremock documentation

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-wiremock.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-wiremock.adoc
@@ -27,7 +27,7 @@ To start the stub server on a different port use (for example),
 server port can be bound in the test application context with the "wiremock.server.port"
 property. Using `@AutoConfigureWireMock` adds a bean of type `WiremockConfiguration` to
 your test application context, where it will be cached in between methods and classes
-having the same context, the same as for Spring integration tests.
+having the same context, the same as for Spring integration tests. Also you can inject a bean of type `WireMockServer` into your test. 
 
 === Registering Stubs Automatically
 


### PR DESCRIPTION
Sometimes people want to use methods like `addMockServiceRequestListener`, which are not static. But there is no any notes about  `WireMockServer` in spring-cloud-wiremock documentation. 

I saw how the developers did not know about it and made a mistake. 
They mixed junit4 and junit5 even for new services, because `WireMockRule` inherits from `WireMockServer` and  provides non static methods.

This situation may seem funny, but many can get into it.