### PR TITLE
Migrate DSL contracts to 'contractTest' source set

### DIFF
--- a/docs/src/main/asciidoc/_project-features-contract.adoc
+++ b/docs/src/main/asciidoc/_project-features-contract.adoc
@@ -103,7 +103,12 @@ contracts {
 
 To get started with writing contracts in Kotlin, you need to start with a (newly created) Kotlin Script file (`.kts`).
 As with the Java DSL, you can put your contracts in any directory of your choice.
-By default, the Maven and Gradle plugins look at the `src/test/resources/contracts` directory.
+By default, the Maven plugin looks at `src/test/resources/contracts` and Gradle plugins look at the
+`src/contractTest/resources/contracts` directory.
+
+NOTE: Since 3.0.0, the Gradle plugin will also look at the legacy
+directory `src/test/resources/contracts` for migration purposes. When contracts are found in this directory, a warning
+will be logged during your build.
 
 You need to explicitly pass the `spring-cloud-contract-spec-kotlin` dependency to your project plugin setup.
 The following example (in both Maven and Gradle) shows how to do so:

--- a/docs/src/main/asciidoc/gradle-project.adoc
+++ b/docs/src/main/asciidoc/gradle-project.adoc
@@ -52,11 +52,11 @@ dependencyManagement {
 }
 
 dependencies {
-	testCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"
+	testImplementation "org.codehaus.groovy:groovy-all:${groovyVersion}"
 	// example with adding Spock core and Spock Spring
-	testCompile "org.spockframework:spock-core:${spockVersion}"
-	testCompile "org.spockframework:spock-spring:${spockVersion}"
-	testCompile 'org.springframework.cloud:spring-cloud-starter-contract-verifier'
+	testImplementation "org.spockframework:spock-core:${spockVersion}"
+	testImplementation "org.spockframework:spock-spring:${spockVersion}"
+	testImplementation 'org.springframework.cloud:spring-cloud-starter-contract-verifier'
 }
 ----
 
@@ -93,11 +93,11 @@ dependencyManagement {
 }
 
 dependencies {
-	testCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"
+	testImplementation "org.codehaus.groovy:groovy-all:${groovyVersion}"
 	// example with adding Spock core and Spock Spring
-	testCompile "org.spockframework:spock-core:${spockVersion}"
-	testCompile "org.spockframework:spock-spring:${spockVersion}"
-	testCompile 'org.springframework.cloud:spring-cloud-starter-contract-verifier'
+	testImplementation "org.spockframework:spock-core:${spockVersion}"
+	testImplementation "org.spockframework:spock-spring:${spockVersion}"
+	testImplementation 'org.springframework.cloud:spring-cloud-starter-contract-verifier'
 }
 ----
 
@@ -118,7 +118,7 @@ buildscript {
 }
 
 apply plugin: 'groovy'
-apply plugin: 'spring-cloud-contract'
+apply plugin: 'org.springframework.cloud.contract'
 
 dependencyManagement {
 	imports {
@@ -127,11 +127,11 @@ dependencyManagement {
 }
 
 dependencies {
-	testCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"
+	testImplementation "org.codehaus.groovy:groovy-all:${groovyVersion}"
 	// example with adding Spock core and Spock Spring
-	testCompile "org.spockframework:spock-core:${spockVersion}"
-	testCompile "org.spockframework:spock-spring:${spockVersion}"
-	testCompile 'org.springframework.cloud:spring-cloud-starter-contract-verifier'
+	testImplementation "org.spockframework:spock-core:${spockVersion}"
+	testImplementation "org.spockframework:spock-spring:${spockVersion}"
+	testImplementation 'org.springframework.cloud:spring-cloud-starter-contract-verifier'
 }
 ----
 ====
@@ -187,7 +187,13 @@ include::{standalone_samples_path}/http-server/build.gradle[tags=repos,indent=0]
 == Add stubs
 
 By default, Spring Cloud Contract Verifier looks for stubs in the
-`src/test/resources/contracts` directory.
+`src/contractTest/resources/contracts` directory. For transitional purposes the plugin
+will also look for contracts in `src/test/resources/contracts`, however, this directory
+is deprecated as of Spring Cloud Contract 3.0.0.
+
+It should also be noted, that with this new Gradle source set, you should also migrate
+any base classes used within your contract tests to `src/contractTest/{language}` where
+`{language}` should be replaced with Java or Groovy as needed for your purposes.
 
 The directory that contains stub definitions is treated as a class name, and each stub
 definition is treated as a single test. Spring Cloud Contract Verifier assumes that it
@@ -198,8 +204,8 @@ as the package name. Consider the following structure:
 ====
 [source,groovy,indent=0]
 ----
-src/test/resources/contracts/myservice/shouldCreateUser.groovy
-src/test/resources/contracts/myservice/shouldReturnUser.groovy
+src/contractTest/resources/contracts/myservice/shouldCreateUser.groovy
+src/contractTest/resources/contracts/myservice/shouldReturnUser.groovy
 ----
 ====
 
@@ -231,24 +237,24 @@ contracts {
     generatedTestJavaSourcesDir = project.file("${project.buildDir}/generated-test-sources/contractTest/java")
     generatedTestGroovySourcesDir = project.file("${project.buildDir}/generated-test-sources/contractTest/groovy")
     generatedTestResourcesDir = project.file("${project.buildDir}/generated-test-resources/contracts")
-    contractsDslDir = project.file("${project.projectDir}/src/test/resources/contracts")
+    contractsDslDir = project.file("${project.projectDir}/src/contractTest/resources/contracts")
     basePackageForTests = 'org.springframework.cloud.verifier.tests'
     stubsOutputDir = project.file("${project.buildDir}/stubs")
     sourceSet = null
 }
 
-tasks.create(type: Jar, name: 'verifierStubsJar', dependsOn: 'generateClientStubs') {
+def verifierStubsJar = tasks.register(type: Jar, name: 'verifierStubsJar', dependsOn: 'generateClientStubs') {
     baseName = project.name
     classifier = contracts.stubsSuffix
     from contractVerifier.stubsOutputDir
 }
 
-tasks.create(type: Copy, name: 'copyContracts') {
+def copyContracts = tasks.register(type: Copy, name: 'copyContracts') {
     from contracts.contractsDslDir
     into contracts.stubsOutputDir
 }
 
-verifierStubsJar.dependsOn 'copyContracts'
+verifierStubsJar.dependsOn copyContracts
 ----
 ====
 
@@ -264,7 +270,7 @@ configuration, as the following listing shows:
 contracts {
 	testMode = 'MockMvc'
 	baseClassForTests = 'org.mycompany.tests'
-	generatedTestSourcesDir = project.file('src/generatedContract')
+	generatedTestJavaSourcesDir = project.file('src/generatedContract')
 }
 ----
 ====
@@ -339,7 +345,7 @@ setting takes precedence over `packageWithBaseClasses` and `baseClassForTests`.
 * `ignoredFiles`: Uses an `Antmatcher` to allow defining stub files for which processing
 should be skipped. By default, it is an empty array.
 * `contractsDslDir`: Specifies the directory that contains contracts written by using the
-GroovyDSL. By default, its value is `$projectDir/src/test/resources/contracts`.
+GroovyDSL. By default, its value is `$projectDir/src/contractTest/resources/contracts`.
 * `generatedTestSourcesDir`: Specifies the test source directory where tests generated
 from the Groovy DSL should be placed. (Deprecrated)
 * `generatedTestJavaSourcesDir`: Specifies the test source directory where Java/JUnit tests generated from the Groovy DSL should be placed. By default, it's value is `$buildDir/generated-tes-sources/contractTest/java`.
@@ -419,7 +425,7 @@ plugin which class should get extended by the autogenerated tests. You have two 
 === By Convention
 
 The convention is such that, if you have a contract in (for example)
-`src/test/resources/contract/foo/bar/baz/` and set the value of the
+`src/contractTest/resources/contract/foo/bar/baz/` and set the value of the
 `packageWithBaseClasses` property to `com.example.base`, then Spring Cloud Contract
 Verifier assumes that there is a `BarBazBase` class under the `com.example.base` package.
 In other words, the system takes the last two parts of the package, if they exist, and
@@ -449,12 +455,12 @@ include::{plugins_path}/spring-cloud-contract-gradle-plugin/src/test/groovy/org/
 
 Assume that you have contracts in the following directories:
 
-- `src/test/resources/contract/com/`
-- `src/test/resources/contract/foo/`
+- `src/contractTest/resources/contract/com/`
+- `src/contractTest/resources/contract/foo/`
 
 By providing `baseClassForTests`, we have a fallback in case mapping did not succeed.
 (You could also provide the `packageWithBaseClasses` as a fallback.) That way, the tests
-generated from `src/test/resources/contract/com/` contracts extend the
+generated from `src/contractTest/resources/contract/com/` contracts extend the
 `com.example.ComBase`, whereas the rest of the tests extend `com.example.FooBase`.
 
 [[gradle-invoking-generated-tests]]
@@ -466,7 +472,7 @@ the following command:
 ====
 [source,bash,indent=0]
 ----
-./gradlew generateContractTests test
+./gradlew contractTest
 ----
 ====
 
@@ -525,7 +531,7 @@ or through a system property or an environment variable.
 
 In a consuming service, you need to configure the Spring Cloud Contract Verifier plugin
 in exactly the same way as in the case of a provider. If you do not want to use Stub Runner,
-you need to copy the contracts stored in `src/test/resources/contracts` and generate
+you need to copy the contracts stored in `src/contractTest/resources/contracts` and generate
 WireMock JSON stubs by using the following command:
 
 ====

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/build.gradle
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/build.gradle
@@ -62,24 +62,24 @@ configurations {
 }
 
 dependencies {
-	compile gradleApi()
-	compile "org.eclipse.aether:aether-api:${aetherVersion}"
+	compileOnly gradleApi()
+	implementation "org.eclipse.aether:aether-api:${aetherVersion}"
 
-	compile("org.springframework.cloud:spring-cloud-contract-converters:${project.version}") {
+	implementation("org.springframework.cloud:spring-cloud-contract-converters:${project.version}") {
 		exclude(group: 'org.codehaus.groovy')
 	}
-	compile("org.springframework.cloud:spring-cloud-contract-stub-runner:${project.version}") {
+	api("org.springframework.cloud:spring-cloud-contract-stub-runner:${project.version}") {
 		exclude(group: 'org.codehaus.groovy')
 	}
-	compile("org.springframework.cloud:spring-cloud-starter-contract-verifier:${project.version}") {
+	api("org.springframework.cloud:spring-cloud-starter-contract-verifier:${project.version}") {
 		exclude(group: 'org.codehaus.groovy')
 	}
-	testCompile('org.spockframework:spock-core:1.3-groovy-2.5') {
+	testImplementation('org.spockframework:spock-core:1.3-groovy-2.5') {
 		exclude(group: 'org.codehaus.groovy')
 	}
-	testCompile 'info.solidsoft.spock:spock-global-unroll:0.5.0'
-	testCompile localGroovy()
-	testCompile gradleTestKit()
+	testImplementation 'info.solidsoft.spock:spock-global-unroll:0.5.0'
+	testImplementation localGroovy()
+	testImplementation gradleTestKit()
 }
 
 task libtest() {

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/ContractVerifierExtension.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/ContractVerifierExtension.java
@@ -247,7 +247,7 @@ public class ContractVerifierExtension implements Serializable {
 		this.imports = objects.listProperty(String.class).convention(new ArrayList<>());
 		this.staticImports = objects.listProperty(String.class).convention(new ArrayList<>());
 		this.contractsDslDir = objects.directoryProperty()
-				.convention(layout.getProjectDirectory().dir("src/test/resources/contracts"));
+				.convention(layout.getProjectDirectory().dir("src/contractTest/resources/contracts"));
 		this.generatedTestSourcesDir = objects.directoryProperty();
 		this.generatedTestJavaSourcesDir = objects.directoryProperty()
 				.convention(layout.getBuildDirectory().dir("generated-test-sources/contractTest/java"));

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/ContractsCopyTask.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/ContractsCopyTask.java
@@ -81,9 +81,6 @@ class ContractsCopyTask extends DefaultTask {
 
 	private final DirectoryProperty contractsDirectory;
 
-	@Deprecated
-	private final DirectoryProperty legacyContractsDirectory;
-
 	private final Dependency contractDependency;
 
 	private final Repository contractRepository;
@@ -114,7 +111,6 @@ class ContractsCopyTask extends DefaultTask {
 		convertToYaml = objects.property(Boolean.class);
 		failOnNoContracts = objects.property(Boolean.class);
 		contractsDirectory = objects.directoryProperty();
-		legacyContractsDirectory = objects.directoryProperty();
 		contractDependency = objects.newInstance(Dependency.class);
 		contractRepository = objects.newInstance(Repository.class);
 		contractsMode = objects.property(StubRunnerProperties.StubsMode.class);
@@ -161,7 +157,7 @@ class ContractsCopyTask extends DefaultTask {
 
 	@TaskAction
 	void sync() {
-		/*final*/ File contractsDirectory;
+		final File contractsDirectory;
 		final String antPattern;
 		if (shouldDownloadContracts()) {
 			DownloadedData downloadedData = downloadContracts();
@@ -171,11 +167,6 @@ class ContractsCopyTask extends DefaultTask {
 		}
 		else {
 			contractsDirectory = this.contractsDirectory.getAsFile().getOrNull();
-			if (contractsDirectory == null || !contractsDirectory.exists()) {
-				getLogger().warn("Spring Cloud Contract Verifier Plugin: Falling back to legacy contracts directory in 'test' source set. Please switch to " +
-						"'contractTest' source set as this will be removed in a future release.");
-				contractsDirectory = this.legacyContractsDirectory.getAsFile().getOrNull();
-			}
 			antPattern = "**/";
 		}
 		getLogger().info("For project [{}] will use contracts provided in the folder [{}]", getProject().getName(),
@@ -295,14 +286,6 @@ class ContractsCopyTask extends DefaultTask {
 	@PathSensitive(PathSensitivity.RELATIVE)
 	DirectoryProperty getContractsDirectory() {
 		return contractsDirectory;
-	}
-
-	@Deprecated
-	@InputDirectory
-	@SkipWhenEmpty
-	@PathSensitive(PathSensitivity.RELATIVE)
-	DirectoryProperty getLegacyContractsDirectory() {
-		return legacyContractsDirectory;
 	}
 
 	@Nested

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/ContractsCopyTask.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/ContractsCopyTask.java
@@ -81,6 +81,9 @@ class ContractsCopyTask extends DefaultTask {
 
 	private final DirectoryProperty contractsDirectory;
 
+	@Deprecated
+	private final DirectoryProperty legacyContractsDirectory;
+
 	private final Dependency contractDependency;
 
 	private final Repository contractRepository;
@@ -111,6 +114,7 @@ class ContractsCopyTask extends DefaultTask {
 		convertToYaml = objects.property(Boolean.class);
 		failOnNoContracts = objects.property(Boolean.class);
 		contractsDirectory = objects.directoryProperty();
+		legacyContractsDirectory = objects.directoryProperty();
 		contractDependency = objects.newInstance(Dependency.class);
 		contractRepository = objects.newInstance(Repository.class);
 		contractsMode = objects.property(StubRunnerProperties.StubsMode.class);
@@ -157,7 +161,7 @@ class ContractsCopyTask extends DefaultTask {
 
 	@TaskAction
 	void sync() {
-		final File contractsDirectory;
+		/*final*/ File contractsDirectory;
 		final String antPattern;
 		if (shouldDownloadContracts()) {
 			DownloadedData downloadedData = downloadContracts();
@@ -167,6 +171,11 @@ class ContractsCopyTask extends DefaultTask {
 		}
 		else {
 			contractsDirectory = this.contractsDirectory.getAsFile().getOrNull();
+			if (contractsDirectory == null || !contractsDirectory.exists()) {
+				getLogger().warn("Spring Cloud Contract Verifier Plugin: Falling back to legacy contracts directory in 'test' source set. Please switch to " +
+						"'contractTest' source set as this will be removed in a future release.");
+				contractsDirectory = this.legacyContractsDirectory.getAsFile().getOrNull();
+			}
 			antPattern = "**/";
 		}
 		getLogger().info("For project [{}] will use contracts provided in the folder [{}]", getProject().getName(),
@@ -286,6 +295,14 @@ class ContractsCopyTask extends DefaultTask {
 	@PathSensitive(PathSensitivity.RELATIVE)
 	DirectoryProperty getContractsDirectory() {
 		return contractsDirectory;
+	}
+
+	@Deprecated
+	@InputDirectory
+	@SkipWhenEmpty
+	@PathSensitive(PathSensitivity.RELATIVE)
+	DirectoryProperty getLegacyContractsDirectory() {
+		return legacyContractsDirectory;
 	}
 
 	@Nested

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/SpringCloudContractVerifierGradlePlugin.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/SpringCloudContractVerifierGradlePlugin.java
@@ -344,9 +344,18 @@ public class SpringCloudContractVerifierGradlePlugin implements Plugin<Project> 
 
 					contractsCopyTask.getConvertToYaml().convention(extension.getConvertToYaml());
 					contractsCopyTask.getFailOnNoContracts().convention(extension.getFailOnNoContracts());
-					contractsCopyTask.getContractsDirectory().convention(extension.getContractsDslDir());
-					contractsCopyTask.getLegacyContractsDirectory()
-							.convention(project.getLayout().getProjectDirectory().dir("src/test/resources/contracts"));
+					contractsCopyTask.getContractsDirectory()
+							.convention(extension.getContractsDslDir().map(contractsDslDir -> {
+								if (contractsDslDir.getAsFile().exists()) {
+									return contractsDslDir;
+								}
+								else {
+									project.getLogger().warn(
+											"Spring Cloud Contract Verifier Plugin: Falling back to legacy contracts directory in 'test' source set. Please switch to 'contractTest' source set as this will be removed in a future release.");
+									return project.getLayout().getProjectDirectory()
+											.dir("src/test/resources/contracts");
+								}
+							}));
 					contractsCopyTask.getContractDependency().getGroupId()
 							.convention(extension.getContractDependency().getGroupId());
 					contractsCopyTask.getContractDependency().getArtifactId()

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/SpringCloudContractVerifierGradlePlugin.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/SpringCloudContractVerifierGradlePlugin.java
@@ -18,8 +18,6 @@ package org.springframework.cloud.contract.verifier.plugin;
 
 import java.io.File;
 
-import javax.annotation.Nullable;
-
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -328,15 +326,6 @@ public class SpringCloudContractVerifierGradlePlugin implements Plugin<Project> 
 		});
 	}
 
-	private @Nullable TaskProvider<Jar> stubsTask() {
-		try {
-			return project.getTasks().named(VERIFIER_STUBS_JAR_TASK_NAME, Jar.class);
-		}
-		catch (Exception e) {
-			return null;
-		}
-	}
-
 	@Deprecated
 	private boolean hasStubsPublication(PublishingExtension publishingExtension) {
 		try {
@@ -356,6 +345,8 @@ public class SpringCloudContractVerifierGradlePlugin implements Plugin<Project> 
 					contractsCopyTask.getConvertToYaml().convention(extension.getConvertToYaml());
 					contractsCopyTask.getFailOnNoContracts().convention(extension.getFailOnNoContracts());
 					contractsCopyTask.getContractsDirectory().convention(extension.getContractsDslDir());
+					contractsCopyTask.getLegacyContractsDirectory()
+							.convention(project.getLayout().getProjectDirectory().dir("src/test/resources/contracts"));
 					contractsCopyTask.getContractDependency().getGroupId()
 							.convention(extension.getContractDependency().getGroupId());
 					contractsCopyTask.getContractDependency().getArtifactId()


### PR DESCRIPTION
This continues the effort started in PR #1480 and as discussed there, it was determined that a separate PR should be opened to handle the changed needed for the Maven plugin as well.