### PR TITLE
Mock an open channel for stub tests; Fixes gh-1542

### DIFF
--- a/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/messaging/amqp/RabbitMockConnectionFactoryAutoConfiguration.java
+++ b/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/messaging/amqp/RabbitMockConnectionFactoryAutoConfiguration.java
@@ -71,6 +71,9 @@ public class RabbitMockConnectionFactoryAutoConfiguration {
 				if ("queueDeclare".equals(invocationOnMock.getMethod().getName())) {
 					return mockDeclareOk;
 				}
+				if ("isOpen".equals(invocationOnMock.getMethod().getName())) {
+					return true;
+				}
 				return Mockito.RETURNS_DEFAULTS.answer(invocationOnMock);
 			});
 			when(mockConnection.isOpen()).thenReturn(true);


### PR DESCRIPTION
Adds mock behavior to ensure channel is always open during tests that use `RabbitMockConnectionFactoryAutoConfiguration`'s `ConnectionFactory`