### PR TITLE
SCC Verifier Docker now publishes stubs just once

### DIFF
--- a/docker/spring-cloud-contract-docker/project/build.gradle
+++ b/docker/spring-cloud-contract-docker/project/build.gradle
@@ -118,9 +118,6 @@ publishing {
 		}
 	}
 	publications {
-		mavenJava(MavenPublication) {
-			from components.java
-		}
 	}
 }
 


### PR DESCRIPTION
Originally, SCC Verifier Docker published artifacts twice.
Once defined in build.gradle - which also uploaded the original contracts and second time in a publish stubs task defined in gradle plugin. This PR removes the definition from build.gradle and now only the stubs are published and just once.