### PR TITLE
Verifier Docker image PUBLISH_ARTIFACTS_OFFLINE option

### DIFF
--- a/docker/spring-cloud-contract-docker/project/build.gradle
+++ b/docker/spring-cloud-contract-docker/project/build.gradle
@@ -109,11 +109,14 @@ test.finalizedBy("copyOutput")
 
 publishing {
 	repositories {
-		maven {
-			url getProp('REPO_WITH_BINARIES_URL') ?: 'http://localhost:8081/artifactory/libs-release-local'
-			credentials {
-				username getProp('REPO_WITH_BINARIES_USERNAME') ?: 'admin'
-				password getProp('REPO_WITH_BINARIES_PASSWORD') ?: 'password'
+		mavenLocal()
+		if (!Boolean.parseBoolean(getProp("PUBLISH_ARTIFACTS_OFFLINE") ?: "false")) {
+			maven {
+				url getProp('REPO_WITH_BINARIES_URL') ?: 'http://localhost:8081/artifactory/libs-release-local'
+				credentials {
+					username getProp('REPO_WITH_BINARIES_USERNAME') ?: 'admin'
+					password getProp('REPO_WITH_BINARIES_PASSWORD') ?: 'password'
+				}
 			}
 		}
 	}

--- a/docs/src/main/asciidoc/docker-project.adoc
+++ b/docs/src/main/asciidoc/docker-project.adoc
@@ -85,6 +85,8 @@ which is the default URL of https://jfrog.com/artifactory/[Artifactory] running 
 - `REPO_WITH_BINARIES_USERNAME`: (optional) Username when the Artifact Manager is secured. Defaults to `admin`.
 - `REPO_WITH_BINARIES_PASSWORD`: (optional) Password when the Artifact Manager is secured. Defaults to `password`.
 - `PUBLISH_ARTIFACTS`: If set to `true`, publishes the artifact to binary storage. Defaults to `true`.
+- `PUBLISH_ARTIFACTS_OFFLINE`: If set to `true` and the publishing is enabled, it will publish the artifacts to local
+`.m2` only. Defaults to `false`.
 
 These environment variables are used when contracts lay in an external repository. To enable
 this feature, you must set the `EXTERNAL_CONTRACTS_ARTIFACT_ID` environment variable.


### PR DESCRIPTION
New option for publishing stubs just into local .m2 added.

Fixes #1283 