### PR TITLE
Add a switch to fail on no stubs

### DIFF
--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/AetherStubDownloader.java
@@ -29,7 +29,6 @@ import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.Proxy;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ArtifactRequest;
@@ -205,14 +204,6 @@ public class AetherStubDownloader implements StubDownloader {
 		}
 	}
 
-	private boolean resolvedFromLocalRepo(ArtifactResult result) {
-		return result.getRepository() instanceof LocalRepository;
-	}
-
-	private boolean shouldDownloadFromRemote() {
-		return !remoteReposMissing() && !this.workOffline;
-	}
-
 	private String getVersion(String stubsGroup, String stubsModule, String version,
 			String classifier) {
 		if (StringUtils.isEmpty(version) || LATEST_VERSION_IN_IVY.equals(version)) {
@@ -228,20 +219,26 @@ public class AetherStubDownloader implements StubDownloader {
 	@Override
 	public Map.Entry<StubConfiguration, File> downloadAndUnpackStubJar(
 			StubConfiguration stubConfiguration) {
-		String version = getVersion(stubConfiguration.groupId,
-				stubConfiguration.artifactId, stubConfiguration.version,
-				stubConfiguration.classifier);
-		if (log.isDebugEnabled()) {
-			log.debug("Will download the stub for version [" + version + "]");
+		try {
+			String version = getVersion(stubConfiguration.groupId,
+					stubConfiguration.artifactId, stubConfiguration.version,
+					stubConfiguration.classifier);
+			if (log.isDebugEnabled()) {
+				log.debug("Will download the stub for version [" + version + "]");
+			}
+			File unpackedJar = unpackedJar(version, stubConfiguration.groupId,
+					stubConfiguration.artifactId, stubConfiguration.classifier);
+			if (unpackedJar == null) {
+				return null;
+			}
+			return new AbstractMap.SimpleEntry<>(new StubConfiguration(
+					stubConfiguration.groupId, stubConfiguration.artifactId, version,
+					stubConfiguration.classifier), unpackedJar);
 		}
-		File unpackedJar = unpackedJar(version, stubConfiguration.groupId,
-				stubConfiguration.artifactId, stubConfiguration.classifier);
-		if (unpackedJar == null) {
+		catch (Exception ex) {
+			log.warn("Exception occurred while trying to fetch the stubs", ex);
 			return null;
 		}
-		return new AbstractMap.SimpleEntry<>(new StubConfiguration(
-				stubConfiguration.groupId, stubConfiguration.artifactId, version,
-				stubConfiguration.classifier), unpackedJar);
 	}
 
 	private String resolveHighestArtifactVersion(String stubsGroup, String stubsModule,

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/CompositeStubDownloaderBuilder.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/CompositeStubDownloaderBuilder.java
@@ -73,8 +73,9 @@ class CompositeStubDownloader implements StubDownloader {
 		}
 		log.warn("No matching stubs or contracts were found");
 		if (this.stubRunnerOptions.isFailOnNoStubs()) {
-			throw new IllegalStateException(
-					"No stubs or contracts were found and the switch to fail on no stubs was set.");
+			throw new IllegalArgumentException("No stubs or contracts were found for ["
+					+ stubConfiguration.toColonSeparatedDependencyNotation()
+					+ "] and the switch to fail on no stubs was set.");
 		}
 		return null;
 	}

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/CompositeStubDownloaderBuilder.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/CompositeStubDownloaderBuilder.java
@@ -67,6 +67,20 @@ class CompositeStubDownloader implements StubDownloader {
 	@Override
 	public Map.Entry<StubConfiguration, File> downloadAndUnpackStubJar(
 			StubConfiguration stubConfiguration) {
+		Map.Entry<StubConfiguration, File> entry = entry(stubConfiguration);
+		if (entry != null) {
+			return entry;
+		}
+		log.warn("No matching stubs or contracts were found");
+		if (this.stubRunnerOptions.isFailOnNoStubs()) {
+			throw new IllegalStateException(
+					"No stubs or contracts were found and the switch to fail on no stubs was set.");
+		}
+		return null;
+	}
+
+	private Map.Entry<StubConfiguration, File> entry(
+			StubConfiguration stubConfiguration) {
 		for (StubDownloaderBuilder builder : this.builders) {
 			StubDownloader downloader = builder.build(this.stubRunnerOptions);
 			if (downloader == null) {

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerOptions.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerOptions.java
@@ -123,6 +123,12 @@ public class StubRunnerOptions {
 	private boolean generateStubs;
 
 	/**
+	 * When enabled, this flag will tell stub runner to throw an exception when no stubs /
+	 * contracts were found.
+	 */
+	private boolean failOnNoStubs;
+
+	/**
 	 * Map of properties that can be passed to custom
 	 * {@link org.springframework.cloud.contract.stubrunner.StubDownloaderBuilder}.
 	 */
@@ -134,7 +140,7 @@ public class StubRunnerOptions {
 			Map<StubConfiguration, Integer> stubIdsToPortMapping, String username,
 			String password, final StubRunnerProxyOptions stubRunnerProxyOptions,
 			boolean stubsPerConsumer, String consumerName, String mappingsOutputFolder,
-			boolean deleteStubsAfterTest, boolean generateStubs,
+			boolean deleteStubsAfterTest, boolean generateStubs, boolean failOnNoStubs,
 			Map<String, String> properties,
 			Class<? extends HttpServerStubConfigurer> httpServerStubConfigurer) {
 		this.minPortValue = minPortValue;
@@ -153,6 +159,7 @@ public class StubRunnerOptions {
 		this.mappingsOutputFolder = mappingsOutputFolder;
 		this.deleteStubsAfterTest = deleteStubsAfterTest;
 		this.generateStubs = generateStubs;
+		this.failOnNoStubs = failOnNoStubs;
 		this.properties = properties;
 		this.httpServerStubConfigurer = httpServerStubConfigurer;
 	}
@@ -179,6 +186,8 @@ public class StubRunnerOptions {
 						System.getProperty("stubrunner.delete-stubs-after-test", "true")))
 				.withGenerateStubs(Boolean.parseBoolean(
 						System.getProperty("stubrunner.generate-stubs", "false")))
+				.withFailOnNoStubs(Boolean.parseBoolean(
+						System.getProperty("stubrunner.fail-on-no-stubs", "false")))
 				.withProperties(stubRunnerProps());
 		builder = httpStubConfigurer(builder);
 		String proxyHost = System.getProperty("stubrunner.proxy.host");
@@ -330,6 +339,10 @@ public class StubRunnerOptions {
 
 	public boolean isGenerateStubs() {
 		return this.generateStubs;
+	}
+
+	public boolean isFailOnNoStubs() {
+		return this.failOnNoStubs;
 	}
 
 	public Map<String, String> getProperties() {

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerOptions.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerOptions.java
@@ -126,7 +126,7 @@ public class StubRunnerOptions {
 	 * When enabled, this flag will tell stub runner to throw an exception when no stubs /
 	 * contracts were found.
 	 */
-	private boolean failOnNoStubs;
+	private boolean failOnNoStubs = true;
 
 	/**
 	 * Map of properties that can be passed to custom

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerOptionsBuilder.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerOptionsBuilder.java
@@ -71,7 +71,7 @@ public class StubRunnerOptionsBuilder {
 
 	private boolean generateStubs;
 
-	private boolean failOnNoStubs;
+	private boolean failOnNoStubs = true;
 
 	private Map<String, String> properties = new HashMap<>();
 

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerOptionsBuilder.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerOptionsBuilder.java
@@ -71,6 +71,8 @@ public class StubRunnerOptionsBuilder {
 
 	private boolean generateStubs;
 
+	private boolean failOnNoStubs;
+
 	private Map<String, String> properties = new HashMap<>();
 
 	private Class httpServerStubConfigurer = HttpServerStubConfigurer.NoOpHttpServerStubConfigurer.class;
@@ -197,6 +199,7 @@ public class StubRunnerOptionsBuilder {
 				? options.stubIdsToPortMapping : new LinkedHashMap<>();
 		this.deleteStubsAfterTest = options.isDeleteStubsAfterTest();
 		this.generateStubs = options.isGenerateStubs();
+		this.failOnNoStubs = options.isFailOnNoStubs();
 		this.properties = options.getProperties();
 		this.httpServerStubConfigurer = options.getHttpServerStubConfigurer();
 		return this;
@@ -219,6 +222,11 @@ public class StubRunnerOptionsBuilder {
 		return this;
 	}
 
+	public StubRunnerOptionsBuilder withFailOnNoStubs(boolean failOnNoStubs) {
+		this.failOnNoStubs = failOnNoStubs;
+		return this;
+	}
+
 	public StubRunnerOptionsBuilder withProperties(Map<String, String> properties) {
 		this.properties = properties;
 		return this;
@@ -236,7 +244,8 @@ public class StubRunnerOptionsBuilder {
 				buildDependencies(), this.stubIdsToPortMapping, this.username,
 				this.password, this.stubRunnerProxyOptions, this.stubsPerConsumer,
 				this.consumerName, this.mappingsOutputFolder, this.deleteStubsAfterTest,
-				this.generateStubs, this.properties, this.httpServerStubConfigurer);
+				this.generateStubs, this.failOnNoStubs, this.properties,
+				this.httpServerStubConfigurer);
 	}
 
 	private Collection<StubConfiguration> buildDependencies() {

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/junit/StubRunnerExtension.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/junit/StubRunnerExtension.java
@@ -259,6 +259,12 @@ public class StubRunnerExtension implements BeforeAllCallback, AfterAllCallback,
 	}
 
 	@Override
+	public StubRunnerExtension failOnNoStubs(boolean failOnNoStubs) {
+		builder().withFailOnNoStubs(failOnNoStubs);
+		return new PortStubRunnerExtension(this.delegate);
+	}
+
+	@Override
 	public StubRunnerExtension withProperties(Map<String, String> properties) {
 		builder().withProperties(properties);
 		return new PortStubRunnerExtension(this.delegate);

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/junit/StubRunnerExtensionOptions.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/junit/StubRunnerExtensionOptions.java
@@ -157,6 +157,13 @@ interface StubRunnerExtensionOptions {
 	StubRunnerExtension withGenerateStubs(boolean generateStubs);
 
 	/**
+	 * @param failOnNoStubs when enabled, this flag will tell stub runner to throw an
+	 * exception when no stubs / contracts were found.
+	 * @return the rule
+	 */
+	StubRunnerExtension failOnNoStubs(boolean failOnNoStubs);
+
+	/**
 	 * @param properties Map of properties that can be passed to custom
 	 * {@link org.springframework.cloud.contract.stubrunner.StubDownloaderBuilder}
 	 * @return the stub runner extension

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/junit/StubRunnerRule.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/junit/StubRunnerRule.java
@@ -192,8 +192,14 @@ public class StubRunnerRule implements TestRule, StubFinder, StubRunnerRuleOptio
 
 	@Override
 	public StubRunnerRule withGenerateStubs(boolean generateStubs) {
-		builder().withGenerateStubs(true);
+		builder().withGenerateStubs(generateStubs);
 		return this.delegate;
+	}
+
+	@Override
+	public StubRunnerRule failOnNoStubs(boolean failOnNoStubs) {
+		builder().withFailOnNoStubs(failOnNoStubs);
+		return null;
 	}
 
 	@Override

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/junit/StubRunnerRuleOptions.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/junit/StubRunnerRuleOptions.java
@@ -153,6 +153,13 @@ interface StubRunnerRuleOptions {
 	StubRunnerRule withGenerateStubs(boolean generateStubs);
 
 	/**
+	 * @param failOnNoStubs when enabled, this flag will tell stub runner to throw an
+	 * exception when no stubs / contracts were found.
+	 * @return the rule
+	 */
+	StubRunnerRule failOnNoStubs(boolean failOnNoStubs);
+
+	/**
 	 * @param properties Map of properties that can be passed to custom
 	 * {@link org.springframework.cloud.contract.stubrunner.StubDownloaderBuilder}
 	 * @return the rule

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/AutoConfigureStubRunner.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/AutoConfigureStubRunner.java
@@ -145,6 +145,12 @@ public @interface AutoConfigureStubRunner {
 	boolean generateStubs() default false;
 
 	/**
+	 * @return when enabled, this flag will tell stub runner to throw an exception when no
+	 * stubs / contracts were found.
+	 */
+	boolean failOnNoStubs() default false;
+
+	/**
 	 * Configuration for an HTTP server stub.
 	 * @return class that allows to perform additional HTTP server stub configuration
 	 */

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/AutoConfigureStubRunner.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/AutoConfigureStubRunner.java
@@ -148,7 +148,7 @@ public @interface AutoConfigureStubRunner {
 	 * @return when enabled, this flag will tell stub runner to throw an exception when no
 	 * stubs / contracts were found.
 	 */
-	boolean failOnNoStubs() default false;
+	boolean failOnNoStubs() default true;
 
 	/**
 	 * Configuration for an HTTP server stub.

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerProperties.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerProperties.java
@@ -115,6 +115,12 @@ public class StubRunnerProperties {
 	private boolean generateStubs;
 
 	/**
+	 * When enabled, this flag will tell stub runner to throw an exception when no stubs /
+	 * contracts were found.
+	 */
+	private boolean failOnNoStubs;
+
+	/**
 	 * Map of properties that can be passed to custom
 	 * {@link org.springframework.cloud.contract.stubrunner.StubDownloaderBuilder}.
 	 */
@@ -258,6 +264,14 @@ public class StubRunnerProperties {
 
 	public void setGenerateStubs(boolean generateStubs) {
 		this.generateStubs = generateStubs;
+	}
+
+	public boolean isFailOnNoStubs() {
+		return this.failOnNoStubs;
+	}
+
+	public void setFailOnNoStubs(boolean failOnNoStubs) {
+		this.failOnNoStubs = failOnNoStubs;
 	}
 
 	public Class getHttpServerStubConfigurer() {

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerProperties.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/spring/StubRunnerProperties.java
@@ -118,7 +118,7 @@ public class StubRunnerProperties {
 	 * When enabled, this flag will tell stub runner to throw an exception when no stubs /
 	 * contracts were found.
 	 */
-	private boolean failOnNoStubs;
+	private boolean failOnNoStubs = true;
 
 	/**
 	 * Map of properties that can be passed to custom

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/AetherStubDownloaderSpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/AetherStubDownloaderSpec.groovy
@@ -43,11 +43,10 @@ class AetherStubDownloaderSpec extends Specification {
 			AetherStubDownloader aetherStubDownloader = new AetherStubDownloader(stubRunnerOptions)
 
 		when:
-			aetherStubDownloader.downloadAndUnpackStubJar(new StubConfiguration("non.existing.group", "missing-artifact-id", "1.0-SNAPSHOT"))
+			def entry = aetherStubDownloader.downloadAndUnpackStubJar(new StubConfiguration("non.existing.group", "missing-artifact-id", "1.0-SNAPSHOT"))
 
 		then:
-			IllegalStateException e = thrown(IllegalStateException)
-			e.message.contains("Exception occurred while trying to download a stub for group")
+			entry == null
 	}
 
 	def 'should throw an exception when local m2 gets replaced with a temp dir and a jar is not found in remote'() {
@@ -65,11 +64,10 @@ class AetherStubDownloaderSpec extends Specification {
 			AetherStubDownloader aetherStubDownloader = new AetherStubDownloader(stubRunnerOptions)
 
 		when:
-			aetherStubDownloader.downloadAndUnpackStubJar(new StubConfiguration("org.springframework.cloud", "spring-cloud-contract-spec", "+", ""))
+			def entry = aetherStubDownloader.downloadAndUnpackStubJar(new StubConfiguration("org.springframework.cloud", "spring-cloud-contract-spec", "+", ""))
 
 		then:
-			IllegalArgumentException e = thrown(IllegalArgumentException)
-			e.message.contains("Could not find metadata org.springframework.cloud:spring-cloud-contract-spec/maven-metadata.xml in remote0")
+			entry == null
 	}
 
 	@RestoreSystemProperties

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/StubRunnerOptionsBuilderSpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/StubRunnerOptionsBuilderSpec.groovy
@@ -231,7 +231,7 @@ class StubRunnerOptionsBuilderSpec extends Specification {
 		given:
 			StubRunnerOptionsBuilder builder = builder.withOptions(new StubRunnerOptions(1, 2, new FileSystemResource("root"), StubRunnerProperties.StubsMode.LOCAL,
 					"classifier", [new StubConfiguration("a:b:c")], [(new StubConfiguration("a:b:c")): 3], "foo", "bar",
-					new StubRunnerOptions.StubRunnerProxyOptions("host", 4), true, "consumer", "folder", false, true, [foo: "bar"], Foo))
+					new StubRunnerOptions.StubRunnerProxyOptions("host", 4), true, "consumer", "folder", false, true, true, [foo: "bar"], Foo))
 			builder.withStubs("foo:bar:baz")
 		when:
 			StubRunnerOptions options = builder.build()
@@ -252,6 +252,7 @@ class StubRunnerOptionsBuilderSpec extends Specification {
 			options.mappingsOutputFolder == "folder"
 			options.deleteStubsAfterTest == false
 			options.generateStubs == true
+			options.failOnNoStubs == true
 			options.properties == [foo: "bar"]
 			options.httpServerStubConfigurer == Foo
 	}
@@ -261,7 +262,7 @@ class StubRunnerOptionsBuilderSpec extends Specification {
 			StubRunnerOptionsBuilder builder = builder.withOptions(new StubRunnerOptions(1, 2, new FileSystemResource("root"),
 					StubRunnerProperties.StubsMode.CLASSPATH, "classifier",
 					[new StubConfiguration("a:b:c")], [(new StubConfiguration("a:b:c")): 3], "username123", "password123",
-					new StubRunnerOptions.StubRunnerProxyOptions("host", 4), true, "consumer", "folder", false, true, [:], Foo))
+					new StubRunnerOptions.StubRunnerProxyOptions("host", 4), true, "consumer", "folder", false, true, true, [:], Foo))
 			builder.withStubs("foo:bar:baz")
 		when:
 			String options = builder.build().toString()
@@ -293,6 +294,7 @@ class StubRunnerOptionsBuilderSpec extends Specification {
 			System.setProperty("stubrunner.properties.bar.bar", "foo")
 			System.setProperty("stubrunner.delete-stubs-after-test", "false")
 			System.setProperty("stubrunner.generate-stubs", "true")
+			System.setProperty("stubrunner.fail-on-no-stubs", "true")
 			System.setProperty("stubrunner.http-server-stub-configurer", "org.springframework.cloud.contract.stubrunner.Foo")
 		when:
 			StubRunnerOptions options = StubRunnerOptions.fromSystemProps()
@@ -310,6 +312,7 @@ class StubRunnerOptionsBuilderSpec extends Specification {
 			options.stubsPerConsumer == true
 			options.deleteStubsAfterTest == false
 			options.generateStubs == true
+			options.failOnNoStubs == true
 			options.consumerName == "consumer"
 			options.mappingsOutputFolder == "folder"
 			options.properties == ["foo-bar": "bar", "foo-baz": "baz", "bar.bar": "foo"]

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/StubRunnerOptionsBuilderSpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/StubRunnerOptionsBuilderSpec.groovy
@@ -231,7 +231,7 @@ class StubRunnerOptionsBuilderSpec extends Specification {
 		given:
 			StubRunnerOptionsBuilder builder = builder.withOptions(new StubRunnerOptions(1, 2, new FileSystemResource("root"), StubRunnerProperties.StubsMode.LOCAL,
 					"classifier", [new StubConfiguration("a:b:c")], [(new StubConfiguration("a:b:c")): 3], "foo", "bar",
-					new StubRunnerOptions.StubRunnerProxyOptions("host", 4), true, "consumer", "folder", false, true, true, [foo: "bar"], Foo))
+					new StubRunnerOptions.StubRunnerProxyOptions("host", 4), true, "consumer", "folder", false, true, false, [foo: "bar"], Foo))
 			builder.withStubs("foo:bar:baz")
 		when:
 			StubRunnerOptions options = builder.build()
@@ -252,7 +252,7 @@ class StubRunnerOptionsBuilderSpec extends Specification {
 			options.mappingsOutputFolder == "folder"
 			options.deleteStubsAfterTest == false
 			options.generateStubs == true
-			options.failOnNoStubs == true
+			options.failOnNoStubs == false
 			options.properties == [foo: "bar"]
 			options.httpServerStubConfigurer == Foo
 	}
@@ -294,7 +294,7 @@ class StubRunnerOptionsBuilderSpec extends Specification {
 			System.setProperty("stubrunner.properties.bar.bar", "foo")
 			System.setProperty("stubrunner.delete-stubs-after-test", "false")
 			System.setProperty("stubrunner.generate-stubs", "true")
-			System.setProperty("stubrunner.fail-on-no-stubs", "true")
+			System.setProperty("stubrunner.fail-on-no-stubs", "false")
 			System.setProperty("stubrunner.http-server-stub-configurer", "org.springframework.cloud.contract.stubrunner.Foo")
 		when:
 			StubRunnerOptions options = StubRunnerOptions.fromSystemProps()
@@ -312,7 +312,7 @@ class StubRunnerOptionsBuilderSpec extends Specification {
 			options.stubsPerConsumer == true
 			options.deleteStubsAfterTest == false
 			options.generateStubs == true
-			options.failOnNoStubs == true
+			options.failOnNoStubs == false
 			options.consumerName == "consumer"
 			options.mappingsOutputFolder == "folder"
 			options.properties == ["foo-bar": "bar", "foo-baz": "baz", "bar.bar": "foo"]

--- a/spring-cloud-contract-stub-runner/src/test/java/org/springframework/cloud/contract/stubrunner/CompositeStubDownloaderBuilderTests.java
+++ b/spring-cloud-contract-stub-runner/src/test/java/org/springframework/cloud/contract/stubrunner/CompositeStubDownloaderBuilderTests.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.contract.stubrunner;
 import java.io.File;
 import java.util.AbstractMap;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -55,6 +56,32 @@ public class CompositeStubDownloaderBuilderTests {
 		StubDownloader downloader = builder.build(new StubRunnerOptionsBuilder().build());
 
 		BDDAssertions.then(downloader).isNull();
+	}
+
+	@Test
+	public void should_return_null_when_no_entries_were_found() {
+		EmptyStubDownloaderBuilder emptyStubDownloaderBuilder = new EmptyStubDownloaderBuilder();
+		CompositeStubDownloaderBuilder builder = new CompositeStubDownloaderBuilder(
+				Collections.singletonList(emptyStubDownloaderBuilder));
+		StubDownloader downloader = builder.build(new StubRunnerOptionsBuilder().build());
+
+		Map.Entry<StubConfiguration, File> entry = downloader
+				.downloadAndUnpackStubJar(new StubConfiguration("a:b:v"));
+
+		BDDAssertions.then(entry).isNull();
+	}
+
+	@Test
+	public void should_throw_exception_when_no_entries_were_found_and_a_switch_to_throw_exception_was_set() {
+		EmptyStubDownloaderBuilder emptyStubDownloaderBuilder = new EmptyStubDownloaderBuilder();
+		CompositeStubDownloaderBuilder builder = new CompositeStubDownloaderBuilder(
+				Collections.singletonList(emptyStubDownloaderBuilder));
+		StubDownloader downloader = builder
+				.build(new StubRunnerOptionsBuilder().withFailOnNoStubs(true).build());
+
+		BDDAssertions.thenThrownBy(
+				() -> downloader.downloadAndUnpackStubJar(new StubConfiguration("a:b:v")))
+				.isInstanceOf(IllegalStateException.class);
 	}
 
 }

--- a/spring-cloud-contract-stub-runner/src/test/java/org/springframework/cloud/contract/stubrunner/CompositeStubDownloaderBuilderTests.java
+++ b/spring-cloud-contract-stub-runner/src/test/java/org/springframework/cloud/contract/stubrunner/CompositeStubDownloaderBuilderTests.java
@@ -63,7 +63,8 @@ public class CompositeStubDownloaderBuilderTests {
 		EmptyStubDownloaderBuilder emptyStubDownloaderBuilder = new EmptyStubDownloaderBuilder();
 		CompositeStubDownloaderBuilder builder = new CompositeStubDownloaderBuilder(
 				Collections.singletonList(emptyStubDownloaderBuilder));
-		StubDownloader downloader = builder.build(new StubRunnerOptionsBuilder().build());
+		StubDownloader downloader = builder
+				.build(new StubRunnerOptionsBuilder().withFailOnNoStubs(false).build());
 
 		Map.Entry<StubConfiguration, File> entry = downloader
 				.downloadAndUnpackStubJar(new StubConfiguration("a:b:v"));
@@ -81,7 +82,7 @@ public class CompositeStubDownloaderBuilderTests {
 
 		BDDAssertions.thenThrownBy(
 				() -> downloader.downloadAndUnpackStubJar(new StubConfiguration("a:b:v")))
-				.isInstanceOf(IllegalStateException.class);
+				.isInstanceOf(IllegalArgumentException.class);
 	}
 
 }

--- a/spring-cloud-contract-stub-runner/src/test/java/org/springframework/cloud/contract/stubrunner/StubDownloaderBuilderProviderTests.java
+++ b/spring-cloud-contract-stub-runner/src/test/java/org/springframework/cloud/contract/stubrunner/StubDownloaderBuilderProviderTests.java
@@ -50,7 +50,8 @@ public class StubDownloaderBuilderProviderTests {
 						.singletonList(StubDownloaderBuilderProviderTests.this.two);
 			}
 		};
-		StubRunnerOptions options = new StubRunnerOptionsBuilder().build();
+		StubRunnerOptions options = new StubRunnerOptionsBuilder()
+				.withFailOnNoStubs(false).build();
 
 		provider.get(options, this.three)
 				.downloadAndUnpackStubJar(new StubConfiguration("a:b:c"));

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/ContractVerifierExtension.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/ContractVerifierExtension.groovy
@@ -267,7 +267,8 @@ class ContractVerifierExtension {
 						password: this.contractRepository.password,
 						proxyPort: this.contractRepository.proxyPort,
 						proxyHost: this.contractRepository.proxyHost,
-						cacheDownloadedContracts: this.contractRepository.cacheDownloadedContracts
+						cacheDownloadedContracts: this.contractRepository.cacheDownloadedContracts,
+						failOnNoStubs: this.contractRepository.failOnNoStubs
 				),
 				contractDependency: new Dependency(
 						groupId: this.contractDependency.groupId,
@@ -294,12 +295,6 @@ class ContractVerifierExtension {
 		String classifier
 		String version
 		String stringNotation
-
-		/**
-		 * When enabled, this flag will tell stub runner to throw an exception when no stubs /
-		 * contracts were found.
-		 */
-		boolean failOnNoStubs;
 
 		void groupId(String groupId) {
 			this.groupId = groupId
@@ -372,6 +367,12 @@ class ContractVerifierExtension {
 		 */
 		boolean cacheDownloadedContracts = true
 
+		/**
+		 * When enabled, this flag will tell stub runner to throw an exception when no stubs /
+		 * contracts were found.
+		 */
+		boolean failOnNoStubs = true
+
 		void repositoryUrl(String repositoryUrl) {
 			this.repositoryUrl = repositoryUrl
 		}
@@ -394,6 +395,10 @@ class ContractVerifierExtension {
 
 		void cacheDownloadedContracts(boolean cacheDownloadedContracts) {
 			this.cacheDownloadedContracts = cacheDownloadedContracts
+		}
+
+		void failOnNoStubs(boolean failOnNoStubs) {
+			this.failOnNoStubs = failOnNoStubs
 		}
 	}
 }

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/ContractVerifierExtension.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/ContractVerifierExtension.groovy
@@ -295,6 +295,12 @@ class ContractVerifierExtension {
 		String version
 		String stringNotation
 
+		/**
+		 * When enabled, this flag will tell stub runner to throw an exception when no stubs /
+		 * contracts were found.
+		 */
+		boolean failOnNoStubs;
+
 		void groupId(String groupId) {
 			this.groupId = groupId
 		}

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/GradleContractsDownloader.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/GradleContractsDownloader.groovy
@@ -91,7 +91,7 @@ class GradleContractsDownloader {
 		if (extension.contractRepository.proxyPort) {
 			options = options.withProxy(extension.contractRepository.proxyHost, extension.contractRepository.proxyPort)
 		}
-		options = options.withFailOnNoStubs(extension.contractDependency.failOnNoStubs)
+		options = options.withFailOnNoStubs(extension.contractRepository.failOnNoStubs)
 		return options.build()
 	}
 

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/GradleContractsDownloader.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/GradleContractsDownloader.groovy
@@ -91,6 +91,7 @@ class GradleContractsDownloader {
 		if (extension.contractRepository.proxyPort) {
 			options = options.withProxy(extension.contractRepository.proxyHost, extension.contractRepository.proxyPort)
 		}
+		options = options.withFailOnNoStubs(extension.contractDependency.failOnNoStubs)
 		return options.build()
 	}
 

--- a/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/ConvertMojo.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/ConvertMojo.java
@@ -45,8 +45,7 @@ import org.springframework.cloud.contract.verifier.converter.ToYamlConverter;
  *
  * @author Mariusz Smykula
  */
-@Mojo(name = "convert", requiresProject = false,
-		defaultPhase = LifecyclePhase.PROCESS_TEST_RESOURCES)
+@Mojo(name = "convert", requiresProject = false, defaultPhase = LifecyclePhase.PROCESS_TEST_RESOURCES)
 public class ConvertMojo extends AbstractMojo {
 
 	static final String DEFAULT_STUBS_DIR = "${project.build.directory}/stubs/";
@@ -61,8 +60,7 @@ public class ConvertMojo extends AbstractMojo {
 	 * Directory containing Spring Cloud Contract Verifier contracts written using the
 	 * GroovyDSL.
 	 */
-	@Parameter(property = "spring.cloud.contract.verifier.contractsDirectory",
-			defaultValue = "${project.basedir}/src/test/resources/contracts")
+	@Parameter(property = "spring.cloud.contract.verifier.contractsDirectory", defaultValue = "${project.basedir}/src/test/resources/contracts")
 	private File contractsDirectory;
 
 	/**
@@ -181,6 +179,13 @@ public class ConvertMojo extends AbstractMojo {
 	@Component(role = MavenResourcesFiltering.class, hint = "default")
 	private MavenResourcesFiltering mavenResourcesFiltering;
 
+	/**
+	 * When enabled, this flag will tell stub runner to throw an exception when no stubs /
+	 * contracts were found.
+	 */
+	@Parameter(property = "failOnNoStubs", defaultValue = "false")
+	private boolean failOnNoStubs;
+
 	@Override
 	public void execute() throws MojoExecutionException {
 		if (this.skip) {
@@ -271,8 +276,9 @@ public class ConvertMojo extends AbstractMojo {
 				getLog(), this.contractsRepositoryUsername,
 				this.contractsRepositoryPassword, this.contractsRepositoryProxyHost,
 				this.contractsRepositoryProxyPort, this.deleteStubsAfterTest,
-				this.contractsProperties).downloadAndUnpackContractsIfRequired(config,
-						this.contractsDirectory);
+				this.contractsProperties, this.failOnNoStubs)
+						.downloadAndUnpackContractsIfRequired(config,
+								this.contractsDirectory);
 	}
 
 	private File stubsOutputDir(String rootPath) {

--- a/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/ConvertMojo.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/ConvertMojo.java
@@ -45,7 +45,8 @@ import org.springframework.cloud.contract.verifier.converter.ToYamlConverter;
  *
  * @author Mariusz Smykula
  */
-@Mojo(name = "convert", requiresProject = false, defaultPhase = LifecyclePhase.PROCESS_TEST_RESOURCES)
+@Mojo(name = "convert", requiresProject = false,
+		defaultPhase = LifecyclePhase.PROCESS_TEST_RESOURCES)
 public class ConvertMojo extends AbstractMojo {
 
 	static final String DEFAULT_STUBS_DIR = "${project.build.directory}/stubs/";
@@ -60,7 +61,8 @@ public class ConvertMojo extends AbstractMojo {
 	 * Directory containing Spring Cloud Contract Verifier contracts written using the
 	 * GroovyDSL.
 	 */
-	@Parameter(property = "spring.cloud.contract.verifier.contractsDirectory", defaultValue = "${project.basedir}/src/test/resources/contracts")
+	@Parameter(property = "spring.cloud.contract.verifier.contractsDirectory",
+			defaultValue = "${project.basedir}/src/test/resources/contracts")
 	private File contractsDirectory;
 
 	/**
@@ -183,7 +185,7 @@ public class ConvertMojo extends AbstractMojo {
 	 * When enabled, this flag will tell stub runner to throw an exception when no stubs /
 	 * contracts were found.
 	 */
-	@Parameter(property = "failOnNoStubs", defaultValue = "false")
+	@Parameter(property = "failOnNoStubs", defaultValue = "true")
 	private boolean failOnNoStubs;
 
 	@Override

--- a/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/GenerateTestsMojo.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/GenerateTestsMojo.java
@@ -46,19 +46,23 @@ import org.springframework.cloud.contract.verifier.config.TestMode;
  *
  * @author Mariusz Smykula
  */
-@Mojo(name = "generateTests", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES, requiresDependencyResolution = ResolutionScope.TEST)
+@Mojo(name = "generateTests", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES,
+		requiresDependencyResolution = ResolutionScope.TEST)
 public class GenerateTestsMojo extends AbstractMojo {
 
 	@Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
 	private RepositorySystemSession repoSession;
 
-	@Parameter(property = "spring.cloud.contract.verifier.contractsDirectory", defaultValue = "${project.basedir}/src/test/resources/contracts")
+	@Parameter(property = "spring.cloud.contract.verifier.contractsDirectory",
+			defaultValue = "${project.basedir}/src/test/resources/contracts")
 	private File contractsDirectory;
 
-	@Parameter(defaultValue = "${project.build.directory}/generated-test-sources/contracts")
+	@Parameter(
+			defaultValue = "${project.build.directory}/generated-test-sources/contracts")
 	private File generatedTestSourcesDir;
 
-	@Parameter(defaultValue = "${project.build.directory}/generated-test-resources/contracts")
+	@Parameter(
+			defaultValue = "${project.build.directory}/generated-test-resources/contracts")
 	private File generatedTestResourcesDir;
 
 	@Parameter
@@ -107,7 +111,8 @@ public class GenerateTestsMojo extends AbstractMojo {
 	 * Incubating feature. You can check the size of JSON arrays. If not turned on
 	 * explicitly will be disabled.
 	 */
-	@Parameter(property = "spring.cloud.contract.verifier.assert.size", defaultValue = "false")
+	@Parameter(property = "spring.cloud.contract.verifier.assert.size",
+			defaultValue = "false")
 	private boolean assertJsonSize;
 
 	/**
@@ -228,7 +233,7 @@ public class GenerateTestsMojo extends AbstractMojo {
 	 * When enabled, this flag will tell stub runner to throw an exception when no stubs /
 	 * contracts were found.
 	 */
-	@Parameter(property = "failOnNoStubs", defaultValue = "false")
+	@Parameter(property = "failOnNoStubs", defaultValue = "true")
 	private boolean failOnNoStubs;
 
 	@Override

--- a/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/GenerateTestsMojo.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/GenerateTestsMojo.java
@@ -46,23 +46,19 @@ import org.springframework.cloud.contract.verifier.config.TestMode;
  *
  * @author Mariusz Smykula
  */
-@Mojo(name = "generateTests", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES,
-		requiresDependencyResolution = ResolutionScope.TEST)
+@Mojo(name = "generateTests", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES, requiresDependencyResolution = ResolutionScope.TEST)
 public class GenerateTestsMojo extends AbstractMojo {
 
 	@Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
 	private RepositorySystemSession repoSession;
 
-	@Parameter(property = "spring.cloud.contract.verifier.contractsDirectory",
-			defaultValue = "${project.basedir}/src/test/resources/contracts")
+	@Parameter(property = "spring.cloud.contract.verifier.contractsDirectory", defaultValue = "${project.basedir}/src/test/resources/contracts")
 	private File contractsDirectory;
 
-	@Parameter(
-			defaultValue = "${project.build.directory}/generated-test-sources/contracts")
+	@Parameter(defaultValue = "${project.build.directory}/generated-test-sources/contracts")
 	private File generatedTestSourcesDir;
 
-	@Parameter(
-			defaultValue = "${project.build.directory}/generated-test-resources/contracts")
+	@Parameter(defaultValue = "${project.build.directory}/generated-test-resources/contracts")
 	private File generatedTestResourcesDir;
 
 	@Parameter
@@ -111,8 +107,7 @@ public class GenerateTestsMojo extends AbstractMojo {
 	 * Incubating feature. You can check the size of JSON arrays. If not turned on
 	 * explicitly will be disabled.
 	 */
-	@Parameter(property = "spring.cloud.contract.verifier.assert.size",
-			defaultValue = "false")
+	@Parameter(property = "spring.cloud.contract.verifier.assert.size", defaultValue = "false")
 	private boolean assertJsonSize;
 
 	/**
@@ -229,6 +224,13 @@ public class GenerateTestsMojo extends AbstractMojo {
 	@Parameter(property = "contractsProperties")
 	private Map<String, String> contractsProperties = new HashMap<>();
 
+	/**
+	 * When enabled, this flag will tell stub runner to throw an exception when no stubs /
+	 * contracts were found.
+	 */
+	@Parameter(property = "failOnNoStubs", defaultValue = "false")
+	private boolean failOnNoStubs;
+
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
 		if (this.skip || this.mavenTestSkip || this.skipTests) {
@@ -258,8 +260,9 @@ public class GenerateTestsMojo extends AbstractMojo {
 				this.contractsMode, getLog(), this.contractsRepositoryUsername,
 				this.contractsRepositoryPassword, this.contractsRepositoryProxyHost,
 				this.contractsRepositoryProxyPort, this.deleteStubsAfterTest,
-				this.contractsProperties).downloadAndUnpackContractsIfRequired(config,
-						this.contractsDirectory);
+				this.contractsProperties, this.failOnNoStubs)
+						.downloadAndUnpackContractsIfRequired(config,
+								this.contractsDirectory);
 		getLog().info(
 				"Directory with contract is present at [" + contractsDirectory + "]");
 		setupConfig(config, contractsDirectory);

--- a/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/MavenContractsDownloader.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/MavenContractsDownloader.java
@@ -71,12 +71,14 @@ class MavenContractsDownloader {
 
 	private final Map<String, String> contractsProperties;
 
+	private final boolean failOnNoStubs;
+
 	MavenContractsDownloader(MavenProject project, Dependency contractDependency,
 			String contractsPath, String contractsRepositoryUrl,
 			StubRunnerProperties.StubsMode stubsMode, Log log, String repositoryUsername,
 			String repositoryPassword, String repositoryProxyHost,
 			Integer repositoryProxyPort, boolean deleteStubsAfterTest,
-			Map<String, String> contractsProperties) {
+			Map<String, String> contractsProperties, boolean failOnNoStubs) {
 		this.project = project;
 		this.contractDependency = contractDependency;
 		this.contractsPath = contractsPath;
@@ -90,6 +92,7 @@ class MavenContractsDownloader {
 		this.stubDownloaderBuilderProvider = new StubDownloaderBuilderProvider();
 		this.deleteStubsAfterTest = deleteStubsAfterTest;
 		this.contractsProperties = contractsProperties;
+		this.failOnNoStubs = failOnNoStubs;
 	}
 
 	File downloadAndUnpackContractsIfRequired(ContractVerifierConfigProperties config,
@@ -144,7 +147,8 @@ class MavenContractsDownloader {
 				.withStubsMode(this.stubsMode).withUsername(this.repositoryUsername)
 				.withPassword(this.repositoryPassword)
 				.withDeleteStubsAfterTest(this.deleteStubsAfterTest)
-				.withProperties(this.contractsProperties);
+				.withProperties(this.contractsProperties)
+				.withFailOnNoStubs(this.failOnNoStubs);
 		if (StringUtils.hasText(this.contractsRepositoryUrl)) {
 			builder.withStubRepositoryRoot(this.contractsRepositoryUrl);
 		}

--- a/tests/spring-cloud-contract-stub-runner-context-path/src/test/java/com/example/loan/FailFastLoanApplicationServiceTests.java
+++ b/tests/spring-cloud-contract-stub-runner-context-path/src/test/java/com/example/loan/FailFastLoanApplicationServiceTests.java
@@ -49,8 +49,7 @@ public class FailFastLoanApplicationServiceTests {
 		assertThat(throwable.getCause()).isInstanceOf(BeanInstantiationException.class);
 		assertThat(throwable.getCause().getCause())
 				.isInstanceOf(IllegalArgumentException.class).hasMessageContaining(
-						"For groupId [org.springframework.cloud.contract.verifier.stubs] artifactId [should-not-be-found] "
-								+ "and classifier [stubs] the version was not resolved! The following exceptions took place");
+						"No stubs or contracts were found for [org.springframework.cloud.contract.verifier.stubs:should-not-be-found:+:stubs] and the switch to fail on no stubs was set.");
 	}
 
 	@Test


### PR DESCRIPTION
without this change we throw an exception if no stubs / contracts were found
with this change we catch exceptions from aether stub downloader and if there are no stubs found whatsover, and a switch is set to fail in that case, then we do throw an exception that no stubs / contracts were found

fixes gh-895