### PR TITLE
WIP: Docker verifier support for custom producer stubs classifier

### DIFF
--- a/docker/spring-cloud-contract-docker/project/build.gradle
+++ b/docker/spring-cloud-contract-docker/project/build.gradle
@@ -60,6 +60,7 @@ test {
 contracts {
 	baseClassForTests = "contracts.RestBase"
 	testMode = "EXPLICIT"
+	stubsSuffix = getProp("PRODUCER_STUBS_CLASSIFIER") ?: "stubs"
 	if (getProp("EXTERNAL_CONTRACTS_ARTIFACT_ID")) {
 		logger.
 				lifecycle("Will use an artifact with contracts [${getProp("EXTERNAL_CONTRACTS_GROUP_ID")}:${getProp("EXTERNAL_CONTRACTS_ARTIFACT_ID")}]")

--- a/docs/src/main/asciidoc/verifier_setup.adoc
+++ b/docs/src/main/asciidoc/verifier_setup.adoc
@@ -1084,6 +1084,7 @@ your running application, to the Artifact manager instance etc.
 - `PROJECT_GROUP` - your project's group id. Defaults to `com.example`
 - `PROJECT_VERSION` - your project's version. Defaults to `0.0.1-SNAPSHOT`
 - `PROJECT_NAME` - artifact id. Defaults to `example`
+- `PRODUCER_STUBS_CLASSIFIER` - archive classifier used for generated producer stubs, defaults to `stubs`.
 - `REPO_WITH_BINARIES_URL` - URL of your Artifact Manager. Defaults to `http://localhost:8081/artifactory/libs-release-local`
 which is the default URL of https://jfrog.com/artifactory/[Artifactory] running locally
 - `REPO_WITH_BINARIES_USERNAME` - (optional) username when the Artifact Manager is secured, defaults to `admin`.

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/SpringCloudContractVerifierGradlePlugin.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/SpringCloudContractVerifierGradlePlugin.groovy
@@ -25,6 +25,8 @@ import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 import org.gradle.jvm.tasks.Jar
 
+import org.springframework.cloud.contract.verifier.config.ContractVerifierConfigProperties
+
 /**
  * Gradle plugin for Spring Cloud Contract Verifier that from the DSL contract can
  * <ul>
@@ -148,11 +150,12 @@ class SpringCloudContractVerifierGradlePlugin implements Plugin<Project> {
 			return task
 		}
 		else {
+			ContractVerifierConfigProperties props = ExtensionToProperties.fromExtension(extension)
 			task = project.tasks.create(type: Jar, name: VERIFIER_STUBS_JAR_TASK_NAME,
 					dependsOn: DSL_TO_CLIENT_TASK_NAME) {
 				baseName = project.name
-				classifier = extension.stubsSuffix
-				from { extension.stubsOutputDir ?: project.file("${project.buildDir}/stubs") }
+				classifier = props.stubsSuffix
+				from { props.stubsOutputDir ?: project.file("${project.buildDir}/stubs") }
 			}
 			task.description = "Creates the stubs JAR task"
 			task.group = GROUP_NAME


### PR DESCRIPTION
Adds the possibility to provide custom stubs classifier. Might be useful to serve as some kind of tag for the stubs published.

This PR also deals with the issue that I stumbled upon initially with SCC Gradle plugin not applying the `stubsSuffix` property set in `build.gradle`. It always used the default value instead, because the stubs jar task was created before the project was evaluated.