### PR TITLE
Deploy also to Gradle plugin portal (#629)

### DIFF
--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/build.gradle
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/build.gradle
@@ -8,10 +8,15 @@ buildscript {
 		if (project.hasProperty('fatJar')) {
 			jcenter()
 		}
+		//For plugin-publish-plugin. Could be limited only to that dependency with Gradle 5.1+ - https://docs.gradle.org/5.1.1/release-notes.html#repository-to-dependency-matching
+		maven {
+			url 'https://plugins.gradle.org/m2/'
+		}
 	}
 	dependencies {
 		classpath "com.bmuschko:gradle-nexus-plugin:2.3"
 		classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3"
+		classpath 'com.gradle.publish:plugin-publish-plugin:0.9.10'
 		if (project.hasProperty('fatJar')) {
 			classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
 		}

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/gradle/release.gradle
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/gradle/release.gradle
@@ -56,6 +56,27 @@ if (isReleaseToCentral) {
 	signing {
 		sign configurations.archives
 	}
+
+	apply plugin: 'com.gradle.plugin-publish'
+
+	pluginBundle {
+		website = 'https://github.com/spring-cloud/spring-cloud-contract'
+		vcsUrl = 'https://github.com/spring-cloud/spring-cloud-contract'
+
+		plugins {
+			plugin {
+				id = 'org.springframework.cloud.contract'
+				displayName = 'spring-cloud-contract'
+				description = 'Spring Cloud Contract Gradle Plugin'
+				tags = ['spring', 'spring-framework', 'spring-cloud', 'spring-cloud-contract']
+			}
+		}
+
+		mavenCoordinates {
+			groupId = project.group
+			artifactId = project.name
+		}
+	}
 }
 
 afterEvaluate {

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/resources/META-INF/gradle-plugins/org.springframework.cloud.contract.properties
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/resources/META-INF/gradle-plugins/org.springframework.cloud.contract.properties
@@ -1,0 +1,16 @@
+#
+#  Copyright 2013-2019 the original author or authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+implementation-class=org.springframework.cloud.contract.verifier.plugin.SpringCloudContractVerifierGradlePlugin


### PR DESCRIPTION
## Summary

This PR makes possible to apply the Spring Cloud Contract Gradle plugin with short syntax (as requested in #629):
```
plugins {
  id 'org.springframework.cloud.contract' version 'XXX.RELEASE'
}
```
**Please note**. This change keeps backward compatibility with 2.x.

## Implementation
The feature is achieved by:
1. Adding an alias for the Gradle plugin id - making it compatible with Plugin portal requirements.
2. Configuring effecting publishing to Plugin portal with a dedicated plugin.

## Additional configuration
1. Valid `gradle.publish.key` and `gradle.publish.secret` properties have to be added in CI/CD configuration (e.g. in `~/.gradle/gradle.properties`.
2. The CI/CD server should call `publishPlugins` (directly or that task can be - after testing - made a requirement for the general release task).

## Remarks/concerns
1. This solution keeps backward compatibility with the 2.x line - the old plugin id is still available. There's just an extra id alias which effectively will be the main one in the future.
2. It's perfectly fine to have more than one plugin defined in a single JAR - see [my test plugins](https://plugins.gradle.org/search?term=dummy-cd) and [their configuration](https://github.com/szpak/dummy-cd-plugin/blob/cDeliveryBoy/gradle/release.gradle#L74-L103).
3. I wasn't able to test it in that project, so some glitches can occur (however, in general, the configuration like that has chance to work - as mine which it is based on).
4. I connected releasing to the portal to releasing to Maven Central. You may change it if desired.
5. I propose you to release some RC version first (before the final one or maybe even a milestone - by temporary slightly modifying `release.gradle`) to ensure the correctness
6. Once successfully released and tested the old plugin id could be marked as deprecated to be eventually removed in some future version.

**Update**. I switched from master to 2.1.x which seems to be the main branch to merge commits to.