### PR TITLE
#883/#1028.: Further DirtiesContext fix where the context is refreshed during the test phase

### DIFF
--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockApplicationListener.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockApplicationListener.java
@@ -47,7 +47,15 @@ public class WireMockApplicationListener
 	}
 
 	private void registerPort(ConfigurableEnvironment environment) {
-		if (environment.getProperty("wiremock.server.port", Integer.class, 0) == 0) {
+		Integer httpPortProperty = environment.getProperty("wiremock.server.port",
+				Integer.class);
+		// If the httpPortProperty is not found it means the AutoConfigureWireMock hasn't
+		// been initialised.
+		if (httpPortProperty == null) {
+			return;
+		}
+
+		if (httpPortProperty.equals(0)) {
 			MutablePropertySources propertySources = environment.getPropertySources();
 			addPropertySource(propertySources);
 			Map<String, Object> source = ((MapPropertySource) propertySources

--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockApplicationListener.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockApplicationListener.java
@@ -56,8 +56,9 @@ public class WireMockApplicationListener
 					SocketUtils.findAvailableTcpPort(10000, 12500));
 			source.put("wiremock.server.port-dynamic", true);
 		}
-		if (environment.getProperty("wiremock.server.https-port", Integer.class,
-				0) == 0) {
+		int httpsPortProperty = environment.getProperty("wiremock.server.https-port",
+				Integer.class, 0);
+		if (httpsPortProperty == 0) {
 			MutablePropertySources propertySources = environment.getPropertySources();
 			addPropertySource(propertySources);
 			Map<String, Object> source = ((MapPropertySource) propertySources
@@ -66,13 +67,12 @@ public class WireMockApplicationListener
 					SocketUtils.findAvailableTcpPort(12500, 15000));
 			source.put("wiremock.server.https-port-dynamic", true);
 		}
-		else if (environment.getProperty("wiremock.server.https-port", Integer.class,
-				0) != -1) {
+		else if (httpsPortProperty == -1) {
 			MutablePropertySources propertySources = environment.getPropertySources();
 			addPropertySource(propertySources);
 			Map<String, Object> source = ((MapPropertySource) propertySources
 					.get("wiremock")).getSource();
-			source.put("wiremock.server.https-port-dynamic", false);
+			source.put("wiremock.server.https-port-dynamic", true);
 		}
 
 	}

--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockConfiguration.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockConfiguration.java
@@ -272,7 +272,7 @@ class WireMockProperties {
 
 		private boolean portDynamic = false;
 
-		private boolean httpsPortDynamic = true;
+		private boolean httpsPortDynamic = false;
 
 		public int getPort() {
 			return this.port;


### PR DESCRIPTION
PR contains the following fixes.

1) Register port now only handles auto port values - Fix for #1028.
2) Register only sets the ports when the values are available in the environment configuration - this resolves the issue seen in the contract-car-rental project/RentACarTests tests.

No test case available. Ideally, we would add a similar test as the RentACarTests to the spring-cloud-contract-stub-runner project. However, this doesn't seem to be running all tests in that project.