### PR TITLE
Fix WebFlux usage section in docs. Remove unused method for XML processing

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1586,6 +1586,14 @@ NOTE: Actually, WireMock always loads mappings from `src/test/resources/mappings
 well as* the custom locations in the stubs attribute. To change this behavior, you can
 also specify a files root as described in the next section of this document.
 
+If you're using Spring Cloud Contract's default stub jars, then your
+stubs are stored under `/META-INF/group-id/artifact-id/versions/mappings/` folder. If you want to register all stubs from that location, from all embedded JARs, then it's enough to use the following syntax.
+
+[source,java,indent=0]
+----
+@AutoConfigureWireMock(port = 0, stubs = "classpath*:/META-INF/**/mappings/**/*.json")
+----
+
 === Using Files to Specify the Stub Bodies
 
 WireMock can read response bodies from files on the classpath or the file system. In that

--- a/docs/src/main/asciidoc/verifier_contract.adoc
+++ b/docs/src/main/asciidoc/verifier_contract.adoc
@@ -1174,10 +1174,59 @@ context path included (for example, `/my-context-path/url`).
 * Your contracts reflect that you have a context path. Your generated stubs also have
 that information (for example, in the stubs, you have to call `/my-context-path/url`).
 
-=== Working with Web Flux
+=== Working with WebFlux
 
-Spring Cloud Contract requires the usage of `EXPLICIT` mode in your generated tests
-to work with Web Flux.
+Spring Cloud Contract offers two ways of working with WebFlux.
+
+==== WebFlux with WebTestClient
+
+One of them is via the `WebTestClient` mode.
+
+[source,xml,indent=0,subs="verbatim,attributes",role="primary"]
+.Maven
+----
+<plugin>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-contract-maven-plugin</artifactId>
+    <version>${spring-cloud-contract.version}</version>
+    <extensions>true</extensions>
+    <configuration>
+        <testMode>WEBTESTCLIENT</testMode>
+    </configuration>
+</plugin>
+----
+
+[source,groovy,indent=0,subs="verbatim,attributes",role="secondary"]
+.Gradle
+----
+contracts {
+		testMode = 'WEBTESTCLIENT'
+}
+----
+
+The following example shows how to set up a `WebTestClient` base class and `RestAssured`
+for WebFlux:
+
+[source,groovy,indent=0]
+----
+import io.restassured.module.webtestclient.RestAssuredWebTestClient;
+import org.junit.Before;
+
+public abstract class BeerRestBase {
+
+	@Before
+	public void setup() {
+		RestAssuredWebTestClient.standaloneSetup(
+		new ProducerController(personToCheck -> personToCheck.age >= 20));
+	}
+}
+}
+----
+
+==== WebFlux with Explicit mode
+
+Another way is with the `EXPLICIT` mode in your generated tests
+to work with WebFlux.
 
 [source,xml,indent=0,subs="verbatim,attributes",role="primary"]
 .Maven

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JUnitMessagingMethodBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JUnitMessagingMethodBodyBuilder.groovy
@@ -206,11 +206,6 @@ class JUnitMessagingMethodBodyBuilder extends MessagingMethodBodyBuilder {
 	}
 
 	@Override
-	protected String getParsedXmlResponseBodyString(String responseString) {
-		return "Object responseBody = new XmlSlurper().parseText($responseString);"
-	}
-
-	@Override
 	protected String getSimpleResponseBodyString(String responseString) {
 		return "Object responseBody = ($responseString);"
 	}

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JUnitMethodBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JUnitMethodBodyBuilder.groovy
@@ -141,11 +141,6 @@ abstract class JUnitMethodBodyBuilder extends RequestProcessingMethodBodyBuilder
 	}
 
 	@Override
-	protected String getParsedXmlResponseBodyString(String responseString) {
-		return "Object responseBody = new XmlSlurper().parseText($responseString);"
-	}
-
-	@Override
 	protected String getSimpleResponseBodyString(String responseString) {
 		return "String responseBody = $responseString;"
 	}

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/MethodBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/MethodBodyBuilder.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2018 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -265,11 +265,6 @@ abstract class MethodBodyBuilder implements ClassVerifier {
 	protected abstract String getPropertyInListString(String property, Integer index)
 
 	protected abstract String convertUnicodeEscapesIfRequired(String json)
-
-	/**
-	 * NOTE: XML support is experimental
-	 */
-	protected abstract String getParsedXmlResponseBodyString(String responseString)
 
 	/**
 	 * Builds the code that returns String from a body that is plain text

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/SpockMessagingMethodBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/SpockMessagingMethodBodyBuilder.groovy
@@ -194,11 +194,6 @@ class SpockMessagingMethodBodyBuilder extends MessagingMethodBodyBuilder {
 	}
 
 	@Override
-	protected String getParsedXmlResponseBodyString(String responseString) {
-		return "def responseBody = new XmlSlurper().parseText($responseString)"
-	}
-
-	@Override
 	protected String getSimpleResponseBodyString(String responseString) {
 		return "def responseBody = ($responseString)"
 	}

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/SpockMethodRequestProcessingBodyBuilder.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/SpockMethodRequestProcessingBodyBuilder.groovy
@@ -115,11 +115,6 @@ abstract class SpockMethodRequestProcessingBodyBuilder extends RequestProcessing
 	}
 
 	@Override
-	protected String getParsedXmlResponseBodyString(String responseString) {
-		return "def responseBody = new XmlSlurper().parseText($responseString)"
-	}
-
-	@Override
 	protected String getResponseBodyPropertyComparisonString(String property, FromFileProperty value) {
 		if (value.isByte()) {
 			return "response.body.asByteArray() == " +


### PR DESCRIPTION
Remove unused method and implementation for processing xml body verification (class is package-
scope, so not backwards incompatible change).