### PR TITLE
Option to disable '.git' suffix in git URLs

### DIFF
--- a/docs/src/main/asciidoc/_additional-stubrunner-configprops.adoc
+++ b/docs/src/main/asciidoc/_additional-stubrunner-configprops.adoc
@@ -12,6 +12,7 @@ IMPORTANT: The following properties can be passed as a system property (e.g. `st
 |stubrunner.properties.git.username |  | When using the SCM based approach, you can pass the username to connect to the Git repository.
 |stubrunner.properties.git.password |  | When using the SCM based approach, you can pass the password to connect to the Git repository.
 |stubrunner.properties.git.wait-between-attempts | 1000 | When using the SCM based approach, you can customize waiting time in ms between trying to push the stubs to Git.
+|stubrunner.properties.git.ensure-git-suffix | true | When using the SCM based approach, you can prevent stubrunner from adding `.git` to the repository URL by setting this property to `false`. This adds compatibility with git repositories which do not support such URLs, for example Azure DevOps.
 
 |stubrunner.properties.stubs.find-producer | false | When using the Stubs protocol, you can toggle this flag to search for contracts via the `group id / artifact id` instead of taking the stubs directly from the provided folder.
 

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/GitRepo.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/GitRepo.java
@@ -77,9 +77,12 @@ class GitRepo {
 
 	private final File basedir;
 
+	private final boolean ensureGitSuffix;
+
 	GitRepo(File basedir, GitStubDownloaderProperties properties) {
 		this.basedir = basedir;
 		this.gitFactory = new JGitFactory(properties);
+		this.ensureGitSuffix = properties.ensureGitSuffix;
 	}
 
 	// for tests
@@ -87,6 +90,15 @@ class GitRepo {
 	GitRepo(File basedir) {
 		this.basedir = basedir;
 		this.gitFactory = new JGitFactory();
+		this.ensureGitSuffix = true;
+	}
+
+	// for tests
+	@Deprecated
+	GitRepo(File basedir, boolean ensureGitSuffix) {
+		this.basedir = basedir;
+		this.gitFactory = new JGitFactory();
+		this.ensureGitSuffix = ensureGitSuffix;
 	}
 
 	// for tests
@@ -94,6 +106,7 @@ class GitRepo {
 	GitRepo(File basedir, JGitFactory factory) {
 		this.basedir = basedir;
 		this.gitFactory = factory;
+		this.ensureGitSuffix = true;
 	}
 
 	/**
@@ -203,8 +216,7 @@ class GitRepo {
 	}
 
 	private Git cloneToBasedir(URI projectUrl, File destinationFolder) {
-		String url = projectUrl.toString();
-		String projectGitUrl = url.endsWith(".git") ? url : url + ".git";
+		String projectGitUrl = sanitizeGitUrl(projectUrl);
 		if (log.isDebugEnabled()) {
 			log.debug("Project git url [" + projectGitUrl + "]");
 		}
@@ -224,6 +236,12 @@ class GitRepo {
 			deleteBaseDirIfExists("Failed to initialize base directory");
 			throw new IllegalStateException(e);
 		}
+	}
+
+	protected String sanitizeGitUrl(URI uri) {
+		String urlString = uri.toString();
+		return (urlString.endsWith(".git") || !this.ensureGitSuffix) ? urlString
+				: urlString + ".git";
 	}
 
 	private Ref checkoutBranch(File projectDir, String branch) throws GitAPIException {

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/ScmStubDownloaderBuilder.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/ScmStubDownloaderBuilder.java
@@ -225,6 +225,8 @@ class GitStubDownloaderProperties {
 
 	private static final String GIT_PASSWORD_PROPERTY = "git.password";
 
+	private static final String GIT_ENSURE_GIT_SUFFIX_PROPERTY = "git.ensure-git-suffix";
+
 	final URI url;
 
 	final String username;
@@ -232,6 +234,8 @@ class GitStubDownloaderProperties {
 	final String password;
 
 	final String branch;
+
+	final Boolean ensureGitSuffix;
 
 	GitStubDownloaderProperties(Resource repo, StubRunnerOptions options) {
 		String repoUrl;
@@ -256,10 +260,16 @@ class GitStubDownloaderProperties {
 		this.password = StringUtils.hasText(password) ? password : options.getPassword();
 		String branch = StubRunnerPropertyUtils.getProperty(args, GIT_BRANCH_PROPERTY);
 		this.branch = StringUtils.hasText(branch) ? branch : "master";
+		String ensureGitSuffix = StubRunnerPropertyUtils.getProperty(args,
+				GIT_ENSURE_GIT_SUFFIX_PROPERTY);
+		this.ensureGitSuffix = StringUtils.hasText(ensureGitSuffix)
+				? Boolean.parseBoolean(ensureGitSuffix) : true;
+
 		if (log.isDebugEnabled()) {
 			log.debug("Repo url is [" + repoUrl + "], modified url string " + "is ["
-					+ modifiedRepo + "] URL is [" + this.url + "] and " + "branch is ["
-					+ this.branch + "]");
+					+ modifiedRepo + "] URL is [" + this.url + "]  branch is ["
+					+ this.branch + "] and ensureGitSuffix is [" + this.ensureGitSuffix
+					+ "]");
 		}
 	}
 

--- a/spring-cloud-contract-stub-runner/src/test/java/org/springframework/cloud/contract/stubrunner/GitRepoTests.java
+++ b/spring-cloud-contract-stub-runner/src/test/java/org/springframework/cloud/contract/stubrunner/GitRepoTests.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.contract.stubrunner;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URISyntaxException;
 
 import org.eclipse.jgit.api.CloneCommand;
@@ -26,6 +27,7 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
@@ -163,6 +165,34 @@ public class GitRepoTests extends AbstractGitTest {
 			RevCommit revCommit = git.log().call().iterator().next();
 			then(revCommit.getShortMessage()).isEqualTo("some message");
 		}
+	}
+
+	@Test
+	public void should_add_git_suffix_to_url_if_not_present() throws Exception {
+		this.gitRepo = new GitRepo(this.tmpFolder, true);
+		String url = this.gitRepo.sanitizeGitUrl(new URI("git://example.com/repo"));
+		assertThat(url).isEqualTo("git://example.com/repo.git");
+	}
+
+	@Test
+	public void should_not_add_git_suffix_to_url_if_already_present() throws Exception {
+		this.gitRepo = new GitRepo(this.tmpFolder, true);
+		String url = this.gitRepo.sanitizeGitUrl(new URI("git://example.com/repo.git"));
+		assertThat(url).isEqualTo("git://example.com/repo.git");
+	}
+
+	@Test
+	public void should_not_add_git_suffix_to_url_if_disabled() throws Exception {
+		this.gitRepo = new GitRepo(this.tmpFolder, false);
+		String url = this.gitRepo.sanitizeGitUrl(new URI("git://example.com/repo"));
+		assertThat(url).isEqualTo("git://example.com/repo");
+	}
+
+	@Test
+	public void should_not_remove_git_suffix_from_url_if_disabled() throws Exception {
+		this.gitRepo = new GitRepo(this.tmpFolder, false);
+		String url = this.gitRepo.sanitizeGitUrl(new URI("git://example.com/repo.git"));
+		assertThat(url).isEqualTo("git://example.com/repo.git");
 	}
 
 }


### PR DESCRIPTION
Added stubrunner.properties.git.ensure-git-suffix to disable the automatic
addition of '.git' to git URLs.  This adds support for repositories which
don't support these kind of URLs (for example Azure DevOps).

As discussed in https://gitter.im/spring-cloud/spring-cloud-contract?at=5f97e00f631a250ab295bdb0