### PR TITLE
Added support of query parameters for RestDocs for WireMock stubs

### DIFF
--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/restdocs/WireMockSnippet.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/restdocs/WireMockSnippet.java
@@ -57,7 +57,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.patch;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.trace;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 
 /**
  * Represents a snippet for a WireMock stub.
@@ -241,7 +241,7 @@ public class WireMockSnippet implements Snippet {
 	}
 
 	private UrlPattern requestPattern(Operation operation) {
-		return urlEqualTo(operation.getRequest().getUri().getPath());
+		return urlPathEqualTo(operation.getRequest().getUri().getPath());
 	}
 
 	private HttpHeaders responseHeaders(Operation operation) {

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/restdocs/WireMockSnippetTests.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/restdocs/WireMockSnippetTests.java
@@ -28,7 +28,9 @@ import java.util.Map;
 
 import com.github.tomakehurst.wiremock.matching.EqualToJsonPattern;
 import com.github.tomakehurst.wiremock.matching.EqualToXmlPattern;
+import com.github.tomakehurst.wiremock.matching.MultiValuePattern;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,6 +50,7 @@ import org.springframework.restdocs.operation.OperationResponse;
 import org.springframework.restdocs.operation.Parameters;
 import org.springframework.restdocs.operation.RequestCookie;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -170,6 +173,24 @@ public class WireMockSnippetTests {
 		File stub = new File(this.outputFolder, "stubs/foo.json");
 		assertThat(stub).exists();
 		WireMockStubMapping.buildFrom(new String(Files.readAllBytes(stub.toPath())));
+	}
+
+	@Test
+	public void should_accept_query_params() throws IOException {
+		this.operation = operation(requestGetWithQueryParam(), response(),
+				this.context);
+		WireMockSnippet snippet = new WireMockSnippet();
+
+		snippet.document(this.operation);
+
+		File stub = new File(this.outputFolder, "stubs/foo.json");
+		assertThat(stub).exists();
+		StubMapping stubMapping = WireMockStubMapping
+				.buildFrom(new String(Files.readAllBytes(stub.toPath())));
+		assertThat(stubMapping.getRequest().getUrlPath()).isEqualTo("/bar");
+		assertThat(stubMapping.getRequest()
+				.getQueryParameters())
+				.containsOnly(Assertions.entry("myParam", MultiValuePattern.of(equalTo(("myValue")))));
 	}
 
 	private Operation operation(OperationRequest request, OperationResponse response,
@@ -459,6 +480,53 @@ public class WireMockSnippetTests {
 			@Override
 			public URI getUri() {
 				return URI.create("https://foo/bar?myParam=");
+			}
+
+			@Override
+			public Collection<RequestCookie> getCookies() {
+				return Collections.emptySet();
+			}
+		};
+	}
+
+	private OperationRequest requestGetWithQueryParam() {
+		return new OperationRequest() {
+			@Override
+			public byte[] getContent() {
+				return new byte[0];
+			}
+
+			@Override
+			public String getContentAsString() {
+				return "";
+			}
+
+			@Override
+			public HttpHeaders getHeaders() {
+				HttpHeaders httpHeaders = new HttpHeaders();
+				httpHeaders.add(HttpHeaders.CONTENT_TYPE,
+						MediaType.APPLICATION_JSON_VALUE);
+				return httpHeaders;
+			}
+
+			@Override
+			public HttpMethod getMethod() {
+				return HttpMethod.GET;
+			}
+
+			@Override
+			public Parameters getParameters() {
+				return null;
+			}
+
+			@Override
+			public Collection<OperationRequestPart> getParts() {
+				return null;
+			}
+
+			@Override
+			public URI getUri() {
+				return URI.create("https://foo/bar?myParam=myValue");
 			}
 
 			@Override


### PR DESCRIPTION
In WireMockSnippet requestPattern is generated by urlEqualTo method. In order to working properly with queryParameters it should be urlPathEqualTo method. Please see the example below:

Generated currently by WireMockSnippet
```
{
  "id" : "3a08a940-3efa-4086-aaf2-fd3718e23bd5",
  "request" : {
    "url" : "/test",
    "method" : "GET",
    "queryParameters" : {
      "userId" : {
        "equalTo" : "11"
      }
    }
  },
  "response" : {
    "status" : 200,
    "body" : "{}" 
  },
  "uuid" : "3a08a940-3efa-4086-aaf2-fd3718e23bd5"
}
```
Request was not matched:
```
 curl  'http://localhost:8080/test?userId=11'

                                               Request was not matched
                                               =======================

-----------------------------------------------------------------------------------------------------------------------
| Closest stub                                             | Request                                                  |
-----------------------------------------------------------------------------------------------------------------------
                                                           |
GET                                                        | GET
/test                                                      | /test?userId=11                                     <<<<< URL does not match
                                                           |
Query: userId = 11                                         | userId: 11
                                                           |
                                                           |
-----------------------------------------------------------------------------------------------------------------------
```
Should generate:
```
{
  "id" : "3a08a940-3efa-4086-aaf2-fd3718e23bd5",
  "request" : {
    "urlPath" : "/test",
    "method" : "GET",
    "queryParameters" : {
      "userId" : {
        "equalTo" : "11"
      }
    }
  },
  "response" : {
    "status" : 200,
    "body" : "{}" 
  },
  "uuid" : "3a08a940-3efa-4086-aaf2-fd3718e23bd5"
}
```
Request matched:
```
curl  'http://localhost:8080/test?userId=11'
{}
```