### PR TITLE
Workaround for missing message destination in message-pacts

### DIFF
--- a/spring-cloud-contract-tools/spring-cloud-contract-pact/src/main/groovy/org/springframework/cloud/contract/verifier/spec/pact/MessagingSCContractCreator.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-pact/src/main/groovy/org/springframework/cloud/contract/verifier/spec/pact/MessagingSCContractCreator.groovy
@@ -133,6 +133,10 @@ class MessagingSCContractCreator {
 							}
 						}
 					}
+					if (!message.description.isEmpty()) {
+                                            sentTo(message.description);
+					}
+
 				}
 			}
 		})


### PR DESCRIPTION
I use (misuse?) the pact description field for specifying the destination and copy it here into the sentTo field. Pact does not offer much more possibilities here at the moment (I asked there though if it would make sense to add something like that to the message-pact).