### PR TITLE
Workaround for missing message destination in message-pacts

### DIFF
--- a/spring-cloud-contract-tools/spring-cloud-contract-pact/src/main/groovy/org/springframework/cloud/contract/verifier/spec/pact/MessagingSCContractCreator.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-pact/src/main/groovy/org/springframework/cloud/contract/verifier/spec/pact/MessagingSCContractCreator.groovy
@@ -133,6 +133,9 @@ class MessagingSCContractCreator {
 							}
 						}
 					}
+
+                                        sentTo(guessDestination(message));
+
 				}
 			}
 		})
@@ -145,6 +148,14 @@ class MessagingSCContractCreator {
 				.replace('(', '')
 				.replace(')', '')
 				.uncapitalize() + "()"
+	}
+
+	private String guessDestination(Message message) {
+		String[] outcomeParts = message.description.split(' ')
+		if (outcomeParts.length > 0) { 
+			return outcomeParts[outcomeParts.length - 1]		
+		}
+		return ''
 	}
 
 }

--- a/spring-cloud-contract-tools/spring-cloud-contract-pact/src/test/groovy/org/springframework/cloud/contract/verifier/spec/pact/PactContractConverterSpec.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-pact/src/test/groovy/org/springframework/cloud/contract/verifier/spec/pact/PactContractConverterSpec.groovy
@@ -659,6 +659,7 @@ class PactContractConverterSpec extends Specification {
 							triggeredBy('bookReturnedTriggered()')
 						}
 						outputMessage {
+							sentTo 'activemq:output'
 							body([
 								bookName: "foo"
 							])


### PR DESCRIPTION
A suggestion how to use the description field as workaround for the sentTo field. I thought it is similar to the translation from SC contracts to pact where sentTo is used as part of the expectation-description (in MessagePactCreator).