### PR TITLE
URL Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ bin/
 *.war
 *.ear
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
 *.class

--- a/README.adoc
+++ b/README.adoc
@@ -135,7 +135,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -148,7 +148,7 @@ The `baseUrl` is prepended to all mock calls, and the `stubs()`
 method takes a stub path resource pattern as an argument. So in this
 example the stub defined at `/stubs/resource.json` is loaded into the
 mock server, so if the `RestTemplate` is asked to visit
-`http://example.org/` it will get the responses as declared
+`https://example.org/` it will get the responses as declared
 there. More than one stub pattern can be specified, and each one can
 be a directory (for a recursive list of all ".json"), or a fixed
 filename (like in the example above) or an ant-style pattern. The JSON
@@ -296,7 +296,7 @@ number of different ways, including as described above using
 
 === Introduction
 
-IMPORTANT: http://codearte.github.io/accurest[The documentation to the deprecated Accurest project in version 1.1.0 is available here.]
+IMPORTANT: https://codearte.github.io/accurest[The documentation to the deprecated Accurest project in version 1.1.0 is available here.]
 
 TIP: The Accurest project was initially started by Marcin Grzejszczak and Jakub Kubrynski (http://codearte.io[codearte.io])
 
@@ -871,7 +871,7 @@ example of achieving the same by changing the properties.
 ----
 stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot
+  repositoryRoot: https://repo.spring.io/libs-snapshot
 ----
 
 And that's it!
@@ -911,7 +911,7 @@ https://vimeo.com/130779882[click here to see the video]
 
 ===== Readings
 
-- http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura[Slides from Marcin Grzejszczak's talk about Accurest]
+- https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura[Slides from Marcin Grzejszczak's talk about Accurest]
 - http://toomuchcoding.com/blog/categories/accurest/[Accurest related articles from Marcin Grzejszczak's blog]
 - http://toomuchcoding.com/blog/categories/spring-cloud-contract/[Spring Cloud Contract related articles from Marcin Grzejszczak's blog]
 
@@ -978,7 +978,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -991,7 +991,7 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).
 

--- a/asciidoctor.css
+++ b/asciidoctor.css
@@ -1,4 +1,4 @@
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove the comments around the @import statement below when using this as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic|Noto+Serif:400,400italic,700,700italic|Droid+Sans+Mono:400";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}

--- a/docs/src/main/asciidoc/spring-cloud-wiremock.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-wiremock.adoc
@@ -75,7 +75,7 @@ The `baseUrl` is prepended to all mock calls, and the `stubs()`
 method takes a stub path resource pattern as an argument. So in this
 example the stub defined at `/stubs/resource.json` is loaded into the
 mock server, so if the `RestTemplate` is asked to visit
-`http://example.org/` it will get the responses as declared
+`https://example.org/` it will get the responses as declared
 there. More than one stub pattern can be specified, and each one can
 be a directory (for a recursive list of all ".json"), or a fixed
 filename (like in the example above) or an ant-style pattern. The JSON

--- a/docs/src/main/asciidoc/verifier/introduction.adoc
+++ b/docs/src/main/asciidoc/verifier/introduction.adoc
@@ -2,7 +2,7 @@
 
 === Introduction
 
-IMPORTANT: http://codearte.github.io/accurest[The documentation to the deprecated Accurest project in version 1.1.0 is available here.]
+IMPORTANT: https://codearte.github.io/accurest[The documentation to the deprecated Accurest project in version 1.1.0 is available here.]
 
 TIP: The Accurest project was initially started by Marcin Grzejszczak and Jakub Kubrynski (http://codearte.io[codearte.io])
 
@@ -454,7 +454,7 @@ https://vimeo.com/130779882[click here to see the video]
 
 ===== Readings
 
-- http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura[Slides from Marcin Grzejszczak's talk about Accurest]
+- https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura[Slides from Marcin Grzejszczak's talk about Accurest]
 - http://toomuchcoding.com/blog/categories/accurest/[Accurest related articles from Marcin Grzejszczak's blog]
 - http://toomuchcoding.com/blog/categories/spring-cloud-contract/[Spring Cloud Contract related articles from Marcin Grzejszczak's blog]
 

--- a/docs/src/main/asciidoc/verifier/rest.adoc
+++ b/docs/src/main/asciidoc/verifier/rest.adoc
@@ -7,7 +7,7 @@
 In order to use Spring Cloud Contract Verifier with WireMock you have to use Gradle or Maven plugin.
 
 WARNING: If you want to use Spock in your projects you have to add separately
-the `spock-core` and `spock-spring` modules. Check http://spockframework.github.io/[Spock docs for more information]
+the `spock-core` and `spock-spring` modules. Check https://spockframework.github.io/[Spock docs for more information]
 
 ====== Add gradle plugin with dependencies
 

--- a/ideas.md
+++ b/ideas.md
@@ -13,5 +13,5 @@ Feature ideas:
 - [ ] `DiscoveryClient` support so backends can be stubbed or mocked transparently (declaratively)
 - [ ] Actuator endpoints that verify the state of contracts supported by the host service
 - [ ] Something to make PACT easier to use in Spring Boot apps?
-- [ ] Support [Citrus](http://www.citrusframework.org/) users (somehow?)
+- [ ] Support [Citrus](https://citrusframework.org/) users (somehow?)
 - [ ] Schema registries for binary formats like protobuf, thrift, avro

--- a/samples/standalone/dsl/http-client/src/test/resources/application-test-repo.yaml
+++ b/samples/standalone/dsl/http-client/src/test/resources/application-test-repo.yaml
@@ -1,3 +1,3 @@
 stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot
+  repositoryRoot: https://repo.spring.io/libs-snapshot

--- a/samples/wiremock-jetty/src/main/java/com/example/WiremockTestsApplication.java
+++ b/samples/wiremock-jetty/src/main/java/com/example/WiremockTestsApplication.java
@@ -40,7 +40,7 @@ class Controller {
 @Component
 class Service {
 
-	@Value("${app.baseUrl:http://example.org}")
+	@Value("${app.baseUrl:https://example.org}")
 	private String base;
 
 	private final RestTemplate restTemplate;

--- a/samples/wiremock-jetty/src/test/java/com/example/WiremockForDocsMockServerApplicationTests.java
+++ b/samples/wiremock-jetty/src/test/java/com/example/WiremockForDocsMockServerApplicationTests.java
@@ -29,7 +29,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");

--- a/samples/wiremock-jetty/src/test/java/com/example/WiremockMockServerApplicationTests.java
+++ b/samples/wiremock-jetty/src/test/java/com/example/WiremockMockServerApplicationTests.java
@@ -27,7 +27,7 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void contextLoads() throws Exception {
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/stubs/resource.json").build();
 		assertThat(this.service.go()).isEqualTo("Hello World");
 		server.verify();

--- a/samples/wiremock-native/src/main/java/com/example/WiremockTestsApplication.java
+++ b/samples/wiremock-native/src/main/java/com/example/WiremockTestsApplication.java
@@ -40,7 +40,7 @@ class Controller {
 @Component
 class Service {
 
-	@Value("${app.baseUrl:http://example.org}")
+	@Value("${app.baseUrl:https://example.org}")
 	private String base;
 
 	private final RestTemplate restTemplate;

--- a/samples/wiremock-tomcat/src/main/java/com/example/WiremockTestsApplication.java
+++ b/samples/wiremock-tomcat/src/main/java/com/example/WiremockTestsApplication.java
@@ -40,7 +40,7 @@ class Controller {
 @Component
 class Service {
 
-	@Value("${app.baseUrl:http://example.org}")
+	@Value("${app.baseUrl:https://example.org}")
 	private String base;
 
 	private final RestTemplate restTemplate;

--- a/samples/wiremock-tomcat/src/test/java/com/example/WiremockMockServerApplicationTests.java
+++ b/samples/wiremock-tomcat/src/test/java/com/example/WiremockMockServerApplicationTests.java
@@ -27,7 +27,7 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void contextLoads() throws Exception {
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/stubs/**/*.json").build();
 		assertThat(this.service.go()).isEqualTo("Hello World");
 		server.verify();

--- a/samples/wiremock-undertow-ssl/src/main/java/com/example/WiremockTestsApplication.java
+++ b/samples/wiremock-undertow-ssl/src/main/java/com/example/WiremockTestsApplication.java
@@ -40,7 +40,7 @@ class Controller {
 @Component
 class Service {
 
-	@Value("${app.baseUrl:http://example.org}")
+	@Value("${app.baseUrl:https://example.org}")
 	private String base;
 
 	private final RestTemplate restTemplate;

--- a/samples/wiremock-undertow/src/main/java/com/example/WiremockTestsApplication.java
+++ b/samples/wiremock-undertow/src/main/java/com/example/WiremockTestsApplication.java
@@ -40,7 +40,7 @@ class Controller {
 @Component
 class Service {
 
-	@Value("${app.baseUrl:http://example.org}")
+	@Value("${app.baseUrl:https://example.org}")
 	private String base;
 
 	private final RestTemplate restTemplate;

--- a/samples/wiremock-undertow/src/test/java/com/example/WiremockMockServerApplicationTests.java
+++ b/samples/wiremock-undertow/src/test/java/com/example/WiremockMockServerApplicationTests.java
@@ -27,7 +27,7 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void contextLoads() throws Exception {
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/stubs").build();
 		assertThat(this.service.go()).isEqualTo("Hello World");
 		server.verify();

--- a/spring-cloud-contract-stub-runner/README.adoc
+++ b/spring-cloud-contract-stub-runner/README.adoc
@@ -1,7 +1,7 @@
 === Stub Runner Core
 
 Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of 
-http://martinfowler.com/articles/consumerDrivenContracts.html[Consumer Driven Contracts].
+https://martinfowler.com/articles/consumerDrivenContracts.html[Consumer Driven Contracts].
 
 Stub Runner allows you to automatically download the stubs of the provided dependencies, start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/serverexamples/StubRunnerBootEurekaExample.java
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/serverexamples/StubRunnerBootEurekaExample.java
@@ -42,7 +42,7 @@ public class StubRunnerBootEurekaExample {
 /*
 
 // tag::stubrunnereureka_args[]
--Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)

--- a/spring-cloud-contract-stub-runner/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/bootService/0.0.1-SNAPSHOT/bootService-0.0.1-SNAPSHOT.pom
+++ b/spring-cloud-contract-stub-runner/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/bootService/0.0.1-SNAPSHOT/bootService-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/spring-cloud-contract-stub-runner/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/fraudDetectionServer/0.0.1-SNAPSHOT/fraudDetectionServer-0.0.1-SNAPSHOT.pom
+++ b/spring-cloud-contract-stub-runner/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/fraudDetectionServer/0.0.1-SNAPSHOT/fraudDetectionServer-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/spring-cloud-contract-stub-runner/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/loanIssuance/0.0.1-SNAPSHOT/loanIssuance-0.0.1-SNAPSHOT.pom
+++ b/spring-cloud-contract-stub-runner/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/loanIssuance/0.0.1-SNAPSHOT/loanIssuance-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/spring-cloud-contract-tools/spring-cloud-contract-converters/src/test/groovy/org/springframework/cloud/contract/verifier/wiremock/DslToWireMockClientConverterSpec.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-converters/src/test/groovy/org/springframework/cloud/contract/verifier/wiremock/DslToWireMockClientConverterSpec.groovy
@@ -123,7 +123,7 @@ class DslToWireMockClientConverterSpec extends Specification {
 							"id":"01fbe706f872cb32",
 							"name":"Washington",
 							"place_type":"city",
-							"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+							"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 						}
 					}]
 				'''
@@ -162,7 +162,7 @@ class DslToWireMockClientConverterSpec extends Specification {
     }, {
       "matchesJsonPath" : "$[*].place.bounding_box[?(@.type == 'Polygon')]"
     }, {
-      "matchesJsonPath" : "$[*].place[?(@.url == 'http://api.twitter.com/1/geo/id/01fbe706f872cb32.json')]"
+      "matchesJsonPath" : "$[*].place[?(@.url == 'https://api.twitter.com/1/geo/id/01fbe706f872cb32.json')]"
     }, {
       "matchesJsonPath" : "$[*].place.bounding_box.coordinates[*][*][?(@ == 38.995548)]"
     }, {

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MockMvcMethodBodyBuilderSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MockMvcMethodBodyBuilderSpec.groovy
@@ -1507,7 +1507,7 @@ World.'''"""
 						"id":"01fbe706f872cb32",
 						"name":"Washington",
 						"place_type":"city",
-						"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+						"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 					}
 				}]
 			'''

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/WiremockMockServerApplicationTests.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/WiremockMockServerApplicationTests.java
@@ -15,9 +15,9 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void simpleGet() throws Exception {
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/resource.json").build();
-		assertThat(this.restTemplate.getForObject("http://example.org/resource", String.class))
+		assertThat(this.restTemplate.getForObject("https://example.org/resource", String.class))
 				.isEqualTo("Hello World");
 		server.verify();
 	}
@@ -25,9 +25,9 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void simplePost() throws Exception {
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/poster.json").build();
-		assertThat(this.restTemplate.postForObject("http://example.org/poster", "greeting",
+		assertThat(this.restTemplate.postForObject("https://example.org/poster", "greeting",
 				String.class)).isEqualTo("Hello World");
 		server.verify();
 	}
@@ -35,18 +35,18 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void postWithHeader() throws Exception {
 		WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/*.json").ignoreExpectOrder(true).build();
-		assertThat(this.restTemplate.exchange("http://example.org/poster", HttpMethod.POST,
+		assertThat(this.restTemplate.exchange("https://example.org/poster", HttpMethod.POST,
 				RequestEntity.EMPTY, String.class).getBody()).isEqualTo("Accepted World");
 	}
 
 	@Test
 	public void simpleGetWithAllStubs() throws Exception {
 		WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings").ignoreExpectOrder(true).build();
-		assertThat(this.restTemplate.getForObject("http://example.org/resource", String.class))
+		assertThat(this.restTemplate.getForObject("https://example.org/resource", String.class))
 				.isEqualTo("Hello World");
 	}
 

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/WiremockTestsApplication.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/WiremockTestsApplication.java
@@ -45,7 +45,7 @@ class Controller {
 @Component
 class Service {
 
-	@Value("${app.baseUrl:http://example.org}")
+	@Value("${app.baseUrl:https://example.org}")
 	private String base;
 
 	private RestTemplate restTemplate;

--- a/tests/spring-cloud-contract-stub-runner-boot-eureka/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/bootService/0.0.1-SNAPSHOT/bootService-0.0.1-SNAPSHOT.pom
+++ b/tests/spring-cloud-contract-stub-runner-boot-eureka/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/bootService/0.0.1-SNAPSHOT/bootService-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/tests/spring-cloud-contract-stub-runner-boot-eureka/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/fraudDetectionServer/0.0.1-SNAPSHOT/fraudDetectionServer-0.0.1-SNAPSHOT.pom
+++ b/tests/spring-cloud-contract-stub-runner-boot-eureka/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/fraudDetectionServer/0.0.1-SNAPSHOT/fraudDetectionServer-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/tests/spring-cloud-contract-stub-runner-boot-eureka/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/loanIssuance/0.0.1-SNAPSHOT/loanIssuance-0.0.1-SNAPSHOT.pom
+++ b/tests/spring-cloud-contract-stub-runner-boot-eureka/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/loanIssuance/0.0.1-SNAPSHOT/loanIssuance-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/tests/spring-cloud-contract-stub-runner-boot-zookeeper/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/bootService/0.0.1-SNAPSHOT/bootService-0.0.1-SNAPSHOT.pom
+++ b/tests/spring-cloud-contract-stub-runner-boot-zookeeper/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/bootService/0.0.1-SNAPSHOT/bootService-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/tests/spring-cloud-contract-stub-runner-boot-zookeeper/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/fraudDetectionServer/0.0.1-SNAPSHOT/fraudDetectionServer-0.0.1-SNAPSHOT.pom
+++ b/tests/spring-cloud-contract-stub-runner-boot-zookeeper/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/fraudDetectionServer/0.0.1-SNAPSHOT/fraudDetectionServer-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/tests/spring-cloud-contract-stub-runner-boot-zookeeper/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/loanIssuance/0.0.1-SNAPSHOT/loanIssuance-0.0.1-SNAPSHOT.pom
+++ b/tests/spring-cloud-contract-stub-runner-boot-zookeeper/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/loanIssuance/0.0.1-SNAPSHOT/loanIssuance-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/tests/spring-cloud-contract-stub-runner-camel/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/camelService/0.0.1-SNAPSHOT/camelService-0.0.1-SNAPSHOT.pom
+++ b/tests/spring-cloud-contract-stub-runner-camel/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/camelService/0.0.1-SNAPSHOT/camelService-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/tests/spring-cloud-contract-stub-runner-integration/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/integrationService/0.0.1-SNAPSHOT/integrationService-0.0.1-SNAPSHOT.pom
+++ b/tests/spring-cloud-contract-stub-runner-integration/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/integrationService/0.0.1-SNAPSHOT/integrationService-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/tests/spring-cloud-contract-stub-runner-stream/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/streamService/0.0.1-SNAPSHOT/streamService-0.0.1-SNAPSHOT.pom
+++ b/tests/spring-cloud-contract-stub-runner-stream/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/streamService/0.0.1-SNAPSHOT/streamService-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://codearte.io (200) with 2 occurrences could not be migrated:  
   ([https](https://codearte.io) result SSLHandshakeException).
* [ ] http://partners.com (200) with 9 occurrences could not be migrated:  
   ([https](https://partners.com) result SSLHandshakeException).
* [ ] http://rest-assured.io/ (200) with 2 occurrences could not be migrated:  
   ([https](https://rest-assured.io/) result SSLHandshakeException).
* [ ] http://toomuchcoding.com/blog/categories/accurest/ (200) with 2 occurrences could not be migrated:  
   ([https](https://toomuchcoding.com/blog/categories/accurest/) result SSLHandshakeException).
* [ ] http://toomuchcoding.com/blog/categories/spring-cloud-contract/ (200) with 2 occurrences could not be migrated:  
   ([https](https://toomuchcoding.com/blog/categories/spring-cloud-contract/) result SSLHandshakeException).
* [ ] http://wiremock.org (200) with 2 occurrences could not be migrated:  
   ([https](https://wiremock.org) result SSLHandshakeException).
* [ ] http://wiremock.org/ (200) with 2 occurrences could not be migrated:  
   ([https](https://wiremock.org/) result SSLHandshakeException).
* [ ] http://wiremock.org/docs/running-standalone/ (200) with 2 occurrences could not be migrated:  
   ([https](https://wiremock.org/docs/running-standalone/) result SSLHandshakeException).
* [ ] http://wiremock.org/stateful-behaviour.html (200) with 2 occurrences could not be migrated:  
   ([https](https://wiremock.org/stateful-behaviour.html) result SSLHandshakeException).
* [ ] http://wiremock.org/stubbing.html (200) with 1 occurrences could not be migrated:  
   ([https](https://wiremock.org/stubbing.html) result SSLHandshakeException).
* [ ] http://nexus.net/content (404) with 1 occurrences could not be migrated:  
   ([https](https://nexus.net/content) result SSLProtocolException).
* [ ] http://nexus.net/content/repositories/repository (404) with 1 occurrences could not be migrated:  
   ([https](https://nexus.net/content/repositories/repository) result SSLProtocolException).
* [ ] http://toomuchcoding.com/blog/2015/09/27/microservice-deployment/ (404) with 1 occurrences could not be migrated:  
   ([https](https://toomuchcoding.com/blog/2015/09/27/microservice-deployment/) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://example.org/poster (404) with 2 occurrences migrated to:  
  https://example.org/poster ([https](https://example.org/poster) result 404).
* [ ] http://example.org/resource (404) with 2 occurrences migrated to:  
  https://example.org/resource ([https](https://example.org/resource) result 404).
* [ ] http://repo.spring.io/snapshots (404) with 1 occurrences migrated to:  
  https://repo.spring.io/snapshots ([https](https://repo.spring.io/snapshots) result 404).
* [ ] http://api.twitter.com/1/geo/id/01fbe706f872cb32.json (403) with 3 occurrences migrated to:  
  https://api.twitter.com/1/geo/id/01fbe706f872cb32.json ([https](https://api.twitter.com/1/geo/id/01fbe706f872cb32.json) result 410).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://asciidoctor.org with 1 occurrences migrated to:  
  https://asciidoctor.org ([https](https://asciidoctor.org) result 200).
* [ ] http://www.citrusframework.org/ (301) with 1 occurrences migrated to:  
  https://citrusframework.org/ ([https](https://www.citrusframework.org/) result 200).
* [ ] http://example.org with 15 occurrences migrated to:  
  https://example.org ([https](https://example.org) result 200).
* [ ] http://example.org/ with 2 occurrences migrated to:  
  https://example.org/ ([https](https://example.org/) result 200).
* [ ] http://martinfowler.com/articles/consumerDrivenContracts.html with 1 occurrences migrated to:  
  https://martinfowler.com/articles/consumerDrivenContracts.html ([https](https://martinfowler.com/articles/consumerDrivenContracts.html) result 200).
* [ ] http://maven.apache.org/xsd/maven-4.0.0.xsd with 12 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://www.java.com/en/download/help/error_hotspot.xml with 1 occurrences migrated to:  
  https://www.java.com/en/download/help/error_hotspot.xml ([https](https://www.java.com/en/download/help/error_hotspot.xml) result 200).
* [ ] http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura with 2 occurrences migrated to:  
  https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura ([https](https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura) result 200).
* [ ] http://codearte.github.io/accurest with 2 occurrences migrated to:  
  https://codearte.github.io/accurest ([https](https://codearte.github.io/accurest) result 301).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 1 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://spockframework.github.io/ with 1 occurrences migrated to:  
  https://spockframework.github.io/ ([https](https://spockframework.github.io/) result 301).
* [ ] http://repo.spring.io/libs-snapshot with 2 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://loanIssuance/name with 3 occurrences
* http://localhost with 18 occurrences
* http://localhost/partners/ with 3 occurrences
* http://localhost/partners/1000/users/1001 with 2 occurrences
* http://localhost:12345 with 2 occurrences
* http://localhost:12346 with 1 occurrences
* http://localhost:8080 with 10 occurrences
* http://localhost:8888/users with 1 occurrences
* http://localhost:9090 with 1 occurrences
* http://maven.apache.org/POM/4.0.0 with 24 occurrences
* http://someNameThatShouldMapFraudDetectionServer/name with 3 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 12 occurrences