### PR TITLE
Fix links to http-server and http-client samples in doc

### DIFF
--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -832,8 +832,8 @@ Social remarks
 discuss changes while going through the process
 * CDC is all about communication
 
-The https://github.com/spring-cloud/spring-cloud-contract/tree/{branch}/samples/standalone/dsl/http-server[server-side
-code is available here] and https://github.com/spring-cloud/spring-cloud-contract/tree/{branch}/samples/standalone/dsl/http-client[the client code  is available here].
+The {samples_code}/{standalone_samples_path}/http-server[server-side
+code is available here] and {samples_code}/{standalone_samples_path}/http-client[the client code  is available here].
 
 TIP: In this case, the producer owns the contracts. Physically, all of the contracts are
 in the producer's repository.


### PR DESCRIPTION
The links to the http-server and http-client samples were pointing to a url with an unresolved `{branch}` attribute.

Replace the links by instead using the attributes `{samples_code}` and `{standalone_samples_path}`.

See the 2 broken links under https://cloud.spring.io/spring-cloud-contract/reference/html/getting-started.html#getting-started-cdc