### PR TITLE
Skip tasks when input directory is empty

### DIFF
--- a/samples/standalone/webclient/http-server/build.gradle
+++ b/samples/standalone/webclient/http-server/build.gradle
@@ -4,6 +4,13 @@ plugins {
 	id "io.spring.dependency-management"
 	id "maven-publish"
 	id "maven"
+	/**
+	 * While the SCC Gradle plugin is not strictly necessary for this project.
+	 * It is included to ensure that if the contractDslDir does not exist, then
+	 * the plugin reports "NO-SOURCE" for associated tasks, rather than resulting
+	 * in an error for the end user.
+	 */
+	id "org.springframework.cloud.contract"
 }
 
 group = 'com.example'
@@ -33,6 +40,10 @@ dependencies {
 	}
 	testImplementation 'org.springframework.restdocs:spring-restdocs-webtestclient'
 	testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock'
+}
+
+contracts {
+	failOnNoContracts = false
 }
 
 test {

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/ContractsCopyTask.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/ContractsCopyTask.java
@@ -42,6 +42,7 @@ import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.springframework.cloud.contract.stubrunner.ContractDownloader;
 import org.springframework.cloud.contract.stubrunner.ScmStubDownloaderBuilder;
@@ -281,6 +282,7 @@ class ContractsCopyTask extends DefaultTask {
 	}
 
 	@InputDirectory
+	@SkipWhenEmpty
 	@PathSensitive(PathSensitivity.RELATIVE)
 	DirectoryProperty getContractsDirectory() {
 		return contractsDirectory;

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/GenerateClientStubsFromDslTask.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/GenerateClientStubsFromDslTask.java
@@ -33,6 +33,7 @@ import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.springframework.cloud.contract.verifier.converter.RecursiveFilesConverter;
 
@@ -81,6 +82,7 @@ class GenerateClientStubsFromDslTask extends DefaultTask {
 	}
 
 	@InputDirectory
+	@SkipWhenEmpty
 	@PathSensitive(PathSensitivity.RELATIVE)
 	public Property<Directory> getContractsDslDir() {
 		return contractsDslDir;

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/GenerateServerTestsTask.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/GenerateServerTestsTask.java
@@ -30,6 +30,7 @@ import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.springframework.cloud.contract.spec.ContractVerifierException;
 import org.springframework.cloud.contract.verifier.TestGenerator;
@@ -132,6 +133,7 @@ class GenerateServerTestsTask extends DefaultTask {
 	}
 
 	@InputDirectory
+	@SkipWhenEmpty
 	@PathSensitive(PathSensitivity.RELATIVE)
 	DirectoryProperty getContractsDslDir() {
 		return contractsDslDir;


### PR DESCRIPTION
When the `contractsDslDir` doesn't exist the tasks would fail. By using `@SkipWhenEmpty` Gradle won't throw an error when the `contractsDslDir` doesn't exist.