### PR TITLE
Local stub publishing reimplemented

### DIFF
--- a/docker/spring-cloud-contract-docker/project/build.gradle
+++ b/docker/spring-cloud-contract-docker/project/build.gradle
@@ -109,14 +109,11 @@ test.finalizedBy("copyOutput")
 
 publishing {
 	repositories {
-		mavenLocal()
-		if (!Boolean.parseBoolean(getProp("PUBLISH_ARTIFACTS_OFFLINE") ?: "false")) {
-			maven {
-				url getProp('REPO_WITH_BINARIES_URL') ?: 'http://localhost:8081/artifactory/libs-release-local'
-				credentials {
-					username getProp('REPO_WITH_BINARIES_USERNAME') ?: 'admin'
-					password getProp('REPO_WITH_BINARIES_PASSWORD') ?: 'password'
-				}
+		maven {
+			url getProp('REPO_WITH_BINARIES_URL') ?: 'http://localhost:8081/artifactory/libs-release-local'
+			credentials {
+				username getProp('REPO_WITH_BINARIES_USERNAME') ?: 'admin'
+				password getProp('REPO_WITH_BINARIES_PASSWORD') ?: 'password'
 			}
 		}
 	}
@@ -125,14 +122,17 @@ publishing {
 }
 
 // explicitly disable artifacts publication
-String publishArtifacts = getProp("PUBLISH_ARTIFACTS") ?: "true"
-boolean publishEnabled = Boolean.parseBoolean(publishArtifacts)
+boolean publishEnabled = Boolean.parseBoolean(getProp("PUBLISH_ARTIFACTS") ?: "true")
+boolean publishOffline = Boolean.parseBoolean(getProp("PUBLISH_ARTIFACTS_OFFLINE") ?: "false")
 publish.setEnabled(publishEnabled)
+publishToMavenLocal.setEnabled(publishOffline)
 
 gradle.taskGraph.whenReady { graph ->
 	graph.allTasks.
 			findAll { it.name.startsWith("publish") && "publishStubsToScm" != it.name }*.
 			setEnabled(publishEnabled)
+	graph.allTasks.
+			findAll { it.name.startsWith("publish") && it.name.endsWith("ToMavenLocal") }*.setEnabled(publishOffline)
 }
 
 if (Boolean.parseBoolean(getProp("PUBLISH_STUBS_TO_SCM"))) {

--- a/docker/spring-cloud-contract-docker/project/build.sh
+++ b/docker/spring-cloud-contract-docker/project/build.sh
@@ -4,4 +4,4 @@ export PROJECT_NAME="${PROJECT_NAME:-example}"
 echo "Setting project name to [${PROJECT_NAME}]"
 echo "rootProject.name='${PROJECT_NAME}'" >> settings.gradle
 echo "Running the build"
-./gradlew clean build publish --stacktrace
+./gradlew clean build publishToMavenLocal publish --stacktrace

--- a/docs/src/main/asciidoc/docker-project.adoc
+++ b/docs/src/main/asciidoc/docker-project.adoc
@@ -85,8 +85,7 @@ which is the default URL of https://jfrog.com/artifactory/[Artifactory] running 
 - `REPO_WITH_BINARIES_USERNAME`: (optional) Username when the Artifact Manager is secured. Defaults to `admin`.
 - `REPO_WITH_BINARIES_PASSWORD`: (optional) Password when the Artifact Manager is secured. Defaults to `password`.
 - `PUBLISH_ARTIFACTS`: If set to `true`, publishes the artifact to binary storage. Defaults to `true`.
-- `PUBLISH_ARTIFACTS_OFFLINE`: If set to `true` and the publishing is enabled, it will publish the artifacts to local
-`.m2` only. Defaults to `false`.
+- `PUBLISH_ARTIFACTS_OFFLINE`: If set to `true`, it will publish the artifacts to local `.m2`. Defaults to `false`.
 
 These environment variables are used when contracts lay in an external repository. To enable
 this feature, you must set the `EXTERNAL_CONTRACTS_ARTIFACT_ID` environment variable.


### PR DESCRIPTION
While the previous approach did publish the contracts to local .m2 repository, it did not create the maven-metadata-local.xml file indicating a local release. It instead created maven-metadata.xml, which indicates a remote release. This wasn't issue when the stubs were retrieved by Gradle directly (in our flow we pre-check availability of these stubs by Gradle), it did however cause problems when they were being resolved by AetherStubDownloader used in SCC Stub Runner.

In addition, this newer implementation allows to enable any publish (remote or local) independently of each other, which wasn't the case previously.

Fixes #1283 - again