### PR TITLE
#1028: Register port now only handles auto port values.

### DIFF
--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockApplicationListener.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockApplicationListener.java
@@ -56,8 +56,9 @@ public class WireMockApplicationListener
 					SocketUtils.findAvailableTcpPort(10000, 12500));
 			source.put("wiremock.server.port-dynamic", true);
 		}
-		if (environment.getProperty("wiremock.server.https-port", Integer.class,
-				0) == 0) {
+		int httpsPortProperty = environment.getProperty("wiremock.server.https-port",
+				Integer.class, 0);
+		if (httpsPortProperty == 0) {
 			MutablePropertySources propertySources = environment.getPropertySources();
 			addPropertySource(propertySources);
 			Map<String, Object> source = ((MapPropertySource) propertySources
@@ -66,13 +67,12 @@ public class WireMockApplicationListener
 					SocketUtils.findAvailableTcpPort(12500, 15000));
 			source.put("wiremock.server.https-port-dynamic", true);
 		}
-		else if (environment.getProperty("wiremock.server.https-port", Integer.class,
-				0) != -1) {
+		else if (httpsPortProperty == -1) {
 			MutablePropertySources propertySources = environment.getPropertySources();
 			addPropertySource(propertySources);
 			Map<String, Object> source = ((MapPropertySource) propertySources
 					.get("wiremock")).getSource();
-			source.put("wiremock.server.https-port-dynamic", false);
+			source.put("wiremock.server.https-port-dynamic", true);
 		}
 
 	}

--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockConfiguration.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockConfiguration.java
@@ -272,7 +272,7 @@ class WireMockProperties {
 
 		private boolean portDynamic = false;
 
-		private boolean httpsPortDynamic = true;
+		private boolean httpsPortDynamic = false;
 
 		public int getPort() {
 			return this.port;


### PR DESCRIPTION
This is to avoid the httpsPortDynamic being set to true on the context initialisation, but then being updated to false when the context is refreshed.

Fix for #1028