### PR TITLE
Sets web-application-type depending on presence of WebMvc / WebFlux

### DIFF
--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockEnvironmentPostProcessor.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockEnvironmentPostProcessor.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.contract.wiremock;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySource;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * Sets the web application type depending on presence of WebMvc / WebFlux API
+ *
+ * @author Marcin Grzejszczak
+ * @since 2.0.3
+ */
+public class WireMockEnvironmentPostProcessor implements EnvironmentPostProcessor {
+	private static final Log log = LogFactory
+			.getLog(WireMockEnvironmentPostProcessor.class);
+
+	private static final String SPRING_MAIN_WEB_APP_TYPE = "spring.main.web-application-type";
+	private static final String PROPERTY_SOURCE_NAME = "defaultProperties";
+
+	@Override
+	public void postProcessEnvironment(ConfigurableEnvironment environment,
+			SpringApplication application) {
+		Map<String, Object> map = new HashMap<>();
+		String webApplicationTypeFromProps = environment
+				.getProperty(SPRING_MAIN_WEB_APP_TYPE);
+		if (StringUtils.isEmpty(webApplicationTypeFromProps)) {
+			WebApplicationType webApplicationType = application.getWebApplicationType();
+			String webApplicationTypeName = WebApplicationType.NONE.name();
+			if (WebApplicationType.NONE != webApplicationType) {
+				webApplicationTypeName = isWebMvcApplication(application.getClassLoader()) ?
+						WebApplicationType.SERVLET.name() : isReactiveApplication(application.getClassLoader()) ?
+						WebApplicationType.REACTIVE.name() : WebApplicationType.NONE.name();
+			}
+			if (log.isDebugEnabled()) {
+				log.debug("Setting [" + SPRING_MAIN_WEB_APP_TYPE + "] with value [" + webApplicationTypeName + "]");
+			}
+			map.put(SPRING_MAIN_WEB_APP_TYPE, webApplicationTypeName);
+			addOrReplace(environment.getPropertySources(), map);
+		}
+		else if (log.isDebugEnabled()) {
+			log.debug("Value of [" + SPRING_MAIN_WEB_APP_TYPE + "] already set to [" + webApplicationTypeFromProps + "]");
+		}
+	}
+
+	private void addOrReplace(MutablePropertySources propertySources,
+			Map<String, Object> map) {
+		MapPropertySource target = null;
+		if (propertySources.contains(PROPERTY_SOURCE_NAME)) {
+			PropertySource<?> source = propertySources.get(PROPERTY_SOURCE_NAME);
+			if (source instanceof MapPropertySource) {
+				target = (MapPropertySource) source;
+				for (String key : map.keySet()) {
+					if (!target.containsProperty(key)) {
+						target.getSource().put(key, map.get(key));
+					}
+				}
+			}
+		}
+		if (target == null) {
+			target = new MapPropertySource(PROPERTY_SOURCE_NAME, map);
+		}
+		if (!propertySources.contains(PROPERTY_SOURCE_NAME)) {
+			propertySources.addLast(target);
+		}
+	}
+
+	boolean isReactiveApplication(ClassLoader classLoader) {
+		return ClassUtils.isPresent("org.springframework.web.reactive.DispatcherHandler",
+				classLoader);
+	}
+
+	boolean isWebMvcApplication(ClassLoader classLoader) {
+		return ClassUtils.isPresent("org.springframework.web.servlet.DispatcherServlet",
+				classLoader);
+	}
+
+}

--- a/spring-cloud-contract-wiremock/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-contract-wiremock/src/main/resources/META-INF/spring.factories
@@ -11,3 +11,7 @@ org.springframework.cloud.contract.wiremock.restdocs.WireMockRestAssuredConfigur
 # Test Execution Listeners
 org.springframework.test.context.TestExecutionListener=\
 org.springframework.cloud.contract.wiremock.WireMockTestExecutionListener
+
+# Environment Post Processor
+org.springframework.boot.env.EnvironmentPostProcessor=\
+org.springframework.cloud.contract.wiremock.WireMockEnvironmentPostProcessor

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/WireMockEnvironmentPostProcessorTests.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/WireMockEnvironmentPostProcessorTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.contract.wiremock;
+
+import org.assertj.core.api.BDDAssertions;
+import org.junit.Test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.mock.env.MockEnvironment;
+
+public class WireMockEnvironmentPostProcessorTests {
+
+	MockEnvironment environment = new MockEnvironment();
+	SpringApplication springApplication = new SpringApplication();
+
+	@Test
+	public void should_pass_current_web_application_type() {
+		WireMockEnvironmentPostProcessor processor = new WireMockEnvironmentPostProcessor();
+		this.springApplication.setWebApplicationType(WebApplicationType.NONE);
+
+		processor.postProcessEnvironment(this.environment, this.springApplication);
+
+		BDDAssertions.then(this.environment.getProperty("spring.main.web-application-type"))
+				.isEqualToIgnoringCase("none");
+	}
+
+	@Test
+	public void should_pass_current_web_application_type_from_properties() {
+		WireMockEnvironmentPostProcessor processor = new WireMockEnvironmentPostProcessor();
+		this.environment.setProperty("spring.main.web-application-type", "none");
+
+		processor.postProcessEnvironment(this.environment, this.springApplication);
+
+		BDDAssertions.then(this.environment.getProperty("spring.main.web-application-type"))
+				.isEqualToIgnoringCase("none");
+	}
+
+	@Test
+	public void should_set_reactive_when_reactive_class_is_found() {
+		WireMockEnvironmentPostProcessor processor = new WireMockEnvironmentPostProcessor() {
+			@Override
+			boolean isWebMvcApplication(ClassLoader classLoader) {
+				return false;
+			}
+
+			@Override
+			boolean isReactiveApplication(ClassLoader classLoader) {
+				return true;
+			}
+		};
+		this.springApplication.setWebApplicationType(WebApplicationType.SERVLET);
+
+		processor.postProcessEnvironment(this.environment, this.springApplication);
+
+		BDDAssertions.then(this.environment.getProperty("spring.main.web-application-type"))
+				.isEqualToIgnoringCase("REACTIVE");
+	}
+
+	@Test
+	public void should_set_servlet_when_reactive_class_is_not_found_and_servlet_is_found() {
+		WireMockEnvironmentPostProcessor processor = new WireMockEnvironmentPostProcessor() {
+			@Override
+			boolean isWebMvcApplication(ClassLoader classLoader) {
+				return true;
+			}
+
+			@Override
+			boolean isReactiveApplication(ClassLoader classLoader) {
+				return false;
+			}
+		};
+		this.springApplication.setWebApplicationType(WebApplicationType.REACTIVE);
+
+		processor.postProcessEnvironment(this.environment, this.springApplication);
+
+		BDDAssertions.then(this.environment.getProperty("spring.main.web-application-type"))
+				.isEqualToIgnoringCase("SERVLET");
+	}
+
+	@Test
+	public void should_set_none_when_reactive_and_servlet_classes_are_not_found() {
+		WireMockEnvironmentPostProcessor processor = new WireMockEnvironmentPostProcessor() {
+
+			@Override
+			boolean isWebMvcApplication(ClassLoader classLoader) {
+				return false;
+			}
+
+			@Override
+			boolean isReactiveApplication(ClassLoader classLoader) {
+				return false;
+			}
+		};
+		this.springApplication.setWebApplicationType(WebApplicationType.NONE);
+
+		processor.postProcessEnvironment(this.environment, this.springApplication);
+
+		BDDAssertions.then(this.environment.getProperty("spring.main.web-application-type"))
+				.isEqualToIgnoringCase("NONE");
+	}
+
+}

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/WiremockServerRestAssuredApplicationTests.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/WiremockServerRestAssuredApplicationTests.java
@@ -3,6 +3,8 @@ package org.springframework.cloud.contract.wiremock;
 import io.restassured.specification.RequestSpecification;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import wiremock.org.eclipse.jetty.http.HttpStatus;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.DispatcherServletAutoConfiguration;
@@ -19,7 +21,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-import wiremock.org.eclipse.jetty.http.HttpStatus;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
@@ -27,7 +28,8 @@ import static org.hamcrest.Matchers.is;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT,
+		properties = "spring.main.web-application-type=servlet")
 @AutoConfigureRestDocs(outputDir = "target/snippets")
 public class WiremockServerRestAssuredApplicationTests {
 


### PR DESCRIPTION
without this change, since WireMock is using the Servlet API, Spring Boot falsely assumes that even a reactive application is a servlet one
with this change we first analyze whether WebMvc related classes are present and then we set the web application type

fixes gh-837