### PR TITLE
bug: handle xml with namespaces closes #1427

### DIFF
--- a/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/util/xml/XmlToXPathsConverter.groovy
+++ b/spring-cloud-contract-verifier/src/main/groovy/org/springframework/cloud/contract/verifier/util/xml/XmlToXPathsConverter.groovy
@@ -16,7 +16,9 @@
 
 package org.springframework.cloud.contract.verifier.util.xml
 
+import com.sun.org.apache.xml.internal.security.utils.DOMNamespaceContext
 
+import javax.xml.namespace.NamespaceContext
 import java.util.stream.IntStream
 
 import javax.xml.parsers.DocumentBuilder
@@ -87,10 +89,13 @@ class XmlToXPathsConverter {
 
 	private static String getNodeValue(String path, Object body) {
 		XPath xPath = XPathFactory.newInstance().newXPath()
-		DocumentBuilder documentBuilder = DocumentBuilderFactory.newInstance()
+		DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance()
+		builderFactory.setNamespaceAware(true)
+		DocumentBuilder documentBuilder = builderFactory
 			.newDocumentBuilder()
 		Document parsedXml = documentBuilder.
 			parse(new InputSource(new StringReader(body as String)))
+		xPath.setNamespaceContext(new DOMNamespaceContext(parsedXml.documentElement))
 		return xPath.evaluate(path, parsedXml.documentElement)
 	}
 

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/util/xml/XmlToXPathsConverterSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/util/xml/XmlToXPathsConverterSpec.groovy
@@ -1,0 +1,40 @@
+package org.springframework.cloud.contract.verifier.util.xml
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import javax.xml.xpath.XPathExpressionException
+
+class XmlToXPathsConverterSpec extends Specification {
+	@Shared
+	String namedXml = '''<ns1:customer xmlns:ns1="http://demo.com/testns">
+      <email>customer@test.com</email>
+    </ns1:customer>
+    '''
+	@Shared
+	String unnamedXml = '''<customer>
+      <email>customer@test.com</email>
+    </customer>
+    '''
+
+	@Unroll
+	def "should generate [#expectedValue] for xPath [#value]"() {
+		expect:
+		value == expectedValue
+		where:
+		value                                                                                || expectedValue
+		XmlToXPathsConverter.retrieveValueFromBody("/ns1:customer/email/text()", namedXml)   || '''customer@test.com'''
+		XmlToXPathsConverter.retrieveValueFromBody("/customer/email/text()", namedXml)       || ''''''
+		XmlToXPathsConverter.retrieveValueFromBody("/customer/email/text()", unnamedXml)     || '''customer@test.com'''
+	}
+
+	@Unroll
+	def "should throw exception when searching for inexistent name space"() {
+		when:
+		XmlToXPathsConverter.retrieveValueFromBody("/ns1:customer/email/text()", unnamedXml)
+		then:
+		def e = thrown(XPathExpressionException)
+		e.message.contains('Prefix must resolve to a namespace: ns1')
+	}
+}


### PR DESCRIPTION
This PR adds test to validate the expected behavior of the XmlToXPathConverter class when the input is an xml that contains an name space and one that does not contain such namespace.
The implementation of the fix consists in enabling the name space aware property of the DocumentBuilderFactory so that the document instance created from the xml is capable of identify the attributes prefixes and use the DOMNamespaceContect to translate the identified name spaces to the required dom elements. 