### PR TITLE
Fixed issues with ignored() contract-DSL for Junit, JUnit5 and Spock #1346

### DIFF
--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JUnit4IgnoreMethodAnnotation.java
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JUnit4IgnoreMethodAnnotation.java
@@ -46,7 +46,8 @@ class JUnit4IgnoreMethodAnnotation implements MethodAnnotations {
 	public boolean accept(SingleContractMetadata singleContractMetadata) {
 		return this.generatedClassMetaData.configProperties
 				.getTestFramework() == TestFramework.JUNIT
-				&& singleContractMetadata.getContractMetadata().isIgnored();
+				&& (singleContractMetadata.getContractMetadata().isIgnored()
+						|| singleContractMetadata.getContract().isIgnored());
 	}
 
 }

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JUnit5IgnoreMethodAnnotation.java
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/JUnit5IgnoreMethodAnnotation.java
@@ -46,7 +46,8 @@ class JUnit5IgnoreMethodAnnotation implements MethodAnnotations {
 	public boolean accept(SingleContractMetadata singleContractMetadata) {
 		return this.generatedClassMetaData.configProperties
 				.getTestFramework() == TestFramework.JUNIT5
-				&& singleContractMetadata.getContractMetadata().isIgnored();
+				&& (singleContractMetadata.getContractMetadata().isIgnored()
+						|| singleContractMetadata.getContract().isIgnored());
 	}
 
 }

--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/SpockIgnoreMethodAnnotation.java
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/builder/SpockIgnoreMethodAnnotation.java
@@ -46,7 +46,8 @@ class SpockIgnoreMethodAnnotation implements MethodAnnotations {
 	public boolean accept(SingleContractMetadata singleContractMetadata) {
 		return this.generatedClassMetaData.configProperties
 				.getTestFramework() == TestFramework.SPOCK
-				&& singleContractMetadata.getContractMetadata().isIgnored();
+				&& (singleContractMetadata.getContractMetadata().isIgnored()
+						|| singleContractMetadata.getContract().isIgnored());
 	}
 
 }


### PR DESCRIPTION
### bug-fix: spring-cloud-contract #1346

- JUnit, JUnit5, Spock *IgnoreMethodAnnotation refactored (TestNG is not affected)
- extended more tests to cover possible scenarios for diff frameworks

### Verified:
- added tests for JUnit, JUnit5, TestNG, Spock for **ignore** (combinations of DSL and config) processing and verification
- by applying fixed spring-cloud-verifier artifact in local project