### PR TITLE
Disable broken incremental build for InitContractsTask

### DIFF
--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/ContractsCopyTask.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/ContractsCopyTask.groovy
@@ -88,7 +88,7 @@ class ContractsCopyTask extends DefaultTask {
 		String slashSeparatedGroupId = project.group.toString().replace(".", File.separator)
 		String slashSeparatedAntPattern = antPattern.replace(slashSeparatedGroupId, project.group.toString())
 		File output = config.copiedContractsFolder.get().asFile
-		logger.info("Downloading and unpacking files from [${contractsDirectory}()] to [$output]. The inclusion ant patterns are [${antPattern}] and [${slashSeparatedAntPattern}]")
+		logger.info("Downloading and unpacking files from [${contractsDirectory}] to [$output]. The inclusion ant patterns are [${antPattern}] and [${slashSeparatedAntPattern}]")
 		sync(contractsDirectory, antPattern, slashSeparatedAntPattern, config.excludeBuildFolders.get(), output)
 		if (config.convertToYaml.get()) {
 			convertBackedUpDslsToYaml(contractsDirectory, antPattern, slashSeparatedAntPattern, output, config.excludeBuildFolders.get())

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/GenerateServerTestsTask.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/GenerateServerTestsTask.groovy
@@ -98,10 +98,16 @@ class GenerateServerTestsTask extends DefaultTask {
 	void generate() {
 		File generatedTestSources = config.generatedTestSourcesDir.get().asFile
 		File generatedTestResources = config.generatedTestResourcesDir.get().asFile
-		logger.info("Generated test sources dir [${ generatedTestSources}]")
+		logger.info("Generated test sources dir [${generatedTestSources}]")
 		logger.info("Generated test resources dir [${generatedTestResources}]")
 		File contractsDslDir = config.contractsDslDir.get().asFile
-		String includedContracts = config.includedContracts.get()
+		// There used to be some bug in old code, which was always setting `includedContracts` to ".*" instead of 
+		// getting it from the config (which is coming from contracts downloader). In fact, that `correct` behaviour 
+		// doesn't even make sense here as contracts are already copied, so that inclusion filter will not include 
+		// anything. So for now just restoring this old behaviour, but it must be reviewed. Probably that 
+		// `includedContracts` should be used in the `copyContracts` task instead?
+		// String includedContracts = config.includedContracts.get()
+		String includedContracts = ".*"
 		project.logger.info("Spring Cloud Contract Verifier Plugin: Invoking test sources generation")
 		project.logger.info("Contracts are unpacked to [${contractsDslDir}]")
 		project.logger.info("Included contracts are [${includedContracts}]")

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/InitContractsTask.groovy
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/groovy/org/springframework/cloud/contract/verifier/plugin/InitContractsTask.groovy
@@ -11,7 +11,6 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.springframework.cloud.contract.stubrunner.spring.StubRunnerProperties
 
@@ -53,7 +52,8 @@ class InitContractsTask extends DefaultTask {
 		@Internal
 		Property<String> includedRootFolderAntPattern
 
-		@OutputDirectory
+		// TODO: Enable it when all caching from `GradleContractsDownloader` is replaced with Gradle's one here:
+		// @OutputDirectory
 		DirectoryProperty initialisedContractsDirectory
 	}
 
@@ -68,7 +68,8 @@ class InitContractsTask extends DefaultTask {
 			config.includedRootFolderAntPattern.set(downloaded.inclusionProperties.includedRootFolderAntPattern)
 			config.initialisedContractsDirectory.set(downloaded.downloadedContracts)
 		}
-		logger.info("For project [{}] will use contracts provided in the folder [{}]", project.name, config.initialisedContractsDirectory.get())
+		logger.info("For project [{}] will use contracts provided in the folder [{}]", project.name,
+				config.initialisedContractsDirectory.get())
 	}
 
 	static Config fromExtension(ContractVerifierExtension extension, Project project) {


### PR DESCRIPTION
With current implementation of the `GradleContractsDownloader`, where
we have custom caching, `InitContractsTask` doesn't really need to be
incremental. Moreover, there is an issue in current implementation of
the `InitContractsTask`: it doesn't mark itself as out of date when
dynamic dependency is used (`+` or `SNAPSHOT` version). So for now just
disabling incremental build for that task.

Also restored old behaviour, where we used to always use `".*"` pattern
to define included contracts for `GenerateServerTests` task.

Also fixed minor logging issue.

Fixes gh-1133