### PR TITLE
URL Cleanup

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,7 +28,7 @@ added after the original pull request but before a merge.
   you can import formatter settings using the
   `eclipse-code-formatter.xml` file from the
   [Spring Cloud Build](https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml) project. If using IntelliJ, you can use the
-  [Eclipse Code Formatter Plugin](http://plugins.jetbrains.com/plugin/6546) to import the same file.
+  [Eclipse Code Formatter Plugin](https://plugins.jetbrains.com/plugin/6546) to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
   for.
@@ -40,6 +40,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow [these conventions](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html),
+* When writing a commit message please follow [these conventions](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html),
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ bin/
 *.ear
 *.versionsBackup
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
 *.class

--- a/README.adoc
+++ b/README.adoc
@@ -19,7 +19,7 @@ producers and consumers -- for both HTTP and message-based interactions.
 
 If you prefer to learn about the project by doing some tutorials, you can check out the
 workshops under
-http://cloud-samples.spring.io/spring-cloud-contract-samples/workshops.html[this link].
+https://cloud-samples.spring.io/spring-cloud-contract-samples/workshops.html[this link].
 
 === Spring Cloud Contract Verifier
 
@@ -227,7 +227,7 @@ Stub Runner` properties, as shown in the following example:
 ----
 stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot
+  repositoryRoot: https://repo.spring.io/libs-snapshot
 ----
 
 Now you can annotate your test class with `@AutoConfigureStubRunner`. In the annotation,
@@ -558,7 +558,7 @@ Runner` properties, as shown in the following example:
 ----
 stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot
+  repositoryRoot: https://repo.spring.io/libs-snapshot
 ----
 
 Now you can annotate your test class with `@AutoConfigureStubRunner`. In the annotation,
@@ -876,9 +876,9 @@ following section to your build:
 repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/release" }
 }
 ----
 
@@ -1458,7 +1458,7 @@ achieving the same thing by changing the properties.
 ----
 stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot
+  repositoryRoot: https://repo.spring.io/libs-snapshot
 ----
 
 That's it!
@@ -1484,7 +1484,7 @@ video::sAAklvxmPmk[youtube,start=538,width=640,height=480]
 
 ==== Readings
 
-- http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura[Slides from Marcin Grzejszczak's talk about Accurest]
+- https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura[Slides from Marcin Grzejszczak's talk about Accurest]
 - http://toomuchcoding.com/blog/categories/accurest/[Accurest related articles from Marcin Grzejszczak's blog]
 - http://toomuchcoding.com/blog/categories/spring-cloud-contract/[Spring Cloud Contract related articles from Marcin Grzejszczak's blog]
 - http://groovy-lang.org/json.html[Groovy docs regarding JSON]
@@ -1711,7 +1711,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");
@@ -1724,7 +1724,7 @@ public class WiremockForDocsMockServerApplicationTests {
 The `baseUrl` value is prepended to all mock calls, and the `stubs()` method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 `/stubs/resource.json` is loaded into the mock server. If the `RestTemplate` is asked to
-visit `http://example.org/`, it gets the responses as being declared at that URL. More
+visit `https://example.org/`, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the
@@ -2015,7 +2015,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -2028,7 +2028,7 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).
 

--- a/asciidoctor.css
+++ b/asciidoctor.css
@@ -1,4 +1,4 @@
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove the comments around the @import statement below when using this as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic|Noto+Serif:400,400italic,700,700italic|Droid+Sans+Mono:400";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}

--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -17,7 +17,7 @@ producers and consumers -- for both HTTP and message-based interactions.
 
 If you prefer to learn about the project by doing some tutorials, you can check out the
 workshops under
-http://cloud-samples.spring.io/spring-cloud-contract-samples/workshops.html[this link].
+https://cloud-samples.spring.io/spring-cloud-contract-samples/workshops.html[this link].
 
 === Spring Cloud Contract Verifier
 

--- a/docs/src/main/asciidoc/migrations.adoc
+++ b/docs/src/main/asciidoc/migrations.adoc
@@ -82,7 +82,7 @@ structure presented in the previous snippet.
 <assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd">
 	<id>stubs</id>
 	<formats>
 		<format>jar</format>

--- a/docs/src/main/asciidoc/spring-cloud-wiremock.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-wiremock.adoc
@@ -152,7 +152,7 @@ include::{doc_samples}/src/test/java/com/example/WiremockForDocsMockServerApplic
 The `baseUrl` value is prepended to all mock calls, and the `stubs()` method takes a stub
 path resource pattern as an argument. In the preceding example, the stub defined at
 `/stubs/resource.json` is loaded into the mock server. If the `RestTemplate` is asked to
-visit `http://example.org/`, it gets the responses as being declared at that URL. More
+visit `https://example.org/`, it gets the responses as being declared at that URL. More
 than one stub pattern can be specified, and each one can be a directory (for a recursive
 list of all ".json"), a fixed filename (as in the example above), or an Ant-style
 pattern. The JSON format is the normal WireMock format, which you can read about in the

--- a/docs/src/main/asciidoc/verifier_contract.adoc
+++ b/docs/src/main/asciidoc/verifier_contract.adoc
@@ -624,7 +624,7 @@ given name.
 matches the JSON Path.
 
 If you're using the YAML contract definition you have to use the
-http://handlebarsjs.com/[Handlebars] `{{{ }}}` notation with custom, Spring Cloud Contract
+https://handlebarsjs.com/[Handlebars] `{{{ }}}` notation with custom, Spring Cloud Contract
  functions to achieve this.
 
 * `{{{ request.url }}}`: Returns the request URL and query parameters.

--- a/docs/src/main/asciidoc/verifier_faq.adoc
+++ b/docs/src/main/asciidoc/verifier_faq.adoc
@@ -316,7 +316,7 @@ When the *consumer* wants to work on the contracts offline, instead of cloning t
 consumer team clones the common repository, goes to the required producer's folder (e.g. `com/example/server`)
 and runs `mvn clean install -DskipTests` to install locally the stubs converted from the contracts.
 
-TIP: You need to have http://maven.apache.org/download.cgi[Maven installed locally]
+TIP: You need to have https://maven.apache.org/download.cgi[Maven installed locally]
 
 ==== Producer
 
@@ -690,7 +690,7 @@ to find stub definitions and contracts. E.g. for `com.example:foo:1.0.0` the pat
 
 === Can I use the Pact Broker?
 
-When using http://pact.io/[Pact] you can use the https://github.com/pact-foundation/pact_broker[Pact Broker]
+When using https://pact.io/[Pact] you can use the https://github.com/pact-foundation/pact_broker[Pact Broker]
 to store and share Pact definitions. Starting from Spring Cloud Contract
 2.0.0 one can fetch Pact files from the Pact Broker to generate
 tests and stubs.

--- a/docs/src/main/asciidoc/verifier_introduction.adoc
+++ b/docs/src/main/asciidoc/verifier_introduction.adoc
@@ -1045,7 +1045,7 @@ video::sAAklvxmPmk[youtube,start=538,width=640,height=480]
 
 ==== Readings
 
-- http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura[Slides from Marcin Grzejszczak's talk about Accurest]
+- https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura[Slides from Marcin Grzejszczak's talk about Accurest]
 - http://toomuchcoding.com/blog/categories/accurest/[Accurest related articles from Marcin Grzejszczak's blog]
 - http://toomuchcoding.com/blog/categories/spring-cloud-contract/[Spring Cloud Contract related articles from Marcin Grzejszczak's blog]
 - http://groovy-lang.org/json.html[Groovy docs regarding JSON]

--- a/docs/src/main/asciidoc/verifier_setup.adoc
+++ b/docs/src/main/asciidoc/verifier_setup.adoc
@@ -33,7 +33,7 @@ In order to use Spring Cloud Contract Verifier with WireMock, you muse use eithe
 Gradle or a Maven plugin.
 
 WARNING: If you want to use Spock in your projects, you must add separately the
-`spock-core` and `spock-spring` modules. Check http://spockframework.github.io/[Spock
+`spock-core` and `spock-spring` modules. Check https://spockframework.github.io/[Spock
 docs for more information]
 
 [[gradle-add-gradle-plugin]]
@@ -1059,7 +1059,7 @@ like them to be available for others to download / reference or reuse. In case
 of the JVM world those artifacts would be JARs, for Ruby these are gems
 and for Docker those would be Docker images. You can store those artifacts
 in a manager. Examples of such managers can be https://jfrog.com/artifactory/[Artifactory]
-or http://www.sonatype.org/nexus/[Nexus].
+or https://www.sonatype.org/nexus/[Nexus].
 
 ==== How it works
 

--- a/ideas.md
+++ b/ideas.md
@@ -13,5 +13,5 @@ Feature ideas:
 - [x] `DiscoveryClient` support so backends can be stubbed or mocked transparently (declaratively)
 - [ ] Actuator endpoints that verify the state of contracts supported by the host service
 - [x] Something to make PACT easier to use in Spring Boot apps?
-- [ ] Support [Citrus](http://www.citrusframework.org/) users (somehow?)
+- [ ] Support [Citrus](https://citrusframework.org/) users (somehow?)
 - [x] Schema registries for binary formats like protobuf, thrift, avro - Stream does it

--- a/samples/standalone/dsl/http-client/src/test/resources/application-test-repo.yaml
+++ b/samples/standalone/dsl/http-client/src/test/resources/application-test-repo.yaml
@@ -1,3 +1,3 @@
 stubrunner:
   ids: 'com.example:http-server-dsl:+:stubs:8080'
-  repositoryRoot: http://repo.spring.io/libs-snapshot
+  repositoryRoot: https://repo.spring.io/libs-snapshot

--- a/samples/wiremock-jetty/src/main/java/com/example/WiremockTestsApplication.java
+++ b/samples/wiremock-jetty/src/main/java/com/example/WiremockTestsApplication.java
@@ -43,7 +43,7 @@ class Controller {
 @Component
 class Service {
 
-	@Value("${app.baseUrl:http://example.org}")
+	@Value("${app.baseUrl:https://example.org}")
 	private String base;
 
 	private final RestTemplate restTemplate;

--- a/samples/wiremock-jetty/src/test/java/com/example/WiremockForDocsMockServerApplicationTests.java
+++ b/samples/wiremock-jetty/src/test/java/com/example/WiremockForDocsMockServerApplicationTests.java
@@ -27,7 +27,7 @@ public class WiremockForDocsMockServerApplicationTests {
 	public void contextLoads() throws Exception {
 		// will read stubs classpath
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate)
-				.baseUrl("http://example.org").stubs("classpath:/stubs/resource.json")
+				.baseUrl("https://example.org").stubs("classpath:/stubs/resource.json")
 				.build();
 		// We're asserting if WireMock responded properly
 		assertThat(this.service.go()).isEqualTo("Hello World");

--- a/samples/wiremock-jetty/src/test/java/com/example/WiremockMockServerApplicationTests.java
+++ b/samples/wiremock-jetty/src/test/java/com/example/WiremockMockServerApplicationTests.java
@@ -25,7 +25,7 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void contextLoads() throws Exception {
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/stubs/resource.json").build();
 		assertThat(this.service.go()).isEqualTo("Hello World");
 		server.verify();

--- a/samples/wiremock-native/src/main/java/com/example/WiremockTestsApplication.java
+++ b/samples/wiremock-native/src/main/java/com/example/WiremockTestsApplication.java
@@ -42,7 +42,7 @@ class Controller {
 @Component
 class Service {
 
-	@Value("${app.baseUrl:http://example.org}")
+	@Value("${app.baseUrl:https://example.org}")
 	private String base;
 
 	private final RestTemplate restTemplate;

--- a/samples/wiremock-tomcat/src/main/java/com/example/WiremockTestsApplication.java
+++ b/samples/wiremock-tomcat/src/main/java/com/example/WiremockTestsApplication.java
@@ -43,7 +43,7 @@ class Controller {
 @Component
 class Service {
 
-	@Value("${app.baseUrl:http://example.org}")
+	@Value("${app.baseUrl:https://example.org}")
 	private String base;
 
 	private final RestTemplate restTemplate;

--- a/samples/wiremock-tomcat/src/test/java/com/example/WiremockMockServerApplicationTests.java
+++ b/samples/wiremock-tomcat/src/test/java/com/example/WiremockMockServerApplicationTests.java
@@ -25,7 +25,7 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void contextLoads() throws Exception {
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/stubs/**/*.json").build();
 		assertThat(this.service.go()).isEqualTo("Hello World");
 		server.verify();

--- a/samples/wiremock-undertow-ssl/src/main/java/com/example/WiremockTestsApplication.java
+++ b/samples/wiremock-undertow-ssl/src/main/java/com/example/WiremockTestsApplication.java
@@ -42,7 +42,7 @@ class Controller {
 @Component
 class Service {
 
-	@Value("${app.baseUrl:http://example.org}")
+	@Value("${app.baseUrl:https://example.org}")
 	private String base;
 
 	private final RestTemplate restTemplate;

--- a/samples/wiremock-undertow/src/main/java/com/example/WiremockTestsApplication.java
+++ b/samples/wiremock-undertow/src/main/java/com/example/WiremockTestsApplication.java
@@ -42,7 +42,7 @@ class Controller {
 @Component
 class Service {
 
-	@Value("${app.baseUrl:http://example.org}")
+	@Value("${app.baseUrl:https://example.org}")
 	private String base;
 
 	private final RestTemplate restTemplate;

--- a/samples/wiremock-undertow/src/test/java/com/example/WiremockMockServerApplicationTests.java
+++ b/samples/wiremock-undertow/src/test/java/com/example/WiremockMockServerApplicationTests.java
@@ -25,7 +25,7 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void contextLoads() throws Exception {
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/stubs").build();
 		assertThat(this.service.go()).isEqualTo("Hello World");
 		server.verify();

--- a/samples/wiremock/src/main/java/com/example/WiremockTestsApplication.java
+++ b/samples/wiremock/src/main/java/com/example/WiremockTestsApplication.java
@@ -51,7 +51,7 @@ class Controller {
 @Component
 class Service {
 
-	@Value("${app.baseUrl:http://example.org}")
+	@Value("${app.baseUrl:https://example.org}")
 	String base;
 
 	private RestTemplate restTemplate;

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/HttpHeaders.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/HttpHeaders.groovy
@@ -17,119 +17,119 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Accept} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-5.3.2">Section 5.3.2 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.3.2">Section 5.3.2 of RFC 7231</a>
 	 */
 	String accept() {
 		return "Accept"
 	}
 	/**
 	 * The HTTP {@code Accept-Charset} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-5.3.3">Section 5.3.3 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.3.3">Section 5.3.3 of RFC 7231</a>
 	 */
 	String acceptCharset() {
 		return "Accept-Charset"
 	}
 	/**
 	 * The HTTP {@code Accept-Encoding} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-5.3.4">Section 5.3.4 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.3.4">Section 5.3.4 of RFC 7231</a>
 	 */
 	String acceptEncoding() {
 		return "Accept-Encoding"
 	}
 	/**
 	 * The HTTP {@code Accept-Language} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-5.3.5">Section 5.3.5 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.3.5">Section 5.3.5 of RFC 7231</a>
 	 */
 	String acceptLanguage() {
 		return "Accept-Language"
 	}
 	/**
 	 * The HTTP {@code Accept-Ranges} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7233#section-2.3">Section 5.3.5 of RFC 7233</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7233#section-2.3">Section 5.3.5 of RFC 7233</a>
 	 */
 	String acceptRanges() {
 		return "Accept-Ranges"
 	}
 	/**
 	 * The CORS {@code Access-Control-Allow-Credentials} response header field name.
-	 * @see <a href="http://www.w3.org/TR/cors/">CORS W3C recommendation</a>
+	 * @see <a href="https://www.w3.org/TR/cors/">CORS W3C recommendation</a>
 	 */
 	String accessControlAllowCredentials() {
 		return "Access-Control-Allow-Credentials"
 	}
 	/**
 	 * The CORS {@code Access-Control-Allow-Headers} response header field name.
-	 * @see <a href="http://www.w3.org/TR/cors/">CORS W3C recommendation</a>
+	 * @see <a href="https://www.w3.org/TR/cors/">CORS W3C recommendation</a>
 	 */
 	String accessControlAllowHeaders() {
 		return "Access-Control-Allow-Headers"
 	}
 	/**
 	 * The CORS {@code Access-Control-Allow-Methods} response header field name.
-	 * @see <a href="http://www.w3.org/TR/cors/">CORS W3C recommendation</a>
+	 * @see <a href="https://www.w3.org/TR/cors/">CORS W3C recommendation</a>
 	 */
 	String accessControlAllowMethods() {
 		return "Access-Control-Allow-Methods"
 	}
 	/**
 	 * The CORS {@code Access-Control-Allow-Origin} response header field name.
-	 * @see <a href="http://www.w3.org/TR/cors/">CORS W3C recommendation</a>
+	 * @see <a href="https://www.w3.org/TR/cors/">CORS W3C recommendation</a>
 	 */
 	String accessControlAllowOrigin() {
 		return "Access-Control-Allow-Origin"
 	}
 	/**
 	 * The CORS {@code Access-Control-Expose-Headers} response header field name.
-	 * @see <a href="http://www.w3.org/TR/cors/">CORS W3C recommendation</a>
+	 * @see <a href="https://www.w3.org/TR/cors/">CORS W3C recommendation</a>
 	 */
 	String accessControlExposeHeaders() {
 		return "Access-Control-Expose-Headers"
 	}
 	/**
 	 * The CORS {@code Access-Control-Max-Age} response header field name.
-	 * @see <a href="http://www.w3.org/TR/cors/">CORS W3C recommendation</a>
+	 * @see <a href="https://www.w3.org/TR/cors/">CORS W3C recommendation</a>
 	 */
 	String accessControlMaxAge() {
 		return "Access-Control-Max-Age"
 	}
 	/**
 	 * The CORS {@code Access-Control-Request-Headers} request header field name.
-	 * @see <a href="http://www.w3.org/TR/cors/">CORS W3C recommendation</a>
+	 * @see <a href="https://www.w3.org/TR/cors/">CORS W3C recommendation</a>
 	 */
 	String accessControlRequestHeaders() {
 		return "Access-Control-Request-Headers"
 	}
 	/**
 	 * The CORS {@code Access-Control-Request-Method} request header field name.
-	 * @see <a href="http://www.w3.org/TR/cors/">CORS W3C recommendation</a>
+	 * @see <a href="https://www.w3.org/TR/cors/">CORS W3C recommendation</a>
 	 */
 	String accessControlRequestMethod() {
 		return "Access-Control-Request-Method"
 	}
 	/**
 	 * The HTTP {@code Age} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7234#section-5.1">Section 5.1 of RFC 7234</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.1">Section 5.1 of RFC 7234</a>
 	 */
 	String age() {
 		return "Age"
 	}
 	/**
 	 * The HTTP {@code Allow} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-7.4.1">Section 7.4.1 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-7.4.1">Section 7.4.1 of RFC 7231</a>
 	 */
 	String allow() {
 		return "Allow"
 	}
 	/**
 	 * The HTTP {@code Authorization} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7235#section-4.2">Section 4.2 of RFC 7235</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7235#section-4.2">Section 4.2 of RFC 7235</a>
 	 */
 	String authorization() {
 		return "Authorization"
 	}
 	/**
 	 * The HTTP {@code Cache-Control} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7234#section-5.2">Section 5.2 of RFC 7234</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.2">Section 5.2 of RFC 7234</a>
 	 */
 	String cacheControl() {
 		return "Cache-Control"
@@ -137,7 +137,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Connection} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7230#section-6.1">Section 6.1 of RFC 7230</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7230#section-6.1">Section 6.1 of RFC 7230</a>
 	 */
 	String connection() {
 		return "Connection"
@@ -145,7 +145,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Content-Encoding} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-3.1.2.2">Section 3.1.2.2 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-3.1.2.2">Section 3.1.2.2 of RFC 7231</a>
 	 */
 	String contentEncoding() {
 		return "Content-Encoding"
@@ -153,7 +153,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Content-Disposition} header field name
-	 * @see <a href="http://tools.ietf.org/html/rfc6266">RFC 6266</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc6266">RFC 6266</a>
 	 */
 	String contentDisposition() {
 		return "Content-Disposition"
@@ -161,7 +161,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Content-Language} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-3.1.3.2">Section 3.1.3.2 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-3.1.3.2">Section 3.1.3.2 of RFC 7231</a>
 	 */
 	String contentLanguage() {
 		return "Content-Language"
@@ -169,7 +169,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Content-Length} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7230#section-3.3.2">Section 3.3.2 of RFC 7230</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7230#section-3.3.2">Section 3.3.2 of RFC 7230</a>
 	 */
 	String contentLength() {
 		return "Content-Length"
@@ -177,7 +177,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Content-Location} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-3.1.4.2">Section 3.1.4.2 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-3.1.4.2">Section 3.1.4.2 of RFC 7231</a>
 	 */
 	String contentLocation() {
 		return "Content-Location"
@@ -185,7 +185,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Content-Range} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7233#section-4.2">Section 4.2 of RFC 7233</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7233#section-4.2">Section 4.2 of RFC 7233</a>
 	 */
 	String contentRange() {
 		return "Content-Range"
@@ -193,7 +193,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Content-Type} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-3.1.1.5">Section 3.1.1.5 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-3.1.1.5">Section 3.1.1.5 of RFC 7231</a>
 	 */
 	String contentType() {
 		return "Content-Type"
@@ -201,7 +201,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Cookie} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc2109#section-4.3.4">Section 4.3.4 of RFC 2109</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2109#section-4.3.4">Section 4.3.4 of RFC 2109</a>
 	 */
 	String cookie() {
 		return "Cookie"
@@ -209,7 +209,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Date} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-7.1.1.2">Section 7.1.1.2 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.2">Section 7.1.1.2 of RFC 7231</a>
 	 */
 	String date() {
 		return "Date"
@@ -217,7 +217,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code ETag} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7232#section-2.3">Section 2.3 of RFC 7232</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7232#section-2.3">Section 2.3 of RFC 7232</a>
 	 */
 	String etag() {
 		return "ETag"
@@ -225,7 +225,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Expect} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-5.1.1">Section 5.1.1 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.1.1">Section 5.1.1 of RFC 7231</a>
 	 */
 	String expect() {
 		return "Expect"
@@ -233,7 +233,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Expires} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7234#section-5.3">Section 5.3 of RFC 7234</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.3">Section 5.3 of RFC 7234</a>
 	 */
 	String expires() {
 		return "Expires"
@@ -241,7 +241,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code From} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-5.5.1">Section 5.5.1 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.5.1">Section 5.5.1 of RFC 7231</a>
 	 */
 	String from() {
 		return "From"
@@ -249,7 +249,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Host} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7230#section-5.4">Section 5.4 of RFC 7230</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7230#section-5.4">Section 5.4 of RFC 7230</a>
 	 */
 	String host() {
 		return "Host"
@@ -257,7 +257,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code If-Match} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7232#section-3.1">Section 3.1 of RFC 7232</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7232#section-3.1">Section 3.1 of RFC 7232</a>
 	 */
 	String ifMatch() {
 		return "If-Match"
@@ -265,7 +265,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code If-Modified-Since} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7232#section-3.3">Section 3.3 of RFC 7232</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7232#section-3.3">Section 3.3 of RFC 7232</a>
 	 */
 	String ifModifiedSince() {
 		return "If-Modified-Since"
@@ -273,7 +273,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code If-None-Match} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7232#section-3.2">Section 3.2 of RFC 7232</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7232#section-3.2">Section 3.2 of RFC 7232</a>
 	 */
 	String ifNoneMatch() {
 		return "If-None-Match"
@@ -281,7 +281,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code If-Range} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7233#section-3.2">Section 3.2 of RFC 7233</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7233#section-3.2">Section 3.2 of RFC 7233</a>
 	 */
 	String ifRange() {
 		return "If-Range"
@@ -289,7 +289,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code If-Unmodified-Since} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7232#section-3.4">Section 3.4 of RFC 7232</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7232#section-3.4">Section 3.4 of RFC 7232</a>
 	 */
 	String ifUnmodifiedSince() {
 		return "If-Unmodified-Since"
@@ -297,7 +297,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Last-Modified} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7232#section-2.2">Section 2.2 of RFC 7232</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7232#section-2.2">Section 2.2 of RFC 7232</a>
 	 */
 	String lastModified() {
 		return "Last-Modified"
@@ -305,7 +305,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Link} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc5988">RFC 5988</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc5988">RFC 5988</a>
 	 */
 	String link() {
 		return "Link"
@@ -313,7 +313,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Location} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-7.1.2">Section 7.1.2 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-7.1.2">Section 7.1.2 of RFC 7231</a>
 	 */
 	String location() {
 		return "Location"
@@ -321,14 +321,14 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Max-Forwards} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-5.1.2">Section 5.1.2 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.1.2">Section 5.1.2 of RFC 7231</a>
 	 */
 	String max_forwards() {
 		return "Max-Forwards"
 	}
 	/**
 	 * The HTTP {@code Origin} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc6454">RFC 6454</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc6454">RFC 6454</a>
 	 */
 	String origin() {
 		return "Origin"
@@ -336,7 +336,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Pragma} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7234#section-5.4">Section 5.4 of RFC 7234</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.4">Section 5.4 of RFC 7234</a>
 	 */
 	String pragma() {
 		return "Pragma"
@@ -344,7 +344,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Proxy-Authenticate} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7235#section-4.3">Section 4.3 of RFC 7235</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7235#section-4.3">Section 4.3 of RFC 7235</a>
 	 */
 	String proxyAuthenticate() {
 		return "Proxy-Authenticate"
@@ -352,7 +352,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Proxy-Authorization} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7235#section-4.4">Section 4.4 of RFC 7235</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7235#section-4.4">Section 4.4 of RFC 7235</a>
 	 */
 	String proxyAuthorization() {
 		return "Proxy-Authorization"
@@ -360,7 +360,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Range} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7233#section-3.1">Section 3.1 of RFC 7233</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7233#section-3.1">Section 3.1 of RFC 7233</a>
 	 */
 	String range() {
 		return "Range"
@@ -368,7 +368,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Referer} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-5.5.2">Section 5.5.2 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Section 5.5.2 of RFC 7231</a>
 	 */
 	String referer() {
 		return "Referer"
@@ -376,7 +376,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Retry-After} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-7.1.3">Section 7.1.3 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-7.1.3">Section 7.1.3 of RFC 7231</a>
 	 */
 	String retryAfter() {
 		return "Retry-After"
@@ -384,7 +384,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Server} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-7.4.2">Section 7.4.2 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-7.4.2">Section 7.4.2 of RFC 7231</a>
 	 */
 	String server() {
 		return "Server"
@@ -392,7 +392,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Set-Cookie} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc2109#section-4.2.2">Section 4.2.2 of RFC 2109</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2109#section-4.2.2">Section 4.2.2 of RFC 2109</a>
 	 */
 	String setCookie() {
 		return "Set-Cookie"
@@ -400,7 +400,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Set-Cookie2} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc2965">RFC 2965</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2965">RFC 2965</a>
 	 */
 	String setCookie2() {
 		return "Set-Cookie2"
@@ -408,7 +408,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code TE} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7230#section-4.3">Section 4.3 of RFC 7230</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7230#section-4.3">Section 4.3 of RFC 7230</a>
 	 */
 	String te() {
 		return "TE"
@@ -416,7 +416,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Trailer} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7230#section-4.4">Section 4.4 of RFC 7230</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7230#section-4.4">Section 4.4 of RFC 7230</a>
 	 */
 	String trailer() {
 		return "Trailer"
@@ -424,7 +424,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Transfer-Encoding} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7230#section-3.3.1">Section 3.3.1 of RFC 7230</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7230#section-3.3.1">Section 3.3.1 of RFC 7230</a>
 	 */
 	String transferEncoding() {
 		return "Transfer-Encoding"
@@ -432,7 +432,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Upgrade} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7230#section-6.7">Section 6.7 of RFC 7230</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7230#section-6.7">Section 6.7 of RFC 7230</a>
 	 */
 	String upgrade() {
 		return "Upgrade"
@@ -440,7 +440,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code User-Agent} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-5.5.3">Section 5.5.3 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.5.3">Section 5.5.3 of RFC 7231</a>
 	 */
 	String user_agent() {
 		return "User-Agent"
@@ -448,7 +448,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Vary} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-7.1.4">Section 7.1.4 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-7.1.4">Section 7.1.4 of RFC 7231</a>
 	 */
 	String vary() {
 		return "Vary"
@@ -456,7 +456,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Via} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7230#section-5.7.1">Section 5.7.1 of RFC 7230</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7230#section-5.7.1">Section 5.7.1 of RFC 7230</a>
 	 */
 	String via() {
 		return "Via"
@@ -464,7 +464,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code Warning} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7234#section-5.5">Section 5.5 of RFC 7234</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.5">Section 5.5 of RFC 7234</a>
 	 */
 	String warning() {
 		return "Warning"
@@ -472,7 +472,7 @@ class HttpHeaders {
 
 	/**
 	 * The HTTP {@code WWW-Authenticate} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7235#section-4.1">Section 4.1 of RFC 7235</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7235#section-4.1">Section 4.1 of RFC 7235</a>
 	 */
 	String wwwAuthenticate() {
 		return "WWW-Authenticate"

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/HttpStatus.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/HttpStatus.groovy
@@ -17,7 +17,7 @@ class HttpStatus {
 
 	/**
 	 * {@code 100 Continue}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.2.1">HTTP/1.1: Semantics and Content, section 6.2.1</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.2.1">HTTP/1.1: Semantics and Content, section 6.2.1</a>
 	 */
 	int CONTINUE() {
 		return 100
@@ -25,19 +25,19 @@ class HttpStatus {
 	
 	/**
 	 * {@code 101 Switching Protocols}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.2.2">HTTP/1.1: Semantics and Content, section 6.2.2</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.2.2">HTTP/1.1: Semantics and Content, section 6.2.2</a>
 	 */
 	int SWITCHING_PROTOCOLS() {
 		return 101
 	}
 	/**
 	 * {@code 102 Processing}.
-	 * @see <a href="http://tools.ietf.org/html/rfc2518#section-10.1">WebDAV</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2518#section-10.1">WebDAV</a>
 	 */
 	int PROCESSING() { return 102 }
 	/**
 	 * {@code 103 Checkpoint}.
-	 * @see <a href="http://code.google.com/p/gears/wiki/ResumableHttpRequestsProposal">A proposal for supporting
+	 * @see <a href="https://code.google.com/p/gears/wiki/ResumableHttpRequestsProposal">A proposal for supporting
 	 * resumable POST/PUT HTTP requests in HTTP/1.0</a>
 	 */
 	int CHECKPOINT() { return 103 }
@@ -46,52 +46,52 @@ class HttpStatus {
 
 	/**
 	 * {@code 200 OK}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.3.1">HTTP/1.1: Semantics and Content, section 6.3.1</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.3.1">HTTP/1.1: Semantics and Content, section 6.3.1</a>
 	 */
 	int OK() { return 200 }
 	/**
 	 * {@code 201 Created}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.3.2">HTTP/1.1: Semantics and Content, section 6.3.2</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.3.2">HTTP/1.1: Semantics and Content, section 6.3.2</a>
 	 */
 	int CREATED() { return 201 }
 	/**
 	 * {@code 202 Accepted}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.3.3">HTTP/1.1: Semantics and Content, section 6.3.3</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.3.3">HTTP/1.1: Semantics and Content, section 6.3.3</a>
 	 */
 	int ACCEPTED() { return 202 }
 	/**
 	 * {@code 203 Non-Authoritative Information}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.3.4">HTTP/1.1: Semantics and Content, section 6.3.4</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.3.4">HTTP/1.1: Semantics and Content, section 6.3.4</a>
 	 */
 	int NON_AUTHORITATIVE_INFORMATION() { return 203 }
 	/**
 	 * {@code 204 No Content}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.3.5">HTTP/1.1: Semantics and Content, section 6.3.5</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.3.5">HTTP/1.1: Semantics and Content, section 6.3.5</a>
 	 */
 	int NO_CONTENT() { return 204 }
 	/**
 	 * {@code 205 Reset Content}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.3.6">HTTP/1.1: Semantics and Content, section 6.3.6</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.3.6">HTTP/1.1: Semantics and Content, section 6.3.6</a>
 	 */
 	int RESET_CONTENT() { return 205 }
 	/**
 	 * {@code 206 Partial Content}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7233#section-4.1">HTTP/1.1: Range Requests, section 4.1</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7233#section-4.1">HTTP/1.1: Range Requests, section 4.1</a>
 	 */
 	int PARTIAL_CONTENT() { return 206 }
 	/**
 	 * {@code 207 Multi-Status}.
-	 * @see <a href="http://tools.ietf.org/html/rfc4918#section-13">WebDAV</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc4918#section-13">WebDAV</a>
 	 */
 	int MULTI_STATUS() { return 207 }
 	/**
 	 * {@code 208 Already Reported}.
-	 * @see <a href="http://tools.ietf.org/html/rfc5842#section-7.1">WebDAV Binding Extensions</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc5842#section-7.1">WebDAV Binding Extensions</a>
 	 */
 	int ALREADY_REPORTED() { return 208 }
 	/**
 	 * {@code 226 IM Used}.
-	 * @see <a href="http://tools.ietf.org/html/rfc3229#section-10.4.1">Delta encoding in HTTP</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc3229#section-10.4.1">Delta encoding in HTTP</a>
 	 */
 	int IM_USED() { return 226 }
 
@@ -99,51 +99,51 @@ class HttpStatus {
 
 	/**
 	 * {@code 300 Multiple Choices}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.4.1">HTTP/1.1: Semantics and Content, section 6.4.1</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.4.1">HTTP/1.1: Semantics and Content, section 6.4.1</a>
 	 */
 	int MULTIPLE_CHOICES() { return 300 }
 	/**
 	 * {@code 301 Moved Permanently}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.4.2">HTTP/1.1: Semantics and Content, section 6.4.2</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.4.2">HTTP/1.1: Semantics and Content, section 6.4.2</a>
 	 */
 	int MOVED_PERMANENTLY() { return 301 }
 	/**
 	 * {@code 302 Found}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.4.3">HTTP/1.1: Semantics and Content, section 6.4.3</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.4.3">HTTP/1.1: Semantics and Content, section 6.4.3</a>
 	 */
 	int FOUND() { return 302 }
 	/**
 	 * {@code 302 Moved Temporarily}.
-	 * @see <a href="http://tools.ietf.org/html/rfc1945#section-9.3">HTTP/1.0, section 9.3</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc1945#section-9.3">HTTP/1.0, section 9.3</a>
 	 * @deprecated in favor of {@link #FOUND} which will be returned from {@code HttpStatus.valueOf(302)}
 	 */
 	@Deprecated
 	int MOVED_TEMPORARILY() { return 302 }
 	/**
 	 * {@code 303 See Other}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.4.4">HTTP/1.1: Semantics and Content, section 6.4.4</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.4.4">HTTP/1.1: Semantics and Content, section 6.4.4</a>
 	 */
 	int SEE_OTHER() { return 303 }
 	/**
 	 * {@code 304 Not Modified}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7232#section-4.1">HTTP/1.1: Conditional Requests, section 4.1</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7232#section-4.1">HTTP/1.1: Conditional Requests, section 4.1</a>
 	 */
 	int NOT_MODIFIED() { return 304 }
 	/**
 	 * {@code 305 Use Proxy}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.4.5">HTTP/1.1: Semantics and Content, section 6.4.5</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.4.5">HTTP/1.1: Semantics and Content, section 6.4.5</a>
 	 * @deprecated due to security concerns regarding in-band configuration of a proxy
 	 */
 	@Deprecated
 	int USE_PROXY() { return 305 }
 	/**
 	 * {@code 307 Temporary Redirect}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.4.7">HTTP/1.1: Semantics and Content, section 6.4.7</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.4.7">HTTP/1.1: Semantics and Content, section 6.4.7</a>
 	 */
 	int TEMPORARY_REDIRECT() { return 307 }
 	/**
 	 * {@code 308 Permanent Redirect}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7238">RFC 7238</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7238">RFC 7238</a>
 	 */
 	int PERMANENT_REDIRECT() { return 308 }
 
@@ -151,78 +151,78 @@ class HttpStatus {
 
 	/**
 	 * {@code 400 Bad Request}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.1">HTTP/1.1: Semantics and Content, section 6.5.1</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.1">HTTP/1.1: Semantics and Content, section 6.5.1</a>
 	 */
 	int BAD_REQUEST() { return 400 }
 	/**
 	 * {@code 401 Unauthorized}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7235#section-3.1">HTTP/1.1: Authentication, section 3.1</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7235#section-3.1">HTTP/1.1: Authentication, section 3.1</a>
 	 */
 	int UNAUTHORIZED() { return 401 }
 	/**
 	 * {@code 402 Payment Required}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.2">HTTP/1.1: Semantics and Content, section 6.5.2</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.2">HTTP/1.1: Semantics and Content, section 6.5.2</a>
 	 */
 	int PAYMENT_REQUIRED() { return 402 }
 	/**
 	 * {@code 403 Forbidden}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.3">HTTP/1.1: Semantics and Content, section 6.5.3</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.3">HTTP/1.1: Semantics and Content, section 6.5.3</a>
 	 */
 	int FORBIDDEN() { return 403 }
 	/**
 	 * {@code 404 Not Found}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.4">HTTP/1.1: Semantics and Content, section 6.5.4</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.4">HTTP/1.1: Semantics and Content, section 6.5.4</a>
 	 */
 	int NOT_FOUND() { return 404 }
 	/**
 	 * {@code 405 Method Not Allowed}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.5">HTTP/1.1: Semantics and Content, section 6.5.5</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.5">HTTP/1.1: Semantics and Content, section 6.5.5</a>
 	 */
 	int METHOD_NOT_ALLOWED() { return 405 }
 	/**
 	 * {@code 406 Not Acceptable}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.6">HTTP/1.1: Semantics and Content, section 6.5.6</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.6">HTTP/1.1: Semantics and Content, section 6.5.6</a>
 	 */
 	int NOT_ACCEPTABLE() { return 406 }
 	/**
 	 * {@code 407 Proxy Authentication Required}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7235#section-3.2">HTTP/1.1: Authentication, section 3.2</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7235#section-3.2">HTTP/1.1: Authentication, section 3.2</a>
 	 */
 	int PROXY_AUTHENTICATION_REQUIRED() { return 407 }
 	/**
 	 * {@code 408 Request Timeout}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.7">HTTP/1.1: Semantics and Content, section 6.5.7</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.7">HTTP/1.1: Semantics and Content, section 6.5.7</a>
 	 */
 	int REQUEST_TIMEOUT() { return 408 }
 	/**
 	 * {@code 409 Conflict}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.8">HTTP/1.1: Semantics and Content, section 6.5.8</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.8">HTTP/1.1: Semantics and Content, section 6.5.8</a>
 	 */
 	int CONFLICT() { return 409 }
 	/**
 	 * {@code 410 Gone}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.9">HTTP/1.1: Semantics and Content, section 6.5.9</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.9">HTTP/1.1: Semantics and Content, section 6.5.9</a>
 	 */
 	int GONE() { return 410 }
 	/**
 	 * {@code 411 Length Required}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.10">HTTP/1.1: Semantics and Content, section 6.5.10</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.10">HTTP/1.1: Semantics and Content, section 6.5.10</a>
 	 */
 	int LENGTH_REQUIRED() { return 411 }
 	/**
 	 * {@code 412 Precondition failed}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7232#section-4.2">HTTP/1.1: Conditional Requests, section 4.2</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7232#section-4.2">HTTP/1.1: Conditional Requests, section 4.2</a>
 	 */
 	int PRECONDITION_FAILED() { return 412 }
 	/**
 	 * {@code 413 Payload Too Large}.
 	 * @since 4.1
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.11">HTTP/1.1: Semantics and Content, section 6.5.11</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.11">HTTP/1.1: Semantics and Content, section 6.5.11</a>
 	 */
 	int PAYLOAD_TOO_LARGE() { return 413 }
 	/**
 	 * {@code 413 Request Entity Too Large}.
-	 * @see <a href="http://tools.ietf.org/html/rfc2616#section-10.4.14">HTTP/1.1, section 10.4.14</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2616#section-10.4.14">HTTP/1.1, section 10.4.14</a>
 	 * @deprecated in favor of {@link #PAYLOAD_TOO_LARGE} which will be returned from {@code HttpStatus.valueOf(413)}
 	 */
 	@Deprecated
@@ -230,84 +230,84 @@ class HttpStatus {
 	/**
 	 * {@code 414 URI Too Long}.
 	 * @since 4.1
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.12">HTTP/1.1: Semantics and Content, section 6.5.12</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.12">HTTP/1.1: Semantics and Content, section 6.5.12</a>
 	 */
 	int URI_TOO_LONG() { return 414 }
 	/**
 	 * {@code 414 Request-URI Too Long}.
-	 * @see <a href="http://tools.ietf.org/html/rfc2616#section-10.4.15">HTTP/1.1, section 10.4.15</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2616#section-10.4.15">HTTP/1.1, section 10.4.15</a>
 	 * @deprecated in favor of {@link #URI_TOO_LONG} which will be returned from {@code HttpStatus.valueOf(414)}
 	 */
 	@Deprecated
 	int REQUEST_URI_TOO_LONG() { return 414 }
 	/**
 	 * {@code 415 Unsupported Media Type}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.13">HTTP/1.1: Semantics and Content, section 6.5.13</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.13">HTTP/1.1: Semantics and Content, section 6.5.13</a>
 	 */
 	int UNSUPPORTED_MEDIA_TYPE() { return 415 }
 	/**
 	 * {@code 416 Requested Range Not Satisfiable}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7233#section-4.4">HTTP/1.1: Range Requests, section 4.4</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7233#section-4.4">HTTP/1.1: Range Requests, section 4.4</a>
 	 */
 	int REQUESTED_RANGE_NOT_SATISFIABLE() { return 416 }
 	/**
 	 * {@code 417 Expectation Failed}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.14">HTTP/1.1: Semantics and Content, section 6.5.14</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.14">HTTP/1.1: Semantics and Content, section 6.5.14</a>
 	 */
 	int EXPECTATION_FAILED() { return 417 }
 	/**
 	 * {@code 418 I'm a teapot}.
-	 * @see <a href="http://tools.ietf.org/html/rfc2324#section-2.3.2">HTCPCP/1.0</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2324#section-2.3.2">HTCPCP/1.0</a>
 	 */
 	int I_AM_A_TEAPOT() { return 418 }
 	/**
-	 * @deprecated See <a href="http://tools.ietf.org/rfcdiff?difftype=--hwdiff&url2=draft-ietf-webdav-protocol-06.txt">WebDAV Draft Changes</a>
+	 * @deprecated See <a href="https://tools.ietf.org/rfcdiff?difftype=--hwdiff&url2=draft-ietf-webdav-protocol-06.txt">WebDAV Draft Changes</a>
 	 */
 	@Deprecated
 	int INSUFFICIENT_SPACE_ON_RESOURCE() { return 419 }
 	/**
-	 * @deprecated See <a href="http://tools.ietf.org/rfcdiff?difftype=--hwdiff&url2=draft-ietf-webdav-protocol-06.txt">WebDAV Draft Changes</a>
+	 * @deprecated See <a href="https://tools.ietf.org/rfcdiff?difftype=--hwdiff&url2=draft-ietf-webdav-protocol-06.txt">WebDAV Draft Changes</a>
 	 */
 	@Deprecated
 	int METHOD_FAILURE() { return 420 }
 	/**
-	 * @deprecated See <a href="http://tools.ietf.org/rfcdiff?difftype=--hwdiff&url2=draft-ietf-webdav-protocol-06.txt">WebDAV Draft Changes</a>
+	 * @deprecated See <a href="https://tools.ietf.org/rfcdiff?difftype=--hwdiff&url2=draft-ietf-webdav-protocol-06.txt">WebDAV Draft Changes</a>
 	 */
 	@Deprecated
 	int DESTINATION_LOCKED() { return 421 }
 	/**
 	 * {@code 422 Unprocessable Entity}.
-	 * @see <a href="http://tools.ietf.org/html/rfc4918#section-11.2">WebDAV</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc4918#section-11.2">WebDAV</a>
 	 */
 	int UNPROCESSABLE_ENTITY() { return 422 }
 	/**
 	 * {@code 423 Locked}.
-	 * @see <a href="http://tools.ietf.org/html/rfc4918#section-11.3">WebDAV</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc4918#section-11.3">WebDAV</a>
 	 */
 	int LOCKED() { return 423 }
 	/**
 	 * {@code 424 Failed Dependency}.
-	 * @see <a href="http://tools.ietf.org/html/rfc4918#section-11.4">WebDAV</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc4918#section-11.4">WebDAV</a>
 	 */
 	int FAILED_DEPENDENCY() { return 424 }
 	/**
 	 * {@code 426 Upgrade Required}.
-	 * @see <a href="http://tools.ietf.org/html/rfc2817#section-6">Upgrading to TLS Within HTTP/1.1</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2817#section-6">Upgrading to TLS Within HTTP/1.1</a>
 	 */
 	int UPGRADE_REQUIRED() { return 426 }
 	/**
 	 * {@code 428 Precondition Required}.
-	 * @see <a href="http://tools.ietf.org/html/rfc6585#section-3">Additional HTTP Status Codes</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc6585#section-3">Additional HTTP Status Codes</a>
 	 */
 	int PRECONDITION_REQUIRED() { return 428 }
 	/**
 	 * {@code 429 Too Many Requests}.
-	 * @see <a href="http://tools.ietf.org/html/rfc6585#section-4">Additional HTTP Status Codes</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc6585#section-4">Additional HTTP Status Codes</a>
 	 */
 	int TOO_MANY_REQUESTS() { return 429 }
 	/**
 	 * {@code 431 Request Header Fields Too Large}.
-	 * @see <a href="http://tools.ietf.org/html/rfc6585#section-5">Additional HTTP Status Codes</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc6585#section-5">Additional HTTP Status Codes</a>
 	 */
 	int REQUEST_HEADER_FIELDS_TOO_LARGE() { return 431 }
 	/**
@@ -322,47 +322,47 @@ class HttpStatus {
 
 	/**
 	 * {@code 500 Internal Server Error}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.6.1">HTTP/1.1: Semantics and Content, section 6.6.1</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.6.1">HTTP/1.1: Semantics and Content, section 6.6.1</a>
 	 */
 	int INTERNAL_SERVER_ERROR() { return 500 }
 	/**
 	 * {@code 501 Not Implemented}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.6.2">HTTP/1.1: Semantics and Content, section 6.6.2</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.6.2">HTTP/1.1: Semantics and Content, section 6.6.2</a>
 	 */
 	int NOT_IMPLEMENTED() { return 501 }
 	/**
 	 * {@code 502 Bad Gateway}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.6.3">HTTP/1.1: Semantics and Content, section 6.6.3</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.6.3">HTTP/1.1: Semantics and Content, section 6.6.3</a>
 	 */
 	int BAD_GATEWAY() { return 502 }
 	/**
 	 * {@code 503 Service Unavailable}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.6.4">HTTP/1.1: Semantics and Content, section 6.6.4</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.6.4">HTTP/1.1: Semantics and Content, section 6.6.4</a>
 	 */
 	int SERVICE_UNAVAILABLE() { return 503 }
 	/**
 	 * {@code 504 Gateway Timeout}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.6.5">HTTP/1.1: Semantics and Content, section 6.6.5</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.6.5">HTTP/1.1: Semantics and Content, section 6.6.5</a>
 	 */
 	int GATEWAY_TIMEOUT() { return 504 }
 	/**
 	 * {@code 505 HTTP Version Not Supported}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.6.6">HTTP/1.1: Semantics and Content, section 6.6.6</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.6.6">HTTP/1.1: Semantics and Content, section 6.6.6</a>
 	 */
 	int HTTP_VERSION_NOT_SUPPORTED() { return 505 }
 	/**
 	 * {@code 506 Variant Also Negotiates}
-	 * @see <a href="http://tools.ietf.org/html/rfc2295#section-8.1">Transparent Content Negotiation</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2295#section-8.1">Transparent Content Negotiation</a>
 	 */
 	int VARIANT_ALSO_NEGOTIATES() { return 506 }
 	/**
 	 * {@code 507 Insufficient Storage}
-	 * @see <a href="http://tools.ietf.org/html/rfc4918#section-11.5">WebDAV</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc4918#section-11.5">WebDAV</a>
 	 */
 	int INSUFFICIENT_STORAGE() { return 507 }
 	/**
 	 * {@code 508 Loop Detected}
-	 * @see <a href="http://tools.ietf.org/html/rfc5842#section-7.2">WebDAV Binding Extensions</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc5842#section-7.2">WebDAV Binding Extensions</a>
 	 */
 	int LOOP_DETECTED() { return 508 }
 	/**
@@ -371,12 +371,12 @@ class HttpStatus {
 	int BANDWIDTH_LIMIT_EXCEEDED() { return 509 }
 	/**
 	 * {@code 510 Not Extended}
-	 * @see <a href="http://tools.ietf.org/html/rfc2774#section-7">HTTP Extension Framework</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2774#section-7">HTTP Extension Framework</a>
 	 */
 	int NOT_EXTENDED() { return 510 }
 	/**
 	 * {@code 511 Network Authentication Required}.
-	 * @see <a href="http://tools.ietf.org/html/rfc6585#section-6">Additional HTTP Status Codes</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc6585#section-6">Additional HTTP Status Codes</a>
 	 */
 	int NETWORK_AUTHENTICATION_REQUIRED() { return 511 }
 }

--- a/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/RegexPatterns.groovy
+++ b/spring-cloud-contract-spec/src/main/groovy/org/springframework/cloud/contract/spec/internal/RegexPatterns.groovy
@@ -180,7 +180,7 @@ class UrlHelper {
 
 	// Examples: "fitbit.com", "22.231.113.64".
 	private static final String REGEX_HOST = "(?:" +
-			// @Author = http://www.regular-expressions.info/examples.html
+			// @Author = https://www.regular-expressions.info/examples.html
 			// IP address
 			"(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" +
 			"|" +

--- a/spring-cloud-contract-spec/src/test/groovy/org/springframework/cloud/contract/spec/internal/RegexPatternsSpec.groovy
+++ b/spring-cloud-contract-spec/src/test/groovy/org/springframework/cloud/contract/spec/internal/RegexPatternsSpec.groovy
@@ -54,57 +54,57 @@ class RegexPatternsSpec extends Specification {
 			'asdf@asdf.online' || true
 	}
 
-	// @see http://formvalidation.io/validators/uri/
+	// @see https://formvalidation.io/validators/uri/
 	def "should generate a regex for url [#textToMatch] that is a match [#shouldMatch]"() {
 		expect:
 			shouldMatch == regexPatterns.url().matcher(textToMatch).matches()
 		where:
 			textToMatch                                         || shouldMatch
 			'ftp://asd.com:9090/asd/a?a=b'                      || true
-			'http://foo.com/blah_blah'                          || true
-			'http://foo.com/blah_blah/'                         || true
-			'http://foo.com/blah_blah_(wikipedia)'              || true
-			'http://foo.com/blah_blah_(wikipedia)_(again)'      || true
-			'http://www.example.com/wpstyle/?p=364'             || true
+			'http://www.foo.com/blah_blah'                          || true
+			'http://www.foo.com/blah_blah/'                         || true
+			'http://www.foo.com/blah_blah_(wikipedia)'              || true
+			'http://www.foo.com/blah_blah_(wikipedia)_(again)'      || true
+			'https://www.example.com/wpstyle/?p=364'             || true
 			'https://www.example.com/foo/?bar=baz&inga=42&quux' || true
 			'http://✪df.ws/123'                                 || true
-			'http://userid:password@example.com:8080'           || true
-			'http://userid:password@example.com:8080/'          || true
-			'http://userid@example.com'                         || true
-			'http://userid@example.com/'                        || true
-			'http://userid@example.com:8080'                    || true
-			'http://userid@example.com:8080/'                   || true
-			'http://userid:password@example.com'                || true
-			'http://userid:password@example.com/'               || true
-			'http://142.42.1.1/'                                || true
-			'http://142.42.1.1:8080/'                           || true
+			'https://userid:password@example.com:8080'           || true
+			'https://userid:password@example.com:8080/'          || true
+			'https://userid@example.com'                         || true
+			'https://userid@example.com/'                        || true
+			'https://userid@example.com:8080'                    || true
+			'https://userid@example.com:8080/'                   || true
+			'https://userid:password@example.com'                || true
+			'https://userid:password@example.com/'               || true
+			'https://142.42.1.1/'                                || true
+			'https://142.42.1.1:8080/'                           || true
 			'http://⌘.ws'                                       || true
 			'http://⌘.ws/'                                      || true
-			'http://foo.com/blah_(wikipedia)#cite-1'            || true
-			'http://foo.com/blah_(wikipedia)_blah#cite-1'       || true
-			'http://foo.com/unicode_(✪)_in_parens'              || true
-			'http://foo.com/(something)?after=parens'           || true
+			'http://www.foo.com/blah_(wikipedia)#cite-1'            || true
+			'http://www.foo.com/blah_(wikipedia)_blah#cite-1'       || true
+			'http://www.foo.com/unicode_(✪)_in_parens'              || true
+			'http://www.foo.com/(something)?after=parens'           || true
 			'http://☺.damowmow.com/'                            || true
-			'http://code.google.com/events/#&product=browser'   || true
-			'http://j.mp'                                       || true
+			'https://code.google.com/events/#&product=browser'   || true
+			'https://j.mp'                                       || true
 			'ftp://foo.bar/baz'                                 || true
-			'http://foo.bar/?q=Test%20URL-encoded%20stuff'      || true
+			'https://foo.bar/?q=Test%20URL-encoded%20stuff'      || true
 			'http://1337.net'                                   || true
-			'http://a.b-c.de'                                   || true
-			'http://223.255.255.254'                            || true
+			'https://a.b-c.de'                                   || true
+			'https://223.255.255.254'                            || true
 			'foo.com'                                           || true
 			'a.b.'                                              || false
 			'http://'                                           || false
 			'http://.'                                          || false
 			'http://..'                                         || false
-			'http://../'                                        || false
+			'https://../'                                        || false
 			'http://?'                                          || false
 			'http://??'                                         || false
 			'http://??/'                                        || false
 			'http://#'                                          || false
 			'http://##'                                         || false
 			'http://##/'                                        || false
-			'http://foo.bar?q=Spaces should be encoded'         || false
+			'https://foo.bar?q=Spaces should be encoded'         || false
 			'//'                                                || false
 			'//a'                                               || false
 			'///a'                                              || false
@@ -114,16 +114,16 @@ class RegexPatternsSpec extends Specification {
 			'h://test'                                          || false
 			'http:// shouldfail.com'                            || false
 			':// should fail'                                   || false
-			'http://foo.bar/foo(bar)baz quux'                   || false
-			'http://-error-.invalid/'                           || false
-			'http://-a.b.co'                                    || false
-			'http://a.b-.co'                                    || false
-			'http://1.1.1.1.1'                                  || false
-			'http://123.123.123'                                || false
+			'https://foo.bar/foo(bar)baz quux'                   || false
+			'https://-error-.invalid/'                           || false
+			'https://-a.b.co'                                    || false
+			'https://a.b-.co'                                    || false
+			'https://1.1.1.1.1'                                  || false
+			'https://123.123.123'                                || false
 			'http://3628126748'                                 || false
-			'http://.www.foo.bar/'                              || false
-			'http://www.foo.bar./'                              || false
-			'http://.www.foo.bar./'                             || false
+			'https://.www.foo.bar/'                              || false
+			'https://www.foo.bar./'                              || false
+			'https://.www.foo.bar./'                             || false
 	}
 
 	def "should generate a regex for httpsUrl [#textToMatch] that is a match [#shouldMatch]"() {
@@ -134,8 +134,8 @@ class RegexPatternsSpec extends Specification {
 			'ftp://asd.com:9090/asd/a?a=b'                      || false
 			'https://foo.com/blah_blah/'                        || true
 			'https://foo.com/blah_blah'                         || true
-			'http://foo.com/blah_blah'                          || false
-			'http://foo.com/blah_blah/'                         || false
+			'http://www.foo.com/blah_blah'                          || false
+			'http://www.foo.com/blah_blah/'                         || false
 			'https://foo.com/blah_blah_(wikipedia)'             || true
 			'https://foo.com/blah_blah_(wikipedia)_(again)'     || true
 			'https://www.example.com/wpstyle/?p=364'            || true

--- a/spring-cloud-contract-stub-runner/README.adoc
+++ b/spring-cloud-contract-stub-runner/README.adoc
@@ -4,7 +4,7 @@
 === Stub Runner Core
 
 Runs stubs for service collaborators. Treating stubs as contracts of services allows to use stub-runner as an implementation of 
-http://martinfowler.com/articles/consumerDrivenContracts.html[Consumer Driven Contracts].
+https://martinfowler.com/articles/consumerDrivenContracts.html[Consumer Driven Contracts].
 
 Stub Runner allows you to automatically download the stubs of the provided dependencies (or pick those from the classpath), start WireMock servers for them and feed them with proper stub definitions.
 For messaging, special stub routes are defined.
@@ -32,7 +32,7 @@ Example:
 
 [source,java]
 ----
-@AutoConfigureStubRunner(repositoryRoot="http://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)
+@AutoConfigureStubRunner(repositoryRoot="https://foo.bar", ids = "com.example:beer-api-producer:+:stubs:8095", stubsMode = StubRunnerProperties.StubsMode.LOCAL)
 ----
 
 ===== Classpath scanning
@@ -508,7 +508,7 @@ $ java -jar stub-runner.jar --stubrunner.ids=... --stubrunner.repositoryRoot=...
 
 ===== Spring Cloud CLI
 
-Starting from `1.4.0.RELEASE` version of the http://cloud.spring.io/spring-cloud-cli[Spring Cloud CLI]
+Starting from `1.4.0.RELEASE` version of the https://cloud.spring.io/spring-cloud-cli[Spring Cloud CLI]
 project you can start Stub Runner Boot by executing `spring cloud stubrunner`.
 
 In order to pass the configuration just create a `stubrunner.yml` file in the current working directory

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/serverexamples/StubRunnerBootEurekaExample.java
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/serverexamples/StubRunnerBootEurekaExample.java
@@ -42,7 +42,7 @@ public class StubRunnerBootEurekaExample {
 /*
 
 // tag::stubrunnereureka_args[]
--Dstubrunner.repositoryRoot=http://repo.spring.io/snapshots (1)
+-Dstubrunner.repositoryRoot=https://repo.spring.io/snapshots (1)
 -Dstubrunner.cloud.stubbed.discovery.enabled=false (2)
 -Dstubrunner.ids=org.springframework.cloud.contract.verifier.stubs:loanIssuance,org.springframework.cloud.contract.verifier.stubs:fraudDetectionServer,org.springframework.cloud.contract.verifier.stubs:bootService (3)
 -Dstubrunner.idsToServiceIds.fraudDetectionServer=someNameThatShouldMapFraudDetectionServer (4)

--- a/spring-cloud-contract-stub-runner/src/test/java/org/springframework/cloud/contract/stubrunner/GitStubDownloaderTests.java
+++ b/spring-cloud-contract-stub-runner/src/test/java/org/springframework/cloud/contract/stubrunner/GitStubDownloaderTests.java
@@ -74,7 +74,7 @@ public class GitStubDownloaderTests {
 		StubDownloader stubDownloader = stubDownloaderBuilder
 				.build(new StubRunnerOptionsBuilder()
 						.withStubsMode(StubRunnerProperties.StubsMode.REMOTE)
-						.withStubRepositoryRoot("http://foo.com").withProperties(props())
+						.withStubRepositoryRoot("http://www.foo.com/").withProperties(props())
 						.build());
 
 		then(stubDownloader).isNull();

--- a/spring-cloud-contract-stub-runner/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/bootService/0.0.1-SNAPSHOT/bootService-0.0.1-SNAPSHOT.pom
+++ b/spring-cloud-contract-stub-runner/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/bootService/0.0.1-SNAPSHOT/bootService-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/spring-cloud-contract-stub-runner/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/fraudDetectionServer/0.0.1-SNAPSHOT/fraudDetectionServer-0.0.1-SNAPSHOT.pom
+++ b/spring-cloud-contract-stub-runner/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/fraudDetectionServer/0.0.1-SNAPSHOT/fraudDetectionServer-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/spring-cloud-contract-stub-runner/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/loanIssuance/0.0.1-SNAPSHOT/loanIssuance-0.0.1-SNAPSHOT.pom
+++ b/spring-cloud-contract-stub-runner/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/loanIssuance/0.0.1-SNAPSHOT/loanIssuance-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/spring-cloud-contract-stub-runner/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/producerWithMultipleConsumers/0.0.1-SNAPSHOT/producerWithMultipleConsumers-0.0.1-SNAPSHOT.pom
+++ b/spring-cloud-contract-stub-runner/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/producerWithMultipleConsumers/0.0.1-SNAPSHOT/producerWithMultipleConsumers-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/spring-cloud-contract-tools/spring-cloud-contract-converters/src/test/groovy/org/springframework/cloud/contract/verifier/wiremock/DslToWireMockClientConverterSpec.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-converters/src/test/groovy/org/springframework/cloud/contract/verifier/wiremock/DslToWireMockClientConverterSpec.groovy
@@ -287,7 +287,7 @@ class DslToWireMockClientConverterSpec extends Specification {
 							"id":"01fbe706f872cb32",
 							"name":"Washington",
 							"place_type":"city",
-							"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+							"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 						}
 					}]
 				'''
@@ -327,7 +327,7 @@ class DslToWireMockClientConverterSpec extends Specification {
 	}, {
 	  "matchesJsonPath" : "$[*].['place'].['bounding_box'][?(@.['type'] == 'Polygon')]"
 	}, {
-	  "matchesJsonPath" : "$[*].['place'][?(@.['url'] == 'http://api.twitter.com/1/geo/id/01fbe706f872cb32.json')]"
+	  "matchesJsonPath" : "$[*].['place'][?(@.['url'] == 'https://api.twitter.com/1/geo/id/01fbe706f872cb32.json')]"
 	}, {
 	  "matchesJsonPath" : "$[*].['place'].['bounding_box'].['coordinates'][*][*][?(@ == 38.995548)]"
 	}, {
@@ -383,7 +383,7 @@ class DslToWireMockClientConverterSpec extends Specification {
 									"id":"01fbe706f872cb32",
 									"name":"Washington",
 									"place_type":"city",
-									"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+									"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 								}
 							}]'''), String)
 	}

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/test/resources/functionalTest/sampleJerseyProject/m2repo/repository/com/example/jersey-contracts/0.0.1-SNAPSHOT/jersey-contracts-0.0.1-SNAPSHOT.pom
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/test/resources/functionalTest/sampleJerseyProject/m2repo/repository/com/example/jersey-contracts/0.0.1-SNAPSHOT/jersey-contracts-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>

--- a/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/test/resources/m2repo/repository/com/example/contracts/0.0.1-SNAPSHOT/contracts-0.0.1-SNAPSHOT.pom
+++ b/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/test/resources/m2repo/repository/com/example/contracts/0.0.1-SNAPSHOT/contracts-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>

--- a/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/test/resources/m2repo/repository/com/example/contracts/1.0.4-SNAPSHOT/contracts-0.0.1-SNAPSHOT.pom
+++ b/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/test/resources/m2repo/repository/com/example/contracts/1.0.4-SNAPSHOT/contracts-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>

--- a/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/test/resources/m2repo/repository/com/example/services-contracts/1.0.4-SNAPSHOT/services-contracts-1.0.4-SNAPSHOT.pom
+++ b/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/test/resources/m2repo/repository/com/example/services-contracts/1.0.4-SNAPSHOT/services-contracts-1.0.4-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/TestSideRequestTemplateModel.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/TestSideRequestTemplateModel.groovy
@@ -82,7 +82,7 @@ class TestSideRequestTemplateModel {
 	}
 
 	private static List<String> buildPathsFromUrl(String url) {
-		String fakeUrl = "http://foo.bar" + (url.startsWith("/") ? url : "/" + url)
+		String fakeUrl = "https://foo.bar" + (url.startsWith("/") ? url : "/" + url)
 		List<String> paths = new URL(fakeUrl).path.split("/") as List<String>
 		if (!paths.isEmpty()) {
 			paths.remove(0)

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/JaxRsClientMethodBuilderSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/JaxRsClientMethodBuilderSpec.groovy
@@ -1181,7 +1181,7 @@ class JaxRsClientMethodBuilderSpec extends Specification implements WireMockStub
 			SyntaxChecker.tryToCompile(methodBuilderName, blockBuilder.toString())
 		and:
 			String jsonSample = '''\
-	String json = "{\\"duck\\":\\"8\\",\\"alpha\\":\\"YAJEOWYGMFBEWPMEMAZI\\",\\"number\\":-2095030871,\\"positiveInt\\":42,\\"aDouble\\":42.345,\\"aBoolean\\":true,\\"ip\\":\\"129.168.99.100\\",\\"hostname\\":\\"http://foo389886219.com\\",\\"email\\":\\"foo@bar1367573183.com\\",\\"url\\":\\"http://foo-597104692.com\\",\\"httpsUrl\\":\\"https://baz-486093581.com\\",\\"uuid\\":\\"e436b817-b764-49a2-908e-967f2f99eb9f\\",\\"date\\":\\"2014-04-14\\",\\"dateTime\\":\\"2011-01-11T12:23:34\\",\\"time\\":\\"12:20:30\\",\\"iso8601WithOffset\\":\\"2015-05-15T12:23:34.123Z\\",\\"nonBlankString\\":\\"EPZWVIRHSUAPBJMMQSFO\\",\\"nonEmptyString\\":\\"RVMFDSEQFHRQFVUVQPIA\\",\\"anyOf\\":\\"foo\\"}";
+	String json = "{\\"duck\\":\\"8\\",\\"alpha\\":\\"YAJEOWYGMFBEWPMEMAZI\\",\\"number\\":-2095030871,\\"positiveInt\\":42,\\"aDouble\\":42.345,\\"aBoolean\\":true,\\"ip\\":\\"129.168.99.100\\",\\"hostname\\":\\"https://foo389886219.com\\",\\"email\\":\\"foo@bar1367573183.com\\",\\"url\\":\\"https://foo-597104692.com\\",\\"httpsUrl\\":\\"https://baz-486093581.com\\",\\"uuid\\":\\"e436b817-b764-49a2-908e-967f2f99eb9f\\",\\"date\\":\\"2014-04-14\\",\\"dateTime\\":\\"2011-01-11T12:23:34\\",\\"time\\":\\"12:20:30\\",\\"iso8601WithOffset\\":\\"2015-05-15T12:23:34.123Z\\",\\"nonBlankString\\":\\"EPZWVIRHSUAPBJMMQSFO\\",\\"nonEmptyString\\":\\"RVMFDSEQFHRQFVUVQPIA\\",\\"anyOf\\":\\"foo\\"}";
 	DocumentContext parsedJson = JsonPath.parse(json);
 	'''
 		and:

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MessagingMethodBodyBuilderSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/MessagingMethodBodyBuilderSpec.groovy
@@ -599,7 +599,7 @@ Contract.make {
 			!test.contains('REGEXP>>')
 		and:
 			String jsonSample = '''\
-	String json = "{\\"shouldFail\\":123,\\"duck\\":\\"8\\",\\"alpha\\":\\"YAJEOWYGMFBEWPMEMAZI\\",\\"number\\":-2095030871,\\"anInteger\\":1780305902,\\"positiveInt\\":345,\\"aDouble\\":42.345,\\"aBoolean\\":true,\\"ip\\":\\"129.168.99.100\\",\\"hostname\\":\\"http://foo389886219.com\\",\\"email\\":\\"foo@bar1367573183.com\\",\\"url\\":\\"http://foo-597104692.com\\",\\"httpsUrl\\":\\"https://baz-486093581.com\\",\\"uuid\\":\\"e436b817-b764-49a2-908e-967f2f99eb9f\\",\\"date\\":\\"2014-04-14\\",\\"dateTime\\":\\"2011-01-11T12:23:34\\",\\"time\\":\\"12:20:30\\",\\"iso8601WithOffset\\":\\"2015-05-15T12:23:34.123Z\\",\\"nonBlankString\\":\\"EPZWVIRHSUAPBJMMQSFO\\",\\"nonEmptyString\\":\\"RVMFDSEQFHRQFVUVQPIA\\",\\"anyOf\\":\\"foo\\"}";
+	String json = "{\\"shouldFail\\":123,\\"duck\\":\\"8\\",\\"alpha\\":\\"YAJEOWYGMFBEWPMEMAZI\\",\\"number\\":-2095030871,\\"anInteger\\":1780305902,\\"positiveInt\\":345,\\"aDouble\\":42.345,\\"aBoolean\\":true,\\"ip\\":\\"129.168.99.100\\",\\"hostname\\":\\"https://foo389886219.com\\",\\"email\\":\\"foo@bar1367573183.com\\",\\"url\\":\\"https://foo-597104692.com\\",\\"httpsUrl\\":\\"https://baz-486093581.com\\",\\"uuid\\":\\"e436b817-b764-49a2-908e-967f2f99eb9f\\",\\"date\\":\\"2014-04-14\\",\\"dateTime\\":\\"2011-01-11T12:23:34\\",\\"time\\":\\"12:20:30\\",\\"iso8601WithOffset\\":\\"2015-05-15T12:23:34.123Z\\",\\"nonBlankString\\":\\"EPZWVIRHSUAPBJMMQSFO\\",\\"nonEmptyString\\":\\"RVMFDSEQFHRQFVUVQPIA\\",\\"anyOf\\":\\"foo\\"}";
 	DocumentContext parsedJson = JsonPath.parse(json);
 	'''
 		and:

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/SpringTestMethodBodyBuildersSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/SpringTestMethodBodyBuildersSpec.groovy
@@ -1961,7 +1961,7 @@ World.'''"""
 						"id":"01fbe706f872cb32",
 						"name":"Washington",
 						"place_type":"city",
-						"url": "http://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
+						"url": "https://api.twitter.com/1/geo/id/01fbe706f872cb32.json"
 					}
 				}]
 			'''
@@ -2323,7 +2323,7 @@ World.'''"""
         SyntaxChecker.tryToCompile(methodBuilderName, blockBuilder.toString())
         and:
         String jsonSample = '''\
-String json = "{\\"duck\\":\\"8\\",\\"alpha\\":\\"YAJEOWYGMFBEWPMEMAZI\\",\\"number\\":-2095030871,\\"anInteger\\":1780305902,\\"positiveInt\\":345,\\"aDouble\\":42.345,\\"aBoolean\\":true,\\"ip\\":\\"129.168.99.100\\",\\"hostname\\":\\"http://foo389886219.com\\",\\"email\\":\\"foo@bar1367573183.com\\",\\"url\\":\\"http://foo-597104692.com\\",\\"httpsUrl\\":\\"https://baz-486093581.com\\",\\"uuid\\":\\"e436b817-b764-49a2-908e-967f2f99eb9f\\",\\"date\\":\\"2014-04-14\\",\\"dateTime\\":\\"2011-01-11T12:23:34\\",\\"time\\":\\"12:20:30\\",\\"iso8601WithOffset\\":\\"2015-05-15T12:23:34.123Z\\",\\"nonBlankString\\":\\"EPZWVIRHSUAPBJMMQSFO\\",\\"nonEmptyString\\":\\"RVMFDSEQFHRQFVUVQPIA\\",\\"anyOf\\":\\"foo\\"}";
+String json = "{\\"duck\\":\\"8\\",\\"alpha\\":\\"YAJEOWYGMFBEWPMEMAZI\\",\\"number\\":-2095030871,\\"anInteger\\":1780305902,\\"positiveInt\\":345,\\"aDouble\\":42.345,\\"aBoolean\\":true,\\"ip\\":\\"129.168.99.100\\",\\"hostname\\":\\"https://foo389886219.com\\",\\"email\\":\\"foo@bar1367573183.com\\",\\"url\\":\\"https://foo-597104692.com\\",\\"httpsUrl\\":\\"https://baz-486093581.com\\",\\"uuid\\":\\"e436b817-b764-49a2-908e-967f2f99eb9f\\",\\"date\\":\\"2014-04-14\\",\\"dateTime\\":\\"2011-01-11T12:23:34\\",\\"time\\":\\"12:20:30\\",\\"iso8601WithOffset\\":\\"2015-05-15T12:23:34.123Z\\",\\"nonBlankString\\":\\"EPZWVIRHSUAPBJMMQSFO\\",\\"nonEmptyString\\":\\"RVMFDSEQFHRQFVUVQPIA\\",\\"anyOf\\":\\"foo\\"}";
 DocumentContext parsedJson = JsonPath.parse(json);
 '''
         and:

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/WiremockMockServerApplicationTests.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/WiremockMockServerApplicationTests.java
@@ -23,9 +23,9 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void simpleGet() throws Exception {
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/resource.json").build();
-		assertThat(this.restTemplate.getForObject("http://example.org/resource",
+		assertThat(this.restTemplate.getForObject("https://example.org/resource",
 				String.class)).isEqualTo("Hello World");
 		server.verify();
 	}
@@ -33,10 +33,10 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void simplePutShouldFail() throws Exception {
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/resource.json").build();
 		RequestEntity<Void> postRequest = RequestEntity
-				.post(URI.create("http://example.org/resource"))
+				.post(URI.create("https://example.org/resource"))
 				.accept(MediaType.TEXT_PLAIN).build();
 		ResponseEntity<String> response;
 		try {
@@ -54,9 +54,9 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void simpleGetWithBodyFile() throws Exception {
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/resource-with-body-file.json").build();
-		assertThat(this.restTemplate.getForObject("http://example.org/resource",
+		assertThat(this.restTemplate.getForObject("https://example.org/resource",
 				String.class)).isEqualTo("{\"message\":\"Hello World\"}");
 		server.verify();
 	}
@@ -64,10 +64,10 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void simpleGetWithBodyFileCustomLocation() throws Exception {
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/resource-with-body-file.json")
 				.files("classpath:/custom/").build();
-		assertThat(this.restTemplate.getForObject("http://example.org/resource",
+		assertThat(this.restTemplate.getForObject("https://example.org/resource",
 				String.class)).isEqualTo("{\"message\":\"Hello Custom\"}");
 		server.verify();
 	}
@@ -75,10 +75,10 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void simpleGetWithBodyFileCustomLocationDirectory() throws Exception {
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/resource-with-body-file.json")
 				.files("file:src/test/resources/custom").build();
-		assertThat(this.restTemplate.getForObject("http://example.org/resource",
+		assertThat(this.restTemplate.getForObject("https://example.org/resource",
 				String.class)).isEqualTo("{\"message\":\"Hello Custom\"}");
 		server.verify();
 	}
@@ -86,9 +86,9 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void simpleGetWithEmptyPath() throws Exception {
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/resource-with-empty-path.json").build();
-		assertThat(this.restTemplate.getForObject("http://example.org/", String.class))
+		assertThat(this.restTemplate.getForObject("https://example.org/", String.class))
 				.isEqualTo("Hello World");
 		server.verify();
 	}
@@ -96,9 +96,9 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void simpleGetWithContentType() throws Exception {
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/resource-with-content-type.json").build();
-		assertThat(this.restTemplate.getForObject("http://example.org/resource",
+		assertThat(this.restTemplate.getForObject("https://example.org/resource",
 				String.class)).isEqualTo("Hello World");
 		server.verify();
 	}
@@ -106,9 +106,9 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void simpleGetWithoutContentType() throws Exception {
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/resource-without-content-type.json").build();
-		assertThat(this.restTemplate.getForObject("http://example.org/resource",
+		assertThat(this.restTemplate.getForObject("https://example.org/resource",
 				String.class)).isEqualTo("Hello World");
 		server.verify();
 	}
@@ -116,9 +116,9 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void simplePost() throws Exception {
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/poster.json").build();
-		assertThat(this.restTemplate.postForObject("http://example.org/poster",
+		assertThat(this.restTemplate.postForObject("https://example.org/poster",
 				"greeting", String.class)).isEqualTo("Hello World");
 		server.verify();
 	}
@@ -126,14 +126,14 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void postWithHeader() throws Exception {
 		WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") // order determined by content...
+				.baseUrl("https://example.org") // order determined by content...
 				.stubs("classpath:/mappings/poster.json",
 						"classpath:/mappings/accept.json")
 				.build();
 		assertThat(
 				this.restTemplate
 						.exchange(
-								RequestEntity.post(new URI("http://example.org/poster"))
+								RequestEntity.post(new URI("https://example.org/poster"))
 										.accept(MediaType.TEXT_PLAIN).build(),
 								String.class)
 						.getBody()).isEqualTo("Accepted World");
@@ -142,12 +142,12 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void postWithHeaderContains() throws Exception {
 		WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") // order determined by content...
+				.baseUrl("https://example.org") // order determined by content...
 				.stubs("classpath:/mappings/poster.json",
 						"classpath:/mappings/header-contains.json")
 				.build();
 		assertThat(this.restTemplate.exchange(
-				RequestEntity.post(new URI("http://example.org/poster"))
+				RequestEntity.post(new URI("https://example.org/poster"))
 						.accept(MediaType.valueOf("application/v.foo")).build(),
 				String.class).getBody()).isEqualTo("Foo World");
 	}
@@ -155,12 +155,12 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void postWithHeaderMatches() throws Exception {
 		WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") // order determined by content...
+				.baseUrl("https://example.org") // order determined by content...
 				.stubs("classpath:/mappings/poster.json",
 						"classpath:/mappings/header-matches.json")
 				.build();
 		assertThat(this.restTemplate.exchange(
-				RequestEntity.post(new URI("http://example.org/poster"))
+				RequestEntity.post(new URI("https://example.org/poster"))
 						.accept(MediaType.valueOf("application/v.bar")).build(),
 				String.class).getBody()).isEqualTo("Bar World");
 	}
@@ -168,14 +168,14 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void postWithMoreExactHeaderMatch() throws Exception {
 		WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") // order determined by content...
+				.baseUrl("https://example.org") // order determined by content...
 				.stubs("classpath:/mappings/header-matches.json",
 						"classpath:/mappings/header-matches-precise.json")
 				.build();
 		assertThat(
 				this.restTemplate
 						.exchange(
-								RequestEntity.post(new URI("http://example.org/poster"))
+								RequestEntity.post(new URI("https://example.org/poster"))
 										.accept(MediaType.valueOf("application/v.bar"))
 										.header("X-Precise", "true").build(),
 								String.class)
@@ -185,14 +185,14 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void postWithMoreExactHeaderMatchButOrdered() throws Exception {
 		WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") // order matters...
+				.baseUrl("https://example.org") // order matters...
 				.stubs("classpath:/mappings/header-matches.json",
 						"classpath:/mappings/header-matches-precise.json")
 				.ignoreExpectOrder(false).build();
 		assertThat(
 				this.restTemplate
 						.exchange(
-								RequestEntity.post(new URI("http://example.org/poster"))
+								RequestEntity.post(new URI("https://example.org/poster"))
 										.accept(MediaType.valueOf("application/v.bar"))
 										.header("X-Precise", "true").build(),
 								String.class)
@@ -203,29 +203,29 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void getWithPriortyOrder() throws Exception {
 		WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/resource-with-low-priority.json",
 						"classpath:/mappings/resource-with-high-priority.json")
 				.build();
-		assertThat(this.restTemplate.getForObject("http://example.org/resource",
+		assertThat(this.restTemplate.getForObject("https://example.org/resource",
 				String.class)).isEqualTo("Hello High");
 	}
 
 	@Test
 	public void simpleGetWithAllStubs() throws Exception {
 		WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings").build();
-		assertThat(this.restTemplate.getForObject("http://example.org/resource",
+		assertThat(this.restTemplate.getForObject("https://example.org/resource",
 				String.class)).isEqualTo("Hello World");
 	}
 
 	@Test
 	public void simpleGetWithAllStubsInDirectoryWithPeriod() throws Exception {
 		WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/io.stubs/mappings").build();
-		assertThat(this.restTemplate.getForObject("http://example.org/resource",
+		assertThat(this.restTemplate.getForObject("https://example.org/resource",
 				String.class)).isEqualTo("Hello World");
 	}
 
@@ -233,10 +233,10 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void postWithBodyMatchingJsonPaths() throws Exception {
 		WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/body-matches-jsonpath.json").build();
 
-		assertThat(this.restTemplate.postForObject("http://example.org/body",
+		assertThat(this.restTemplate.postForObject("https://example.org/body",
 				new Things(Collections.singletonList(new Thing("RequiredThing"))),
 				String.class)).isEqualTo("Hello Body");
 	}
@@ -244,12 +244,12 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void postWithRequestThatHasNonMatchingJsonPaths() throws Exception {
 		WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/body-matches-jsonpath.json").build();
 
 		String response;
 		try {
-			response = this.restTemplate.postForObject("http://example.org/body",
+			response = this.restTemplate.postForObject("https://example.org/body",
 					new Things(Collections.singletonList(new Thing("AbsentThing"))),
 					String.class);
 		}
@@ -265,11 +265,11 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void postWithBodyMatchingXPath() throws Exception {
 		WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/body-matches-xpath.json").build();
 
 		assertThat(this.restTemplate.exchange(RequestEntity
-				.post(URI.create("http://example.org/body"))
+				.post(URI.create("https://example.org/body"))
 				.contentType(MediaType.APPLICATION_XML)
 				.body("<things><thing><name>RequiredThing</name></thing></things>"),
 				String.class).getBody()).isEqualTo("Hello Body");
@@ -278,13 +278,13 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void postWithRequestThatHasNonMatchingXPaths() throws Exception {
 		WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/body-matches-xpath.json").build();
 
 		ResponseEntity<String> response;
 		try {
 			response = this.restTemplate.exchange(
-					RequestEntity.post(URI.create("http://example.org/body"))
+					RequestEntity.post(URI.create("https://example.org/body"))
 							.contentType(MediaType.APPLICATION_XML).body("<foo/>"),
 					String.class);
 		}
@@ -300,10 +300,10 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void postWithBodyMatchingJson() throws Exception {
 		WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/body-matches-equaltojson.json").build();
 
-		assertThat(this.restTemplate.postForObject("http://example.org/body",
+		assertThat(this.restTemplate.postForObject("https://example.org/body",
 				new Things(Collections.singletonList(new Thing("RequiredThing"))),
 				String.class)).isEqualTo("Hello Body");
 	}
@@ -311,12 +311,12 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void postWithRequestThatHasNonMatchingJson() throws Exception {
 		WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/body-matches-equaltojson.json").build();
 
 		String response;
 		try {
-			response = this.restTemplate.postForObject("http://example.org/body",
+			response = this.restTemplate.postForObject("https://example.org/body",
 					new Things(Collections.singletonList(new Thing("AbsentThing"))),
 					String.class);
 		}
@@ -332,11 +332,11 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void postWithBodyMatchingXml() throws Exception {
 		WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/body-matches-equaltoxml.json").build();
 
 		assertThat(this.restTemplate.exchange(RequestEntity
-				.post(URI.create("http://example.org/body"))
+				.post(URI.create("https://example.org/body"))
 				.contentType(MediaType.APPLICATION_XML)
 				.body("<things><thing><name>RequiredThing</name></thing></things>"),
 				String.class).getBody()).isEqualTo("Hello Body");
@@ -345,13 +345,13 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void postWithRequestThatHasNonMatchingXml() throws Exception {
 		WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/body-matches-equaltoxml.json").build();
 
 		ResponseEntity<String> response;
 		try {
 			response = this.restTemplate.exchange(RequestEntity
-					.post(URI.create("http://example.org/body"))
+					.post(URI.create("https://example.org/body"))
 					.contentType(MediaType.APPLICATION_XML)
 					.body("<things><thing><name>AbsentThing</name></thing></things>"),
 					String.class);
@@ -368,11 +368,11 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void postWithBodyMatchingRegex() throws Exception {
 		WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/body-matches-regex.json").build();
 
 		assertThat(this.restTemplate.exchange(RequestEntity
-				.post(URI.create("http://example.org/body"))
+				.post(URI.create("https://example.org/body"))
 				.contentType(MediaType.APPLICATION_XML)
 				.body("<things><thing><name>RequiredThing</name></thing></things>"),
 				String.class).getBody()).isEqualTo("Hello Body");
@@ -381,13 +381,13 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void postWithRequestThatHasNonMatchingRegex() throws Exception {
 		WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/body-matches-regex.json").build();
 
 		ResponseEntity<String> response;
 		try {
 			response = this.restTemplate.exchange(RequestEntity
-					.post(URI.create("http://example.org/body"))
+					.post(URI.create("https://example.org/body"))
 					.contentType(MediaType.APPLICATION_XML)
 					.body("<things><thing><name>AbsentThing</name></thing></things>"),
 					String.class);
@@ -404,9 +404,9 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void getWithUrlPathMatching() throws Exception {
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/url-path-pattern.json").build();
-		assertThat(this.restTemplate.getForObject("http://example.org/123/url-path-pattern/",
+		assertThat(this.restTemplate.getForObject("https://example.org/123/url-path-pattern/",
 				String.class)).isEqualTo("Hello Url Path Matcher");
 		server.verify();
 	}
@@ -414,9 +414,9 @@ public class WiremockMockServerApplicationTests {
 	@Test
 	public void getWithUrlMatching() throws Exception {
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate) //
-				.baseUrl("http://example.org") //
+				.baseUrl("https://example.org") //
 				.stubs("classpath:/mappings/url-matches.json").build();
-		assertThat(this.restTemplate.getForObject("http://example.org/123/hello-url-matcher/",
+		assertThat(this.restTemplate.getForObject("https://example.org/123/hello-url-matcher/",
 				String.class)).isEqualTo("Hello Url Matcher");
 		server.verify();
 	}

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/WiremockTestsApplication.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/WiremockTestsApplication.java
@@ -51,7 +51,7 @@ class Controller {
 @Component
 class Service {
 
-	@Value("${app.baseUrl:http://example.org}")
+	@Value("${app.baseUrl:https://example.org}")
 	String base;
 
 	private RestTemplate restTemplate;

--- a/tests/samples-messaging-amqp/src/test/groovy/com/example/AmqpMessagingApplicationSpec.groovy
+++ b/tests/samples-messaging-amqp/src/test/groovy/com/example/AmqpMessagingApplicationSpec.groovy
@@ -90,7 +90,7 @@ class AmqpMessagingApplicationSpec extends Specification {
 					Contract.make {
 						description("""
 Represents scenario 2 from documentation: 
-http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html#_publisher_side_test_generation
+https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html#_publisher_side_test_generation
 
 "The input message triggers an output message."
 

--- a/tests/spring-cloud-contract-stub-runner-amqp/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/amqp/spring-cloud-contract-amqp-test/0.4.0-SNAPSHOT/spring-cloud-contract-amqp-test-0.4.0-SNAPSHOT.pom
+++ b/tests/spring-cloud-contract-stub-runner-amqp/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/amqp/spring-cloud-contract-amqp-test/0.4.0-SNAPSHOT/spring-cloud-contract-amqp-test-0.4.0-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs.amqp</groupId>

--- a/tests/spring-cloud-contract-stub-runner-boot-eureka/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/bootService/0.0.1-SNAPSHOT/bootService-0.0.1-SNAPSHOT.pom
+++ b/tests/spring-cloud-contract-stub-runner-boot-eureka/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/bootService/0.0.1-SNAPSHOT/bootService-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/tests/spring-cloud-contract-stub-runner-boot-eureka/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/fraudDetectionServer/0.0.1-SNAPSHOT/fraudDetectionServer-0.0.1-SNAPSHOT.pom
+++ b/tests/spring-cloud-contract-stub-runner-boot-eureka/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/fraudDetectionServer/0.0.1-SNAPSHOT/fraudDetectionServer-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/tests/spring-cloud-contract-stub-runner-boot-eureka/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/loanIssuance/0.0.1-SNAPSHOT/loanIssuance-0.0.1-SNAPSHOT.pom
+++ b/tests/spring-cloud-contract-stub-runner-boot-eureka/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/loanIssuance/0.0.1-SNAPSHOT/loanIssuance-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/tests/spring-cloud-contract-stub-runner-boot-zookeeper/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/bootService/0.0.1-SNAPSHOT/bootService-0.0.1-SNAPSHOT.pom
+++ b/tests/spring-cloud-contract-stub-runner-boot-zookeeper/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/bootService/0.0.1-SNAPSHOT/bootService-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/tests/spring-cloud-contract-stub-runner-boot-zookeeper/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/fraudDetectionServer/0.0.1-SNAPSHOT/fraudDetectionServer-0.0.1-SNAPSHOT.pom
+++ b/tests/spring-cloud-contract-stub-runner-boot-zookeeper/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/fraudDetectionServer/0.0.1-SNAPSHOT/fraudDetectionServer-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/tests/spring-cloud-contract-stub-runner-boot-zookeeper/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/loanIssuance/0.0.1-SNAPSHOT/loanIssuance-0.0.1-SNAPSHOT.pom
+++ b/tests/spring-cloud-contract-stub-runner-boot-zookeeper/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/loanIssuance/0.0.1-SNAPSHOT/loanIssuance-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/tests/spring-cloud-contract-stub-runner-camel/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/camelService/0.0.1-SNAPSHOT/camelService-0.0.1-SNAPSHOT.pom
+++ b/tests/spring-cloud-contract-stub-runner-camel/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/camelService/0.0.1-SNAPSHOT/camelService-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/tests/spring-cloud-contract-stub-runner-context-path/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/contextPathFraudDetectionServer/0.0.1-SNAPSHOT/contextPathFraudDetectionServer-0.0.1-SNAPSHOT.pom
+++ b/tests/spring-cloud-contract-stub-runner-context-path/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/contextPathFraudDetectionServer/0.0.1-SNAPSHOT/contextPathFraudDetectionServer-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/tests/spring-cloud-contract-stub-runner-integration/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/integrationService/0.0.1-SNAPSHOT/integrationService-0.0.1-SNAPSHOT.pom
+++ b/tests/spring-cloud-contract-stub-runner-integration/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/integrationService/0.0.1-SNAPSHOT/integrationService-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>

--- a/tests/spring-cloud-contract-stub-runner-stream/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/streamService/0.0.1-SNAPSHOT/streamService-0.0.1-SNAPSHOT.pom
+++ b/tests/spring-cloud-contract-stub-runner-stream/src/test/resources/m2repo/repository/org/springframework/cloud/contract/verifier/stubs/streamService/0.0.1-SNAPSHOT/streamService-0.0.1-SNAPSHOT.pom
@@ -15,7 +15,7 @@
   ~  limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.cloud.contract.verifier.stubs</groupId>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://1337.net (200) with 1 occurrences could not be migrated:  
   ([https](https://1337.net) result SSLHandshakeException).
* [ ] http://codearte.io (200) with 2 occurrences could not be migrated:  
   ([https](https://codearte.io) result SSLHandshakeException).
* [ ] http://groovy-lang.org/json.html (200) with 5 occurrences could not be migrated:  
   ([https](https://groovy-lang.org/json.html) result SSLProtocolException).
* [ ] http://partners.com (200) with 15 occurrences could not be migrated:  
   ([https](https://partners.com) result SSLHandshakeException).
* [ ] http://rest-assured.io/ (200) with 2 occurrences could not be migrated:  
   ([https](https://rest-assured.io/) result SSLHandshakeException).
* [ ] http://spockframework.org/ (200) with 1 occurrences could not be migrated:  
   ([https](https://spockframework.org/) result SSLHandshakeException).
* [ ] http://toomuchcoding.com/blog/categories/accurest/ (200) with 2 occurrences could not be migrated:  
   ([https](https://toomuchcoding.com/blog/categories/accurest/) result SSLHandshakeException).
* [ ] http://toomuchcoding.com/blog/categories/spring-cloud-contract/ (200) with 2 occurrences could not be migrated:  
   ([https](https://toomuchcoding.com/blog/categories/spring-cloud-contract/) result SSLHandshakeException).
* [ ] http://wiremock.org (200) with 3 occurrences could not be migrated:  
   ([https](https://wiremock.org) result SSLHandshakeException).
* [ ] http://wiremock.org/docs/running-standalone/ (200) with 2 occurrences could not be migrated:  
   ([https](https://wiremock.org/docs/running-standalone/) result SSLHandshakeException).
* [ ] http://wiremock.org/docs/stateful-behaviour/ (200) with 2 occurrences could not be migrated:  
   ([https](https://wiremock.org/docs/stateful-behaviour/) result SSLHandshakeException).
* [ ] http://wiremock.org/docs/stubbing/ (200) with 2 occurrences could not be migrated:  
   ([https](https://wiremock.org/docs/stubbing/) result SSLHandshakeException).
* [ ] http://wiremock.org/stubbing.html (200) with 1 occurrences could not be migrated:  
   ([https](https://wiremock.org/stubbing.html) result SSLHandshakeException).
* [ ] http://foo.com/ (301) with 1 occurrences could not be migrated:  
   ([https](https://foo.com/) result SSLHandshakeException).
* [ ] http://foo.com (301) with 1 occurrences could not be migrated:  
   ([https](https://foo.com) result SSLHandshakeException).
* [ ] http://foo.com/blah_ (301) with 2 occurrences could not be migrated:  
   ([https](https://foo.com/blah_) result SSLHandshakeException).
* [ ] http://foo.com/blah_blah (301) with 2 occurrences could not be migrated:  
   ([https](https://foo.com/blah_blah) result SSLHandshakeException).
* [ ] http://foo.com/blah_blah/ (301) with 2 occurrences could not be migrated:  
   ([https](https://foo.com/blah_blah/) result SSLHandshakeException).
* [ ] http://foo.com/blah_blah_ (301) with 2 occurrences could not be migrated:  
   ([https](https://foo.com/blah_blah_) result SSLHandshakeException).
* [ ] http://foo.com/unicode_ (301) with 1 occurrences could not be migrated:  
   ([https](https://foo.com/unicode_) result SSLHandshakeException).
* [ ] http://192.168.0.100:8081/artifactory/libs-release-local (403) with 1 occurrences could not be migrated:  
   ([https](https://192.168.0.100:8081/artifactory/libs-release-local) result ConnectTimeoutException).
* [ ] http://nexus.net/content/repositories/repository (404) with 1 occurrences could not be migrated:  
   ([https](https://nexus.net/content/repositories/repository) result SSLProtocolException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://142.42.1.1/ (AnnotatedNoRouteToHostException) with 1 occurrences migrated to:  
  https://142.42.1.1/ ([https](https://142.42.1.1/) result AnnotatedNoRouteToHostException).
* [ ] http://142.42.1.1:8080/ (AnnotatedNoRouteToHostException) with 1 occurrences migrated to:  
  https://142.42.1.1:8080/ ([https](https://142.42.1.1:8080/) result AnnotatedNoRouteToHostException).
* [ ] http://223.255.255.254 (AnnotatedNoRouteToHostException) with 1 occurrences migrated to:  
  https://223.255.255.254 ([https](https://223.255.255.254) result AnnotatedNoRouteToHostException).
* [ ] http://123.123.123 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://123.123.123 ([https](https://123.123.123) result ConnectTimeoutException).
* [ ] http://-a.b.co (UnknownHostException) with 1 occurrences migrated to:  
  https://-a.b.co ([https](https://-a.b.co) result UnknownHostException).
* [ ] http://-error-.invalid/ (UnknownHostException) with 1 occurrences migrated to:  
  https://-error-.invalid/ ([https](https://-error-.invalid/) result UnknownHostException).
* [ ] http://../ (UnknownHostException) with 1 occurrences migrated to:  
  https://../ ([https](https://../) result UnknownHostException).
* [ ] http://.www.foo.bar./ (UnknownHostException) with 1 occurrences migrated to:  
  https://.www.foo.bar./ ([https](https://.www.foo.bar./) result UnknownHostException).
* [ ] http://.www.foo.bar/ (UnknownHostException) with 1 occurrences migrated to:  
  https://.www.foo.bar/ ([https](https://.www.foo.bar/) result UnknownHostException).
* [ ] http://1.1.1.1.1 (UnknownHostException) with 1 occurrences migrated to:  
  https://1.1.1.1.1 ([https](https://1.1.1.1.1) result UnknownHostException).
* [ ] http://a.b-.co (UnknownHostException) with 1 occurrences migrated to:  
  https://a.b-.co ([https](https://a.b-.co) result UnknownHostException).
* [ ] http://a.b-c.de (UnknownHostException) with 1 occurrences migrated to:  
  https://a.b-c.de ([https](https://a.b-c.de) result UnknownHostException).
* [ ] http://foo-597104692.com (UnknownHostException) with 3 occurrences migrated to:  
  https://foo-597104692.com ([https](https://foo-597104692.com) result UnknownHostException).
* [ ] http://foo.bar (UnknownHostException) with 2 occurrences migrated to:  
  https://foo.bar ([https](https://foo.bar) result UnknownHostException).
* [ ] http://foo.bar/?q=Test%20URL-encoded%20stuff (UnknownHostException) with 1 occurrences migrated to:  
  https://foo.bar/?q=Test%20URL-encoded%20stuff ([https](https://foo.bar/?q=Test%20URL-encoded%20stuff) result UnknownHostException).
* [ ] http://foo.bar/foo (UnknownHostException) with 1 occurrences migrated to:  
  https://foo.bar/foo ([https](https://foo.bar/foo) result UnknownHostException).
* [ ] http://foo.bar?q=Spaces (UnknownHostException) with 1 occurrences migrated to:  
  https://foo.bar?q=Spaces ([https](https://foo.bar?q=Spaces) result UnknownHostException).
* [ ] http://foo389886219.com (UnknownHostException) with 3 occurrences migrated to:  
  https://foo389886219.com ([https](https://foo389886219.com) result UnknownHostException).
* [ ] http://userid:password@example.com (UnknownHostException) with 1 occurrences migrated to:  
  https://userid:password@example.com ([https](https://userid:password@example.com) result UnknownHostException).
* [ ] http://userid:password@example.com/ (UnknownHostException) with 1 occurrences migrated to:  
  https://userid:password@example.com/ ([https](https://userid:password@example.com/) result UnknownHostException).
* [ ] http://userid:password@example.com:8080 (UnknownHostException) with 1 occurrences migrated to:  
  https://userid:password@example.com:8080 ([https](https://userid:password@example.com:8080) result UnknownHostException).
* [ ] http://userid:password@example.com:8080/ (UnknownHostException) with 1 occurrences migrated to:  
  https://userid:password@example.com:8080/ ([https](https://userid:password@example.com:8080/) result UnknownHostException).
* [ ] http://userid@example.com (UnknownHostException) with 1 occurrences migrated to:  
  https://userid@example.com ([https](https://userid@example.com) result UnknownHostException).
* [ ] http://userid@example.com/ (UnknownHostException) with 1 occurrences migrated to:  
  https://userid@example.com/ ([https](https://userid@example.com/) result UnknownHostException).
* [ ] http://userid@example.com:8080 (UnknownHostException) with 1 occurrences migrated to:  
  https://userid@example.com:8080 ([https](https://userid@example.com:8080) result UnknownHostException).
* [ ] http://userid@example.com:8080/ (UnknownHostException) with 1 occurrences migrated to:  
  https://userid@example.com:8080/ ([https](https://userid@example.com:8080/) result UnknownHostException).
* [ ] http://www.foo.bar./ (UnknownHostException) with 1 occurrences migrated to:  
  https://www.foo.bar./ ([https](https://www.foo.bar./) result UnknownHostException).
* [ ] http://example.org/123/hello-url-matcher/ (404) with 1 occurrences migrated to:  
  https://example.org/123/hello-url-matcher/ ([https](https://example.org/123/hello-url-matcher/) result 404).
* [ ] http://example.org/123/url-path-pattern/ (404) with 1 occurrences migrated to:  
  https://example.org/123/url-path-pattern/ ([https](https://example.org/123/url-path-pattern/) result 404).
* [ ] http://example.org/body (404) with 10 occurrences migrated to:  
  https://example.org/body ([https](https://example.org/body) result 404).
* [ ] http://example.org/poster (404) with 6 occurrences migrated to:  
  https://example.org/poster ([https](https://example.org/poster) result 404).
* [ ] http://example.org/resource (404) with 10 occurrences migrated to:  
  https://example.org/resource ([https](https://example.org/resource) result 404).
* [ ] http://repo.spring.io/snapshots (404) with 1 occurrences migrated to:  
  https://repo.spring.io/snapshots ([https](https://repo.spring.io/snapshots) result 404).
* [ ] http://www.example.com/wpstyle/?p=364 (404) with 1 occurrences migrated to:  
  https://www.example.com/wpstyle/?p=364 ([https](https://www.example.com/wpstyle/?p=364) result 404).
* [ ] http://api.twitter.com/1/geo/id/01fbe706f872cb32.json (403) with 4 occurrences migrated to:  
  https://api.twitter.com/1/geo/id/01fbe706f872cb32.json ([https](https://api.twitter.com/1/geo/id/01fbe706f872cb32.json) result 410).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://asciidoctor.org with 1 occurrences migrated to:  
  https://asciidoctor.org ([https](https://asciidoctor.org) result 200).
* [ ] http://www.citrusframework.org/ (301) with 1 occurrences migrated to:  
  https://citrusframework.org/ ([https](https://www.citrusframework.org/) result 200).
* [ ] http://cloud-samples.spring.io/spring-cloud-contract-samples/workshops.html with 2 occurrences migrated to:  
  https://cloud-samples.spring.io/spring-cloud-contract-samples/workshops.html ([https](https://cloud-samples.spring.io/spring-cloud-contract-samples/workshops.html) result 200).
* [ ] http://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html ([https](https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html) result 200).
* [ ] http://example.org with 41 occurrences migrated to:  
  https://example.org ([https](https://example.org) result 200).
* [ ] http://example.org/ with 3 occurrences migrated to:  
  https://example.org/ ([https](https://example.org/) result 200).
* [ ] http://handlebarsjs.com/ with 1 occurrences migrated to:  
  https://handlebarsjs.com/ ([https](https://handlebarsjs.com/) result 200).
* [ ] http://martinfowler.com/articles/consumerDrivenContracts.html with 1 occurrences migrated to:  
  https://martinfowler.com/articles/consumerDrivenContracts.html ([https](https://martinfowler.com/articles/consumerDrivenContracts.html) result 200).
* [ ] http://maven.apache.org/download.cgi with 1 occurrences migrated to:  
  https://maven.apache.org/download.cgi ([https](https://maven.apache.org/download.cgi) result 200).
* [ ] http://maven.apache.org/xsd/assembly-1.1.3.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/assembly-1.1.3.xsd ([https](https://maven.apache.org/xsd/assembly-1.1.3.xsd) result 200).
* [ ] http://maven.apache.org/xsd/maven-4.0.0.xsd with 19 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 2 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://tools.ietf.org/html/rfc1945 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc1945 ([https](https://tools.ietf.org/html/rfc1945) result 200).
* [ ] http://tools.ietf.org/html/rfc2109 with 2 occurrences migrated to:  
  https://tools.ietf.org/html/rfc2109 ([https](https://tools.ietf.org/html/rfc2109) result 200).
* [ ] http://tools.ietf.org/html/rfc2295 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc2295 ([https](https://tools.ietf.org/html/rfc2295) result 200).
* [ ] http://tools.ietf.org/html/rfc2324 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc2324 ([https](https://tools.ietf.org/html/rfc2324) result 200).
* [ ] http://tools.ietf.org/html/rfc2518 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc2518 ([https](https://tools.ietf.org/html/rfc2518) result 200).
* [ ] http://tools.ietf.org/html/rfc2616 with 2 occurrences migrated to:  
  https://tools.ietf.org/html/rfc2616 ([https](https://tools.ietf.org/html/rfc2616) result 200).
* [ ] http://tools.ietf.org/html/rfc2774 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc2774 ([https](https://tools.ietf.org/html/rfc2774) result 200).
* [ ] http://tools.ietf.org/html/rfc2817 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc2817 ([https](https://tools.ietf.org/html/rfc2817) result 200).
* [ ] http://tools.ietf.org/html/rfc2965 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc2965 ([https](https://tools.ietf.org/html/rfc2965) result 200).
* [ ] http://tools.ietf.org/html/rfc3229 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc3229 ([https](https://tools.ietf.org/html/rfc3229) result 200).
* [ ] http://tools.ietf.org/html/rfc4918 with 5 occurrences migrated to:  
  https://tools.ietf.org/html/rfc4918 ([https](https://tools.ietf.org/html/rfc4918) result 200).
* [ ] http://tools.ietf.org/html/rfc5842 with 2 occurrences migrated to:  
  https://tools.ietf.org/html/rfc5842 ([https](https://tools.ietf.org/html/rfc5842) result 200).
* [ ] http://tools.ietf.org/html/rfc5988 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc5988 ([https](https://tools.ietf.org/html/rfc5988) result 200).
* [ ] http://tools.ietf.org/html/rfc6266 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc6266 ([https](https://tools.ietf.org/html/rfc6266) result 200).
* [ ] http://tools.ietf.org/html/rfc6454 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc6454 ([https](https://tools.ietf.org/html/rfc6454) result 200).
* [ ] http://tools.ietf.org/html/rfc6585 with 4 occurrences migrated to:  
  https://tools.ietf.org/html/rfc6585 ([https](https://tools.ietf.org/html/rfc6585) result 200).
* [ ] http://tools.ietf.org/html/rfc7230 with 8 occurrences migrated to:  
  https://tools.ietf.org/html/rfc7230 ([https](https://tools.ietf.org/html/rfc7230) result 200).
* [ ] http://tools.ietf.org/html/rfc7231 with 53 occurrences migrated to:  
  https://tools.ietf.org/html/rfc7231 ([https](https://tools.ietf.org/html/rfc7231) result 200).
* [ ] http://tools.ietf.org/html/rfc7232 with 8 occurrences migrated to:  
  https://tools.ietf.org/html/rfc7232 ([https](https://tools.ietf.org/html/rfc7232) result 200).
* [ ] http://tools.ietf.org/html/rfc7233 with 6 occurrences migrated to:  
  https://tools.ietf.org/html/rfc7233 ([https](https://tools.ietf.org/html/rfc7233) result 200).
* [ ] http://tools.ietf.org/html/rfc7234 with 5 occurrences migrated to:  
  https://tools.ietf.org/html/rfc7234 ([https](https://tools.ietf.org/html/rfc7234) result 200).
* [ ] http://tools.ietf.org/html/rfc7235 with 6 occurrences migrated to:  
  https://tools.ietf.org/html/rfc7235 ([https](https://tools.ietf.org/html/rfc7235) result 200).
* [ ] http://tools.ietf.org/html/rfc7238 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc7238 ([https](https://tools.ietf.org/html/rfc7238) result 200).
* [ ] http://tools.ietf.org/rfcdiff?difftype=--hwdiff&url2=draft-ietf-webdav-protocol-06.txt with 3 occurrences migrated to:  
  https://tools.ietf.org/rfcdiff?difftype=--hwdiff&url2=draft-ietf-webdav-protocol-06.txt ([https](https://tools.ietf.org/rfcdiff?difftype=--hwdiff&url2=draft-ietf-webdav-protocol-06.txt) result 200).
* [ ] http://www.java.com/en/download/help/error_hotspot.xml with 1 occurrences migrated to:  
  https://www.java.com/en/download/help/error_hotspot.xml ([https](https://www.java.com/en/download/help/error_hotspot.xml) result 200).
* [ ] http://www.regular-expressions.info/examples.html with 1 occurrences migrated to:  
  https://www.regular-expressions.info/examples.html ([https](https://www.regular-expressions.info/examples.html) result 200).
* [ ] http://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura with 2 occurrences migrated to:  
  https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura ([https](https://www.slideshare.net/MarcinGrzejszczak/stick-to-the-rules-consumer-driven-contracts-201507-confitura) result 200).
* [ ] http://www.w3.org/TR/cors/ with 8 occurrences migrated to:  
  https://www.w3.org/TR/cors/ ([https](https://www.w3.org/TR/cors/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-cli with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-cli ([https](https://cloud.spring.io/spring-cloud-cli) result 301).
* [ ] http://code.google.com/events/ with 1 occurrences migrated to:  
  https://code.google.com/events/ ([https](https://code.google.com/events/) result 301).
* [ ] http://code.google.com/p/gears/wiki/ResumableHttpRequestsProposal with 1 occurrences migrated to:  
  https://code.google.com/p/gears/wiki/ResumableHttpRequestsProposal ([https](https://code.google.com/p/gears/wiki/ResumableHttpRequestsProposal) result 301).
* [ ] http://j.mp with 1 occurrences migrated to:  
  https://j.mp ([https](https://j.mp) result 301).
* [ ] http://pact.io/ with 1 occurrences migrated to:  
  https://pact.io/ ([https](https://pact.io/) result 301).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 2 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://spockframework.github.io/ with 1 occurrences migrated to:  
  https://spockframework.github.io/ ([https](https://spockframework.github.io/) result 301).
* [ ] http://www.sonatype.org/nexus/ with 1 occurrences migrated to:  
  https://www.sonatype.org/nexus/ ([https](https://www.sonatype.org/nexus/) result 301).
* [ ] http://formvalidation.io/validators/uri/ with 1 occurrences migrated to:  
  https://formvalidation.io/validators/uri/ ([https](https://formvalidation.io/validators/uri/) result 302).
* [ ] http://repo.spring.io/libs-snapshot with 4 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* [ ] http://repo.spring.io/milestone with 1 occurrences migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* [ ] http://repo.spring.io/release with 1 occurrences migrated to:  
  https://repo.spring.io/release ([https](https://repo.spring.io/release) result 302).
* [ ] http://repo.spring.io/snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/snapshot ([https](https://repo.spring.io/snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http:///a with 1 occurrences
* http://3628126748 with 1 occurrences
* http://??/ with 1 occurrences
* http://foo with 2 occurrences
* http://foo/bar with 4 occurrences
* http://link/to/your/nexus/or/artifactory/or/sth with 2 occurrences
* http://loanIssuance/name with 3 occurrences
* http://localhost with 54 occurrences
* http://localhost/partners/ with 8 occurrences
* http://localhost/partners/1000/users/1001 with 3 occurrences
* http://localhost:12345 with 2 occurrences
* http://localhost:12346 with 2 occurrences
* http://localhost:5435 with 1 occurrences
* http://localhost:6060 with 1 occurrences
* http://localhost:6061 with 1 occurrences
* http://localhost:6063 with 1 occurrences
* http://localhost:6065 with 1 occurrences
* http://localhost:6066 with 1 occurrences
* http://localhost:6067 with 1 occurrences
* http://localhost:6565/ with 1 occurrences
* http://localhost:6565/1 with 1 occurrences
* http://localhost:7070 with 1 occurrences
* http://localhost:7071 with 1 occurrences
* http://localhost:8080 with 3 occurrences
* http://localhost:8081/artifactory/libs-release-local with 2 occurrences
* http://localhost:8081/artifactory/libs-release-local/com/example/bookstore/0.0.1.RELEASE/ with 1 occurrences
* http://localhost:8081/artifactory/libs-release-local/com/example/bookstore/0.0.1.RELEASE/bookstore-0.0.1.RELEASE-stubs.jar with 1 occurrences
* http://localhost:8085 with 4 occurrences
* http://localhost:8888/users with 1 occurrences
* http://localhost:9090 with 1 occurrences
* http://localhost:9876/api/books with 2 occurrences
* http://maven.apache.org/POM/4.0.0 with 38 occurrences
* http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 with 2 occurrences
* http://someNameThatShouldMapFraudDetectionServer/name with 3 occurrences
* http://some_url with 1 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 20 occurrences