### PR TITLE
Docker image support for authenticated contracts download

### DIFF
--- a/docker/spring-cloud-contract-docker/project/build.gradle
+++ b/docker/spring-cloud-contract-docker/project/build.gradle
@@ -69,6 +69,10 @@ contracts {
 			contractRepository {
 				repositoryUrl = getProp('EXTERNAL_CONTRACTS_REPO_WITH_BINARIES_URL') ?:
 						getProp('REPO_WITH_BINARIES_URL') ?: 'http://localhost:8081/artifactory/libs-release-local'
+				username = getProp('EXTERNAL_CONTRACTS_REPO_WITH_BINARIES_USERNAME') ?:
+						getProp('REPO_WITH_BINARIES_USERNAME') ?: 'admin'
+				password = getProp('EXTERNAL_CONTRACTS_REPO_WITH_BINARIES_PASSWORD') ?:
+						getProp('REPO_WITH_BINARIES_PASSWORD') ?: 'password'
 			}
 		}
 		contractDependency {

--- a/docs/src/main/asciidoc/verifier_setup.adoc
+++ b/docs/src/main/asciidoc/verifier_setup.adoc
@@ -1086,8 +1086,8 @@ your running application, to the Artifact manager instance etc.
 - `PROJECT_NAME` - artifact id. Defaults to `example`
 - `REPO_WITH_BINARIES_URL` - URL of your Artifact Manager. Defaults to `http://localhost:8081/artifactory/libs-release-local`
 which is the default URL of https://jfrog.com/artifactory/[Artifactory] running locally
-- `REPO_WITH_BINARIES_USERNAME` - (optional) username when the Artifact Manager is secured
-- `REPO_WITH_BINARIES_PASSWORD` - (optional) password when the Artifact Manager is secured
+- `REPO_WITH_BINARIES_USERNAME` - (optional) username when the Artifact Manager is secured, defaults to `admin`.
+- `REPO_WITH_BINARIES_PASSWORD` - (optional) password when the Artifact Manager is secured, defaults to `password`.
 - `PUBLISH_ARTIFACTS` - if set to `true` then will publish artifact to binary storage. Defaults to `true`.
 
 These environment variables are used when contracts lay in an external repository. To enable
@@ -1100,6 +1100,10 @@ this feature you must set the `EXTERNAL_CONTRACTS_ARTIFACT_ID` environment varia
 - `EXTERNAL_CONTRACTS_REPO_WITH_BINARIES_URL` - URL of your Artifact Manager. Defaults to value of `REPO_WITH_BINARIES_URL` env var.
 If that's not set, defaults to `http://localhost:8081/artifactory/libs-release-local`
 which is the default URL of https://jfrog.com/artifactory/[Artifactory] running locally
+- `EXTERNAL_CONTRACTS_REPO_WITH_BINARIES_USERNAME` - (optional) username if the `EXTERNAL_CONTRACTS_REPO_WITH_BINARIES_URL`
+requires authentication, defaults to `REPO_WITH_BINARIES_USERNAME`. If that's not set defaults to `admin`.
+- `EXTERNAL_CONTRACTS_REPO_WITH_BINARIES_PASSWORD` - (optional) password if the `EXTERNAL_CONTRACTS_REPO_WITH_BINARIES_URL`
+requires authentication, defaults to `REPO_WITH_BINARIES_PASSWORD`. If that's not set defaults to `password`.
 - `EXTERNAL_CONTRACTS_PATH` - path to contracts for the given project, inside the project with contracts.
 Defaults to slash separated `EXTERNAL_CONTRACTS_GROUP_ID` concatenated with `/` and `EXTERNAL_CONTRACTS_ARTIFACT_ID`. E.g.
 for group id `foo.bar` and artifact id `baz`, would result in `foo/bar/baz` contracts path.


### PR DESCRIPTION
Since there was no way to download contracts from external binary repository as authenticated user while using Docker Verifier image, it was added.