### PR TITLE
Added default error handler for XmlSlurper to avoid printing annoying

### DIFF
--- a/spring-cloud-contract-tools/spring-cloud-contract-converters/src/main/groovy/org/springframework/cloud/contract/verifier/wiremock/WireMockToDslConverter.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-converters/src/main/groovy/org/springframework/cloud/contract/verifier/wiremock/WireMockToDslConverter.groovy
@@ -208,7 +208,7 @@ ${Contract.name}.make {
 """
 	}
 
-	private static XmlSlurper getXmlSlurperWithDefaultErrorHandler() {
+	 static XmlSlurper getXmlSlurperWithDefaultErrorHandler() {
 		def xmlSlurper = new XmlSlurper()
 		xmlSlurper.setErrorHandler(new DefaultHandler())
 		return xmlSlurper

--- a/spring-cloud-contract-tools/spring-cloud-contract-converters/src/main/groovy/org/springframework/cloud/contract/verifier/wiremock/WireMockToDslConverter.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-converters/src/main/groovy/org/springframework/cloud/contract/verifier/wiremock/WireMockToDslConverter.groovy
@@ -23,6 +23,7 @@ import groovy.json.JsonSlurper
 import groovy.transform.CompileDynamic
 import groovy.xml.XmlUtil
 import org.springframework.cloud.contract.spec.Contract
+import org.xml.sax.helpers.DefaultHandler
 import repackaged.nl.flotsam.xeger.Xeger
 
 import java.nio.charset.StandardCharsets
@@ -123,7 +124,7 @@ class WireMockToDslConverter {
 			return wrapWithMultilineGString(JsonOutput.prettyPrint(responseBody))
 		} catch (Exception jsonException) {
 			try {
-				def xml = new XmlSlurper().parseText(responseBody)
+				def xml = getXmlSlurperWithDefaultErrorHandler().parseText(responseBody)
 				return wrapWithMultilineGString(XmlUtil.serialize(responseBody))
 			} catch (Exception xmlException) {
 				return wrapWithMultilineGString(responseBody)
@@ -205,5 +206,11 @@ ${Contract.name}.make {
 	$dslFromWireMockStub
 }
 """
+	}
+
+	private static XmlSlurper getXmlSlurperWithDefaultErrorHandler() {
+		def xmlSlurper = new XmlSlurper()
+		xmlSlurper.setErrorHandler(new DefaultHandler())
+		return xmlSlurper
 	}
 }

--- a/spring-cloud-contract-tools/spring-cloud-contract-converters/src/test/groovy/org/springframework/cloud/contract/verifier/wiremock/WireMockToDslConverterSpec.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-converters/src/test/groovy/org/springframework/cloud/contract/verifier/wiremock/WireMockToDslConverterSpec.groovy
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.contract.verifier.wiremock
 
+import org.xml.sax.helpers.DefaultHandler
+
 import java.util.regex.Pattern
 
 import spock.lang.Specification
@@ -563,6 +565,13 @@ class WireMockToDslConverterSpec extends Specification {
 				}""").first()
 		and:
 			evaluatedGroovyDsl == expectedGroovyDsl
+	}
+
+	def "should return XmlSlurper with default error handler"() {
+		given:
+		XmlSlurper xmlSlurper = WireMockToDslConverter.getXmlSlurperWithDefaultErrorHandler()
+		expect:
+		xmlSlurper.getErrorHandler() in DefaultHandler
 	}
 
 	void stubMappingIsValidWireMockStub(String mappingDefinition) {

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/util/ContentUtils.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/util/ContentUtils.groovy
@@ -550,7 +550,7 @@ class ContentUtils {
 		return contentType
 	}
 
-	private static XmlSlurper getXmlSlurperWithDefaultErrorHandler() {
+	static XmlSlurper getXmlSlurperWithDefaultErrorHandler() {
 		def xmlSlurper = new XmlSlurper()
 		xmlSlurper.setErrorHandler(new DefaultHandler())
 		return xmlSlurper

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/util/ContentUtils.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/util/ContentUtils.groovy
@@ -17,6 +17,8 @@
 
 package org.springframework.cloud.contract.verifier.util
 
+import org.xml.sax.helpers.DefaultHandler
+
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
@@ -119,7 +121,7 @@ class ContentUtils {
 			return JSON
 		} catch(JsonException e) {
 			try {
-				new XmlSlurper().parseText(extractValueForXML(bodyAsValue, GET_STUB_SIDE).toString())
+				getXmlSlurperWithDefaultErrorHandler().parseText(extractValueForXML(bodyAsValue, GET_STUB_SIDE).toString())
 				return ContentType.XML
 			} catch (Exception ignored) {
 				extractValueForGString(bodyAsValue, GET_STUB_SIDE)
@@ -134,7 +136,7 @@ class ContentUtils {
 			return JSON
 		} catch(JsonException e) {
 			try {
-				new XmlSlurper().parseText(bodyAsValue)
+				getXmlSlurperWithDefaultErrorHandler().parseText(bodyAsValue)
 				return ContentType.XML
 			} catch (Exception ignored) {
 				return UNKNOWN
@@ -234,7 +236,7 @@ class ContentUtils {
 				bodyAsValue.strings.clone() as String[]
 		)
 		// try to convert it to XML
-		new XmlSlurper().parseText(impl.toString())
+		getXmlSlurperWithDefaultErrorHandler().parseText(impl.toString())
 		return impl
 	}
 
@@ -464,7 +466,7 @@ class ContentUtils {
 				gString.strings.clone() as String[]
 		)
 		try {
-			new XmlSlurper().parseText(stringWithoutValues.toString())
+			getXmlSlurperWithDefaultErrorHandler().parseText(stringWithoutValues.toString())
 			return true
 		} catch (Exception ignored) {
 			// Not XML
@@ -546,5 +548,11 @@ class ContentUtils {
 			contentType = recognizeContentTypeFromContent(body)
 		}
 		return contentType
+	}
+
+	private static XmlSlurper getXmlSlurperWithDefaultErrorHandler() {
+		def xmlSlurper = new XmlSlurper()
+		xmlSlurper.setErrorHandler(new DefaultHandler())
+		return xmlSlurper
 	}
 }

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/util/ContentUtilsSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/util/ContentUtilsSpec.groovy
@@ -2,6 +2,7 @@ package org.springframework.cloud.contract.verifier.util
 
 import org.springframework.cloud.contract.spec.internal.DslProperty
 import org.springframework.cloud.contract.verifier.util.ContentUtils
+import org.xml.sax.helpers.DefaultHandler
 import spock.lang.Specification
 
 /**
@@ -21,5 +22,12 @@ class ContentUtilsSpec extends Specification {
 			DslProperty<String> dslProperty = new DslProperty<>("stub", "test")
 		expect:
 			"test" == ContentUtils.GET_TEST_SIDE(dslProperty)
+	}
+
+	def "should return XmlSlurper with default error handler"() {
+		given:
+		XmlSlurper xmlSlurper = ContentUtils.getXmlSlurperWithDefaultErrorHandler()
+		expect:
+		xmlSlurper.getErrorHandler() in DefaultHandler
 	}
 }


### PR DESCRIPTION
Fix for annoying error [Fatal Error] :1:1: Content is not allowed in prolog.