### PR TITLE
Configure for WireMockServer instead of port

### DIFF
--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockConfiguration.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockConfiguration.java
@@ -162,7 +162,7 @@ public class WireMockConfiguration implements SmartLifecycle {
 	@Override
 	public void start() {
 		this.server.start();
-		WireMock.configureFor("localhost", this.server.port());
+		WireMock.configureFor(new WireMock(this.server));
 		this.running = true;
 		if (log.isDebugEnabled()) {
 			log.debug("Started WireMock at port [" + this.server.port() + "]. It has ["


### PR DESCRIPTION
When port = 0, WireMock will assign different ports for admin server and mock server. As a result, the original implementation will send admin HTTP requests to mock server, which is wrong behavior.

If this PR got merged, WireMock will directly add stubs via internal Java interface instead of sending admin HTTP requests, which is correct behavior and also improves performance.