### PR TITLE
Fix formatting in documentation

### DIFF
--- a/docs/src/main/asciidoc/verifier_setup.adoc
+++ b/docs/src/main/asciidoc/verifier_setup.adoc
@@ -48,7 +48,7 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-	    classpath "org.springframework.boot:spring-boot-gradle-plugin:${springboot_version}"
+		classpath "org.springframework.boot:spring-boot-gradle-plugin:${springboot_version}"
 		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${verifier_version}"
 	}
 }

--- a/docs/src/main/asciidoc/verifier_setup.adoc
+++ b/docs/src/main/asciidoc/verifier_setup.adoc
@@ -84,7 +84,7 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-	    classpath "org.springframework.boot:spring-boot-gradle-plugin:${springboot_version}"
+		classpath "org.springframework.boot:spring-boot-gradle-plugin:${springboot_version}"
 		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${verifier_version}"
 		classpath "com.jayway.restassured:rest-assured:2.5.0"
 		classpath "com.jayway.restassured:spring-mock-mvc:2.5.0"


### PR DESCRIPTION
It looks somehow odd with mixed tabs and spaces:
![image](https://user-images.githubusercontent.com/148013/54918170-d6443f00-4efd-11e9-9269-8e1570ec7048.png)
