### PR TITLE
Adds handling for empty list and empty map response body

### DIFF
--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/SpringTestMethodBodyBuildersSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/SpringTestMethodBodyBuildersSpec.groovy
@@ -578,6 +578,66 @@ class SpringTestMethodBodyBuildersSpec extends Specification implements WireMock
 			"webclient"       | { properties.testMode = TestMode.WEBTESTCLIENT }
 	}
 
+	@Issue('#1423')
+	def 'should generate assertions for a response body containing an empty list with #methodBuilderName'() {
+		given:
+			Contract contractDsl = Contract.make {
+				request {
+					method "GET"
+					url "/url"
+				}
+				response {
+					status OK()
+					body("[]")
+				}
+			}
+			methodBuilder()
+		when:
+			String test = singleTestGenerator(contractDsl)
+		then:
+			test.contains("""assertThatJson(parsedJson).isEmpty()""")
+		and:
+			stubMappingIsValidWireMockStub(contractDsl)
+		and:
+			SyntaxChecker.tryToCompile(methodBuilderName, test)
+		where:
+			methodBuilderName | methodBuilder
+			"spock"           | { properties.testFramework = TestFramework.SPOCK }
+			"testng"          | { properties.testFramework = TestFramework.TESTNG }
+			"mockmvc"         | { properties.testMode = TestMode.MOCKMVC }
+			"webclient"       | { properties.testMode = TestMode.WEBTESTCLIENT }
+	}
+
+	@Issue('#1423')
+	def 'should generate assertions for a response body containing an empty map with #methodBuilderName'() {
+		given:
+			Contract contractDsl = Contract.make {
+				request {
+					method "GET"
+					url "/url"
+				}
+				response {
+					status OK()
+					body("{}")
+				}
+			}
+			methodBuilder()
+		when:
+			String test = singleTestGenerator(contractDsl)
+		then:
+			test.contains("""assertThatJson(parsedJson).isEmpty()""")
+		and:
+			stubMappingIsValidWireMockStub(contractDsl)
+		and:
+			SyntaxChecker.tryToCompile(methodBuilderName, test)
+		where:
+			methodBuilderName | methodBuilder
+			"spock"           | { properties.testFramework = TestFramework.SPOCK }
+			"testng"          | { properties.testFramework = TestFramework.TESTNG }
+			"mockmvc"         | { properties.testMode = TestMode.MOCKMVC }
+			"webclient"       | { properties.testMode = TestMode.WEBTESTCLIENT }
+	}
+
 	def 'should generate regex assertions for map objects in response body with #methodBuilderName'() {
 		given:
 			Contract contractDsl = Contract.make {

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/YamlMockMvcMethodBodyBuilderSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/YamlMockMvcMethodBodyBuilderSpec.groovy
@@ -434,6 +434,68 @@ response:
 			"webclient"       | { properties.testMode = TestMode.WEBTESTCLIENT }
 	}
 
+	@Issue('#1423')
+	def 'should generate assertions for a response body containing an empty list with #methodBuilderName'() {
+		given:
+			String contract = """\
+---
+description: Returns an empty collection
+request:
+  method: GET
+  urlPath: /url
+response:
+  status: 200
+  body: []
+"""
+			Contract contractDsl = fromYaml(contract)
+			methodBuilder()
+		when:
+			String test = singleTestGenerator(contractDsl)
+		then:
+			test.contains("""assertThatJson(parsedJson).isEmpty()""")
+		and:
+			stubMappingIsValidWireMockStub(contractDsl)
+		and:
+			SyntaxChecker.tryToCompile(methodBuilderName, test)
+		where:
+			methodBuilderName | methodBuilder
+			"spock"           | { properties.testFramework = TestFramework.SPOCK }
+			"testng"          | { properties.testFramework = TestFramework.TESTNG }
+			"mockmvc"         | { properties.testMode = TestMode.MOCKMVC }
+			"webclient"       | { properties.testMode = TestMode.WEBTESTCLIENT }
+	}
+
+	@Issue('#1423')
+	def 'should generate assertions for a response body containing an empty map with #methodBuilderName'() {
+		given:
+			String contract = """\
+---
+description: Returns an empty map
+request:
+  method: GET
+  urlPath: /url
+response:
+  status: 200
+  body: {}
+"""
+			Contract contractDsl = fromYaml(contract)
+			methodBuilder()
+		when:
+			String test = singleTestGenerator(contractDsl)
+		then:
+			test.contains("""assertThatJson(parsedJson).isEmpty()""")
+		and:
+			stubMappingIsValidWireMockStub(contractDsl)
+		and:
+			SyntaxChecker.tryToCompile(methodBuilderName, test)
+		where:
+			methodBuilderName | methodBuilder
+			"spock"           | { properties.testFramework = TestFramework.SPOCK }
+			"testng"          | { properties.testFramework = TestFramework.TESTNG }
+			"mockmvc"         | { properties.testMode = TestMode.MOCKMVC }
+			"webclient"       | { properties.testMode = TestMode.WEBTESTCLIENT }
+	}
+
 	def 'should generate regex assertions for map objects in response body with #methodBuilderName'() {
 		given:
 			String contract = '''\


### PR DESCRIPTION
Fixes gh-1423

This change allows the response body to be either an empty map (`{}`) or empty collection (`[]`). They can be represented as follows *(yaml and groovy dsl, respectively):*

**empty collection**
```yaml
body: []
```
```groovy
body([])
```
**empty map**
```yaml
body: {}
```
```groovy
body({})
```

---
#### NPE 
The report of the NPE occurs when handling a single null element collection:
```yaml
body:
  - 
```
```groovy
body([null])
```
At first I was going to fix both w/in this code proposal but it became evident that it should it be its own solve - I created #1557 .
