### PR TITLE
Attempt to keep Kotlin totally off the classpath

### DIFF
--- a/samples/standalone/dsl/http-client/build.gradle
+++ b/samples/standalone/dsl/http-client/build.gradle
@@ -1,14 +1,8 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-	}
+plugins {
+	id "groovy"
+	id "org.springframework.boot"
+	id "io.spring.dependency-management"
+	id "maven-publish"
 }
 
 group = 'com.example'
@@ -21,11 +15,6 @@ repositories {
 	maven { url "https://repo.spring.io/milestone" }
 	maven { url "https://repo.spring.io/release" }
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
 
 dependencyManagement {
 	imports {

--- a/samples/standalone/dsl/http-client/settings.gradle
+++ b/samples/standalone/dsl/http-client/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        maven { url "https://repo.spring.io/snapshot" }
+        maven { url "https://repo.spring.io/milestone" }
+        maven { url "https://repo.spring.io/release" }
+        gradlePluginPortal()
+    }
+    plugins {
+        id "org.springframework.boot" version "${bootVersion}"
+        id "io.spring.dependency-management" version "1.0.10.RELEASE"
+    }
+}
+
 rootProject.name = 'http-client-dsl-gradle'

--- a/samples/standalone/dsl/http-server/build.gradle
+++ b/samples/standalone/dsl/http-server/build.gradle
@@ -1,42 +1,9 @@
-// tag::repos[]
-/*
- We need to use the [buildscript {}] section when we have to modify
- the classpath for the plugins. If that's not the case this section
- can be skipped.
-
- If you don't need to modify the classpath (e.g. add a Pact dependency),
- then you can just set the [pluginManagement {}] section in [settings.gradle] file.
-
- // settings.gradle
- pluginManagement {
-    repositories {
-        // for snapshots
-        maven {url "https://repo.spring.io/snapshot"}
-        // for milestones
-        maven {url "https://repo.spring.io/milestone"}
-        // for GA versions
-        gradlePluginPortal()
-    }
- }
-
- */
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-// end::repos[]
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		//tag::pact_dependency[]
-		// if additional dependencies are needed e.g. for Pact
-		classpath "org.springframework.cloud:spring-cloud-contract-pact:${findProperty('verifierVersion') ?: verifierVersion}"
-		//end::pact_dependency[]
-	}
+plugins {
+	id "java"
+	id "org.springframework.boot"
+	id "io.spring.dependency-management"
+	id "org.springframework.cloud.contract"
+	id "maven-publish"
 }
 
 group = 'com.example'
@@ -51,12 +18,6 @@ repositories {
 	maven { url "https://repo.spring.io/release" }
 }
 // end::deps_repos[]
-
-apply plugin: 'java'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'spring-cloud-contract'
-apply plugin: 'maven-publish'
 
 dependencyManagement {
 	imports {

--- a/samples/standalone/dsl/http-server/settings.gradle
+++ b/samples/standalone/dsl/http-server/settings.gradle
@@ -1,1 +1,25 @@
+// tag:repos[]
+pluginManagement {
+    repositories {
+        mavenLocal()
+        maven { url "https://repo.spring.io/snapshot" }
+        maven { url "https://repo.spring.io/milestone" }
+        maven { url "https://repo.spring.io/release" }
+        gradlePluginPortal()
+    }
+// end:repos[]
+    plugins {
+        id "org.springframework.boot" version "${bootVersion}"
+        id "io.spring.dependency-management" version "1.0.10.RELEASE"
+    }
+    resolutionStrategy {
+        eachPlugin {
+            // protects us in case the gradle-portal-plugin hasn't yet been published by Maven
+            if (requested.id.id == 'org.springframework.cloud.contract') {
+                useModule("org.springframework.cloud:spring-cloud-contract-gradle-plugin:${verifierVersion}")
+            }
+        }
+    }
+}
+
 rootProject.name = 'http-server-dsl-gradle'

--- a/samples/standalone/restdocs/http-server/build.gradle
+++ b/samples/standalone/restdocs/http-server/build.gradle
@@ -1,15 +1,9 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${project.findProperty('verifierVersion') ?: verifierVersion}"
-	}
+plugins {
+	id "groovy"
+	id "org.springframework.boot"
+	id "io.spring.dependency-management"
+	id "org.springframework.cloud.contract"
+	id "maven-publish"
 }
 
 group = 'com.example'
@@ -23,17 +17,10 @@ repositories {
 	maven { url "https://repo.spring.io/release" }
 }
 
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
-apply plugin: 'maven'
-apply plugin: 'spring-cloud-contract'
-
 dependencyManagement {
 	imports {
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:$BOM_VERSION"
-		mavenBom "org.springframework.cloud:spring-cloud-contract-dependencies:${project.findProperty('verifierVersion') ?: verifierVersion}"
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${BOM_VERSION}"
+		mavenBom "org.springframework.cloud:spring-cloud-contract-dependencies:${verifierVersion}"
 	}
 }
 
@@ -50,7 +37,17 @@ dependencies {
 	// end::dependencies[]
 }
 
+contracts {
+	baseClassMappings {
+		baseClassMapping('.*standalone.*', 'com.example.fraud.FraudBaseWithStandaloneSetup')
+		baseClassMapping('.*webapp.*', 'com.example.fraud.FraudBaseWithWebAppSetup')
+	}
+}
+
+generateClientStubs.enabled = false
+
 test {
+	useJUnitPlatform()
 	systemProperty 'spring.profiles.active', 'gradle'
 	testLogging {
 		exceptionFormat = 'full'
@@ -65,27 +62,10 @@ test {
 	}
 }
 
-contracts {
-	baseClassMappings {
-		baseClassMapping('.*standalone.*', 'com.example.fraud.FraudBaseWithStandaloneSetup')
-		baseClassMapping('.*webapp.*', 'com.example.fraud.FraudBaseWithWebAppSetup')
-	}
-}
-
-generateClientStubs.enabled = false
-
 task stubsJar(type: Jar, dependsOn: ['copySnippets', 'copySources', 'copyClasses']) {
 	baseName = project.name
 	classifier = 'stubs'
 	from project.file("${project.buildDir}/stubs")
-}
-
-artifacts {
-	archives stubsJar
-}
-
-test {
-	useJUnitPlatform()
 }
 
 task copySnippets(type: Copy, dependsOn: test) {
@@ -103,6 +83,25 @@ task copyClasses(type: Copy) {
 	from "${project.buildDir}/classes/main/"
 	include '**/model/Fraud*.*'
 	into "${project.buildDir}/stubs/"
+}
+
+publishing {
+	publications {
+		maven(MavenPublication) {
+			artifact bootJar
+			artifact stubsJar
+
+			// https://github.com/spring-gradle-plugins/dependency-management-plugin/issues/273
+			versionMapping {
+				usage("java-api") {
+					fromResolutionOf("runtimeClasspath")
+				}
+				usage("java-runtime") {
+					fromResolutionResult()
+				}
+			}
+		}
+	}
 }
 
 clean.doFirst {

--- a/samples/standalone/restdocs/http-server/pom.xml
+++ b/samples/standalone/restdocs/http-server/pom.xml
@@ -225,8 +225,7 @@
 									<arguments>
 										<argument>clean</argument>
 										<argument>build</argument>
-										<!-- For some reason publishToMavenLocal doesn't work... Please don't troll Gradle ;)-->
-										<argument>install</argument>
+										<argument>publishToMavenLocal</argument>
 										<argument>
 											-PverifierVersion=${spring-cloud-contract.version}
 										</argument>

--- a/samples/standalone/restdocs/http-server/settings.gradle
+++ b/samples/standalone/restdocs/http-server/settings.gradle
@@ -1,1 +1,22 @@
-rootProject.name = 'http-server-restdocs'
+pluginManagement {
+    repositories {
+        mavenLocal()
+        maven { url "https://repo.spring.io/snapshot" }
+        maven { url "https://repo.spring.io/milestone" }
+        gradlePluginPortal()
+    }
+    plugins {
+        id 'org.springframework.boot' version "${bootVersion}"
+        id "io.spring.dependency-management" version "1.0.10.RELEASE"
+    }
+    resolutionStrategy {
+        eachPlugin {
+            // protects us in case the gradle-portal-plugin hasn't yet been published by Maven
+            if (requested.id.id == 'org.springframework.cloud.contract') {
+                useModule("org.springframework.cloud:spring-cloud-contract-gradle-plugin:${verifierVersion}")
+            }
+        }
+    }
+}
+
+rootProject.name = 'http-server-restdocs-gradle'

--- a/samples/standalone/restdocs/http-server/src/test/java/com/example/fraud/StubGeneratorTests.java
+++ b/samples/standalone/restdocs/http-server/src/test/java/com/example/fraud/StubGeneratorTests.java
@@ -40,7 +40,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @SpringBootTest(classes = Application.class)
-@AutoConfigureRestDocs
+@AutoConfigureRestDocs(outputDir = "target/snippets")
 @AutoConfigureMockMvc
 @AutoConfigureJsonTesters
 public class StubGeneratorTests {

--- a/samples/standalone/webclient/http-client/build.gradle
+++ b/samples/standalone/webclient/http-client/build.gradle
@@ -1,14 +1,8 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-	}
+plugins {
+	id "groovy"
+	id "org.springframework.boot"
+	id "io.spring.dependency-management"
+	id "maven-publish"
 }
 
 group = 'com.example'
@@ -22,15 +16,10 @@ repositories {
 	maven { url "https://repo.spring.io/release" }
 }
 
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
-
 dependencyManagement {
 	imports {
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:$BOM_VERSION"
-		mavenBom "org.springframework.cloud:spring-cloud-contract-dependencies:${project.findProperty('verifierVersion') ?: verifierVersion}"
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${BOM_VERSION}"
+		mavenBom "org.springframework.cloud:spring-cloud-contract-dependencies:${verifierVersion}"
 	}
 }
 

--- a/samples/standalone/webclient/http-client/settings.gradle
+++ b/samples/standalone/webclient/http-client/settings.gradle
@@ -1,1 +1,14 @@
-rootProject.name = 'http-client-webclient'
+pluginManagement {
+    repositories {
+        mavenLocal()
+        maven { url "https://repo.spring.io/snapshot" }
+        maven { url "https://repo.spring.io/milestone" }
+        gradlePluginPortal()
+    }
+    plugins {
+        id 'org.springframework.boot' version "${bootVersion}"
+        id "io.spring.dependency-management" version "1.0.10.RELEASE"
+    }
+}
+
+rootProject.name = 'http-client-webclient-gradle'

--- a/samples/standalone/webclient/http-server/build.gradle
+++ b/samples/standalone/webclient/http-server/build.gradle
@@ -26,8 +26,8 @@ repositories {
 
 dependencyManagement {
 	imports {
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:$BOM_VERSION"
-		mavenBom "org.springframework.cloud:spring-cloud-contract-dependencies:${project.findProperty('verifierVersion') ?: verifierVersion}"
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${BOM_VERSION}"
+		mavenBom "org.springframework.cloud:spring-cloud-contract-dependencies:${verifierVersion}"
 	}
 }
 
@@ -45,6 +45,8 @@ dependencies {
 contracts {
 	failOnNoContracts = false
 }
+
+generateClientStubs.enabled = false
 
 test {
 	useJUnitPlatform()
@@ -66,10 +68,6 @@ task stubsJar(type: Jar, dependsOn: ['copySnippets', 'copySources', 'copyClasses
 	baseName = project.name
 	classifier = 'stubs'
 	from project.file("${project.buildDir}/stubs")
-}
-
-artifacts {
-	archives stubsJar
 }
 
 task copySnippets(type: Copy, dependsOn: test) {
@@ -110,7 +108,7 @@ publishing {
 
 clean.doFirst {
 	delete 'target/snippets/stubs'
-	delete "~/.m2/repository/com/example/http-server-restdocs-gradle"
+	delete "~/.m2/repository/com/example/http-server-webclient-gradle"
 }
 
 task resolveDependencies {

--- a/samples/standalone/webclient/http-server/pom.xml
+++ b/samples/standalone/webclient/http-server/pom.xml
@@ -196,8 +196,7 @@
 									<arguments>
 										<argument>clean</argument>
 										<argument>build</argument>
-										<!-- For some reason publishToMavenLocal doesn't work... Please don't troll Gradle ;)-->
-										<argument>install</argument>
+										<argument>publishToMavenLocal</argument>
 										<argument>
 											-PverifierVersion=${spring-cloud-contract.version}
 										</argument>

--- a/samples/standalone/webclient/http-server/settings.gradle
+++ b/samples/standalone/webclient/http-server/settings.gradle
@@ -1,26 +1,22 @@
 pluginManagement {
-	plugins {
-		id 'org.springframework.boot'
-		id "org.springframework.cloud.contract" version "${verifierVersion}"
-		id "io.spring.dependency-management" version "1.0.8.RELEASE"
-	}
 	repositories {
-		// to pick from local .m2
 		mavenLocal()
-		// for snapshots
-		maven { url "https://repo.spring.io/libs-snapshot-local" }
-		// for milestones
-		maven { url "https://repo.spring.io/libs-milestone-local" }
-		// for GA versions
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
 		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version "${bootVersion}"
+		id "io.spring.dependency-management" version "1.0.10.RELEASE"
 	}
 	resolutionStrategy {
 		eachPlugin {
-			if (requested.id.id == 'org.springframework.boot') {
-				useModule("org.springframework.boot:spring-boot-gradle-plugin:${bootVersion}")
+			// protects us in case the gradle-portal-plugin hasn't yet been published by Maven
+			if (requested.id.id == 'org.springframework.cloud.contract') {
+				useModule("org.springframework.cloud:spring-cloud-contract-gradle-plugin:${verifierVersion}")
 			}
 		}
 	}
 }
-rootProject.name = 'http-server-webclient'
 
+rootProject.name = 'http-server-webclient-gradle'

--- a/scripts/gradleOnly.sh
+++ b/scripts/gradleOnly.sh
@@ -7,5 +7,5 @@ FOLDER=`pwd`
 set -e
 
 cd "${FOLDER}/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin"
-  ./gradlew clean build install
+  ./gradlew clean build publishToMavenLocal
 cd "${FOLDER}"

--- a/spring-cloud-contract-tools/spring-cloud-contract-converters/src/main/java/org/springframework/cloud/contract/verifier/converter/RecursiveFilesConverterApplication.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-converters/src/main/java/org/springframework/cloud/contract/verifier/converter/RecursiveFilesConverterApplication.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.contract.verifier.converter;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.util.StringUtils;
+
+public final class RecursiveFilesConverterApplication {
+
+	private RecursiveFilesConverterApplication() {
+	}
+
+	public static void main(String[] args) {
+		if (args.length != 5) {
+			throw new RuntimeException("Invalid number of arguments");
+		}
+
+		File stubsOutputDir = new File(args[0]);
+		File contractsDslDir = new File(args[1]);
+		List<String> excludedFiles = Arrays.asList(StringUtils.commaDelimitedListToStringArray(args[2]));
+		String includedContracts = args[3];
+		boolean excludeBuildFolders = Boolean.parseBoolean(args[4]);
+
+		RecursiveFilesConverter converter = new RecursiveFilesConverter(stubsOutputDir, contractsDslDir, excludedFiles,
+				includedContracts, excludeBuildFolders);
+		converter.processFiles();
+	}
+
+}

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/build.gradle
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/build.gradle
@@ -62,17 +62,21 @@ configurations {
 
 dependencies {
 	compileOnly gradleApi()
-	implementation "org.eclipse.aether:aether-api:${aetherVersion}"
 
-	implementation("org.springframework.cloud:spring-cloud-contract-converters:${project.version}") {
-		exclude(group: 'org.codehaus.groovy')
+	// provide version alignment with project
+	implementation(platform("org.springframework.cloud:spring-cloud-contract-tools:${project.version}"))
+
+	implementation "org.eclipse.jgit:org.eclipse.jgit"
+	implementation "com.fasterxml.jackson.core:jackson-databind"
+
+	implementation "org.springframework:spring-core"
+	api("org.springframework.cloud:spring-cloud-contract-stub-runner") {
+		exclude(group: '*')
 	}
-	api("org.springframework.cloud:spring-cloud-contract-stub-runner:${project.version}") {
-		exclude(group: 'org.codehaus.groovy')
+	api("org.springframework.cloud:spring-cloud-contract-verifier") {
+		exclude(group: '*')
 	}
-	api("org.springframework.cloud:spring-cloud-starter-contract-verifier:${project.version}") {
-		exclude(group: 'org.codehaus.groovy')
-	}
+
 	testImplementation('org.spockframework:spock-core:1.3-groovy-2.5') {
 		exclude(group: 'org.codehaus.groovy')
 	}
@@ -113,6 +117,12 @@ jacocoTestReport {
 		xml.enabled true
 	}
 }*/
+
+jar {
+	manifest {
+		attributes 'Implementation-Version': version
+	}
+}
 
 task resolveDependencies {
 	doLast {

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/build.gradle
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/build.gradle
@@ -66,10 +66,13 @@ dependencies {
 	// provide version alignment with project
 	implementation(platform("org.springframework.cloud:spring-cloud-contract-tools:${project.version}"))
 
+	implementation "org.apache.maven.resolver:maven-resolver-api"
 	implementation "org.eclipse.jgit:org.eclipse.jgit"
+	implementation "com.jcraft:jsch.agentproxy.jsch"
 	implementation "com.fasterxml.jackson.core:jackson-databind"
 
 	implementation "org.springframework:spring-core"
+	implementation("org.springframework.cloud:spring-cloud-contract-shade")
 	api("org.springframework.cloud:spring-cloud-contract-stub-runner") {
 		exclude(group: '*')
 	}

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/build.gradle
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/build.gradle
@@ -120,7 +120,7 @@ jacocoTestReport {
 
 jar {
 	manifest {
-		attributes 'Implementation-Version': version
+		attributes 'Implementation-Version': project.version
 	}
 }
 

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/gradle/release.gradle
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/gradle/release.gradle
@@ -55,6 +55,7 @@ publishing {
 	}
 	publications {
 		pluginMaven(MavenPublication) {
+			artifact groovydocJar
 			pom {
 				name = project.name
 				packaging = 'jar'

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/gradle/release.gradle
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/gradle/release.gradle
@@ -13,6 +13,8 @@ task groovydocJar(type: Jar, dependsOn: groovydoc) {
 	from groovydoc.destinationDir
 }
 
+assemble.dependsOn(groovydocJar)
+
 ext {
 	resolveRepoName = { Project project ->
 		resolvedRepoName = "libs-${resolveVersion(project.version)}-local"

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/gradle/release.gradle
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/gradle/release.gradle
@@ -1,27 +1,16 @@
-apply plugin: 'maven'
-//apply plugin: 'signing'
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
-uploadArchives.dependsOn { [check] }
+publish.dependsOn(check)
 
-task sourcesJar(type: Jar) {
-	classifier 'sources'
-	from sourceSets.main.allSource
+java {
+	withSourcesJar()
+	withJavadocJar()
 }
 
 task groovydocJar(type: Jar, dependsOn: groovydoc) {
 	classifier 'groovydoc'
 	from groovydoc.destinationDir
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-	classifier 'javadoc'
-	from javadoc.destinationDir
-}
-
-artifacts {
-	archives sourcesJar
-	archives groovydocJar
-	archives javadocJar
 }
 
 ext {
@@ -50,12 +39,68 @@ ext {
 	repoUrl = isReleaseToCentral ?
 			"https://oss.sonatype.org/service/local/staging/deploy/maven2/" :
 			"https://repo.spring.io/${resolveRepoName(project)}"
+	repoUserName = isReleaseToCentral ? getProp("SONATYPE_USER") : repoUser
+	repoPass = isReleaseToCentral ? getProp("SONATYPE_PASSWORD") : repoPass
+}
+
+publishing {
+	repositories {
+		maven {
+			url = repoUrl
+			credentials {
+				username = repoUserName
+				password = repoPass
+			}
+		}
+	}
+	publications {
+		pluginMaven(MavenPublication) {
+			pom {
+				name = project.name
+				packaging = 'jar'
+				description = 'Spring Cloud Contract Gradle Plugin'
+				url = 'https://github.com/spring-cloud/spring-cloud-contract'
+				inceptionYear = '2014'
+
+				scm {
+					connection = 'scm:git:git@github.com:spring-cloud/spring-cloud-contract.git'
+					developerConnection = 'scm:git:git@github.com:spring-cloud/spring-cloud-contract.git'
+					url = 'https://github.com/spring-cloud/spring-cloud-contract'
+				}
+
+				licenses {
+					license {
+						name = 'The Apache License, Version 2.0'
+						url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+					}
+				}
+
+				developers {
+					developer {
+						id = 'jkubrynski'
+						name = 'Jakub Kubrynski'
+						email = 'jk ATT codearte DOTT io'
+					}
+					developer {
+						id = 'marcingrzejszczak'
+						name = 'Marcin Grzejszczak'
+						email = 'mgrzejszczak ATT pivotal DOTT io'
+					}
+					developer {
+						id = 'dsyer'
+						name = 'Dave Syer'
+						email = 'dsyer ATT pivotal DOTT io'
+					}
+				}
+			}
+		}
+	}
 }
 
 if (isReleaseToCentral) {
-	/*signing {
-		sign configurations.archives
-	}*/
+	signing {
+		sign publishing.publications.maven
+	}
 
 	apply plugin: 'com.gradle.plugin-publish'
 
@@ -79,65 +124,6 @@ if (isReleaseToCentral) {
 	}
 }
 
-afterEvaluate {
-	uploadArchives {
-		repositories {
-			mavenDeployer {
-				// POM signature
-				if (isReleaseVersion && isReleaseToCentral) {
-					beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-				}
-				// Target repository
-				String repoUserName = isReleaseToCentral ? getProp("SONATYPE_USER") : repoUser
-				String repoPass = isReleaseToCentral ? getProp("SONATYPE_PASSWORD") : repoPass
-				repository(url: repoUrl) {
-					authentication(userName: repoUserName, password: repoPass)
-				}
-				pom.project {
-					name "$project.name"
-					packaging 'jar'
-					description 'Spring Cloud Contract Gradle Plugin'
-					url 'https://github.com/spring-cloud/spring-cloud-contract'
-					inceptionYear '2014'
-
-					scm {
-						connection 'scm:git:git@github.com:spring-cloud/spring-cloud-contract.git'
-						developerConnection 'scm:git:git@github.com:spring-cloud/spring-cloud-contract.git'
-						url 'https://github.com/spring-cloud/spring-cloud-contract'
-					}
-
-					licenses {
-						license {
-							name 'The Apache License, Version 2.0'
-							url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
-						}
-					}
-
-					developers {
-						developer {
-							id 'jkubrynski'
-							name 'Jakub Kubrynski'
-							email 'jk ATT codearte DOTT io'
-						}
-						developer {
-							id 'marcingrzejszczak'
-							name 'Marcin Grzejszczak'
-							email 'mgrzejszczak ATT pivotal DOTT io'
-						}
-						developer {
-							id 'dsyer'
-							name 'Dave Syer'
-							email 'dsyer ATT pivotal DOTT io'
-						}
-					}
-				}
-			}
-		}
-	}
-}
-
 String getProp(String propName) {
-	return hasProperty(propName) ?
-			(getProperty(propName) ?: System.properties[propName]) : System.properties[propName] ?:
-			System.getenv(propName)
+	return (findProperty(propName) ?: System.properties[propName]) ?: System.getenv(propName)
 }

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/pom.xml
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/pom.xml
@@ -29,14 +29,32 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-contract-verifier</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>*</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-contract-converters</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>*</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-contract-stub-runner</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>*</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/pom.xml
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/pom.xml
@@ -56,8 +56,20 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-contract-shade</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven.resolver</groupId>
+			<artifactId>maven-resolver-api</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.jcraft</groupId>
+			<artifactId>jsch.agentproxy.jsch</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/pom.xml
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/pom.xml
@@ -25,7 +25,6 @@
 	</properties>
 
 	<dependencies>
-
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-contract-verifier</artifactId>
@@ -55,6 +54,18 @@
 					<artifactId>*</artifactId>
 				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jgit</groupId>
+			<artifactId>org.eclipse.jgit</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-core</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/ContractsCopyTask.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/ContractsCopyTask.java
@@ -529,8 +529,12 @@ class ContractsCopyTask extends DefaultTask {
 		return null;
 	}
 
+	// See: https://github.com/gradle/gradle/issues/6072
 	private String quoteAndEscape(String str) {
-		return "\"" + str.replace("\"", "\\\"") + "\"";
+		if (System.getProperty("os.name").contains("Windows")) {
+			return "\"" + str.replace("\"", "\\\"") + "\"";
+		}
+		return str;
 	}
 
 }

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/ContractsCopyTask.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/ContractsCopyTask.java
@@ -16,7 +16,9 @@
 
 package org.springframework.cloud.contract.verifier.plugin;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.OutputStream;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
@@ -178,13 +180,22 @@ class ContractsCopyTask extends DefaultTask {
 	private void convertContractsToYaml(File file, String antPattern, String slashSeparatedAntPattern,
 			File outputContractsFolder, boolean excludeBuildFolders) {
 		sync(file, antPattern, slashSeparatedAntPattern, excludeBuildFolders, backupContractsFolder.get().getAsFile());
+		OutputStream os;
+		if (getLogger().isDebugEnabled()) {
+			os = new ByteArrayOutputStream();
+		} else {
+			os = NullOutputStream.INSTANCE;
+		}
 		getProject().javaexec(exec -> {
 			exec.getMainClass().convention("org.springframework.cloud.contract.verifier.converter.ToYamlConverterApplication");
 			exec.classpath(classpath);
 			exec.args(quoteAndEscape(outputContractsFolder.getAbsolutePath()));
-			exec.setStandardOutput(NullOutputStream.INSTANCE);
-			exec.setErrorOutput(NullOutputStream.INSTANCE);
+			exec.setStandardOutput(os);
+			exec.setErrorOutput(os);
 		});
+		if (getLogger().isDebugEnabled()) {
+			getLogger().debug(os.toString());
+		}
 		getLogger().info("Replaced DSL files with their YAML representation at [{}]", outputContractsFolder);
 	}
 

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/ContractsCopyTask.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/ContractsCopyTask.java
@@ -187,7 +187,7 @@ class ContractsCopyTask extends DefaultTask {
 			os = NullOutputStream.INSTANCE;
 		}
 		getProject().javaexec(exec -> {
-			exec.getMainClass().convention("org.springframework.cloud.contract.verifier.converter.ToYamlConverterApplication");
+			exec.setMain("org.springframework.cloud.contract.verifier.converter.ToYamlConverterApplication");
 			exec.classpath(classpath);
 			exec.args(quoteAndEscape(outputContractsFolder.getAbsolutePath()));
 			exec.setStandardOutput(os);

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/GenerateClientStubsFromDslTask.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/GenerateClientStubsFromDslTask.java
@@ -128,8 +128,12 @@ class GenerateClientStubsFromDslTask extends DefaultTask {
 		return stubsOutputDir;
 	}
 
+	// See: https://github.com/gradle/gradle/issues/6072
 	private String quoteAndEscape(String str) {
-		return "\"" + str.replace("\"", "\\\"") + "\"";
+		if (System.getProperty("os.name").contains("Windows")) {
+			return "\"" + str.replace("\"", "\\\"") + "\"";
+		}
+		return str;
 	}
 
 }

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/GenerateServerTestsTask.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/GenerateServerTestsTask.java
@@ -281,8 +281,12 @@ class GenerateServerTestsTask extends DefaultTask {
 		return properties;
 	}
 
+	// See: https://github.com/gradle/gradle/issues/6072
 	private String quoteAndEscape(String str) {
-		return "\"" + str.replace("\"", "\\\"") + "\"";
+		if (System.getProperty("os.name").contains("Windows")) {
+			return "\"" + str.replace("\"", "\\\"") + "\"";
+		}
+		return str;
 	}
 
 }

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/GenerateServerTestsTask.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/GenerateServerTestsTask.java
@@ -16,14 +16,18 @@
 
 package org.springframework.cloud.contract.verifier.plugin;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.jgit.util.io.NullOutputStream;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.Optional;
@@ -32,8 +36,6 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
-import org.springframework.cloud.contract.spec.ContractVerifierException;
-import org.springframework.cloud.contract.verifier.TestGenerator;
 import org.springframework.cloud.contract.verifier.config.ContractVerifierConfigProperties;
 import org.springframework.cloud.contract.verifier.config.TestFramework;
 import org.springframework.cloud.contract.verifier.config.TestMode;
@@ -85,6 +87,8 @@ class GenerateServerTestsTask extends DefaultTask {
 
 	private final Property<Boolean> failOnInProgress;
 
+	private final ConfigurableFileCollection classpath;
+
 	private final DirectoryProperty generatedTestSourcesDir;
 
 	private final DirectoryProperty generatedTestResourcesDir;
@@ -106,6 +110,7 @@ class GenerateServerTestsTask extends DefaultTask {
 		this.baseClassMappings = objects.mapProperty(String.class, String.class);
 		this.assertJsonSize = objects.property(Boolean.class);
 		this.failOnInProgress = objects.property(Boolean.class);
+		this.classpath = objects.fileCollection();
 		this.generatedTestSourcesDir = objects.directoryProperty();
 		this.generatedTestResourcesDir = objects.directoryProperty();
 	}
@@ -121,13 +126,18 @@ class GenerateServerTestsTask extends DefaultTask {
 		getLogger().info("Spring Cloud Contract Verifier Plugin: Invoking test sources generation");
 		getLogger().info("Contracts are unpacked to [{}]", contractsDslDir);
 		getLogger().info("Included contracts are [{}]", includedContracts);
+		ContractVerifierConfigProperties properties = toConfigProperties(contractsDslDir, includedContracts, generatedTestSources, generatedTestResources);
 		try {
-			TestGenerator generator = new TestGenerator(toConfigProperties(contractsDslDir, includedContracts,
-					generatedTestSources, generatedTestResources));
-			int generatedClasses = generator.generate();
-			getLogger().info("Generated {} test classes", generatedClasses);
+			String propertiesJson = new ObjectMapper().writeValueAsString(properties);
+			getProject().javaexec(exec -> {
+				exec.getMainClass().convention("org.springframework.cloud.contract.verifier.TestGeneratorApplication");
+				exec.classpath(classpath);
+				exec.args(quoteAndEscape(propertiesJson));
+				exec.setStandardOutput(NullOutputStream.INSTANCE);
+				exec.setErrorOutput(NullOutputStream.INSTANCE);
+			});
 		}
-		catch (ContractVerifierException e) {
+		catch (Exception e) {
 			throw new GradleException("Spring Cloud Contract Verifier Plugin exception: " + e.getMessage(), e);
 		}
 	}
@@ -213,6 +223,11 @@ class GenerateServerTestsTask extends DefaultTask {
 		return failOnInProgress;
 	}
 
+	@Classpath
+	ConfigurableFileCollection getClasspath() {
+		return classpath;
+	}
+
 	@OutputDirectory
 	DirectoryProperty getGeneratedTestSourcesDir() {
 		return generatedTestSourcesDir;
@@ -251,6 +266,10 @@ class GenerateServerTestsTask extends DefaultTask {
 		properties.setAssertJsonSize(assertJsonSize.get());
 		properties.setFailOnInProgress(failOnInProgress.get());
 		return properties;
+	}
+
+	private String quoteAndEscape(String str) {
+		return "\"" + str.replace("\"", "\\\"") + "\"";
 	}
 
 }

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/SpringCloudContractVerifierGradlePlugin.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/SpringCloudContractVerifierGradlePlugin.java
@@ -232,12 +232,20 @@ public class SpringCloudContractVerifierGradlePlugin implements Plugin<Project> 
 
 			generateServerTestsTask.dependsOn(copyContracts);
 		});
-		project.getTasks().named(contractTestSourceSet.getCompileJavaTaskName(), compileContractTestJava -> {
-			compileContractTestJava.dependsOn(task);
-		});
+		project.getTasks().named(contractTestSourceSet.getCompileJavaTaskName(), compileContractTestJava -> compileContractTestJava.dependsOn(task));
 		project.getPlugins().withType(GroovyPlugin.class, groovyPlugin -> {
 			project.getTasks().named(contractTestSourceSet.getCompileTaskName("groovy"), compileContractTestGroovy -> {
 				compileContractTestGroovy.dependsOn(task);
+			});
+		});
+		project.getPlugins().withId("kotlin", kotlinPlugin -> {
+			project.getTasks().named(contractTestSourceSet.getCompileTaskName("kotlin"), compileContractTestKotlin -> {
+				compileContractTestKotlin.dependsOn(task);
+			});
+		});
+		project.getPlugins().withId("org.jetbrains.kotlin.jvm", kotlinJvmPlugin -> {
+			project.getTasks().named(contractTestSourceSet.getCompileTaskName("kotlin"), compileContractTestKotlin -> {
+				compileContractTestKotlin.dependsOn(task);
 			});
 		});
 	}

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/VersionExtractor.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/VersionExtractor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.contract.verifier.plugin;
 
 import java.io.File;

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/VersionExtractor.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/VersionExtractor.java
@@ -1,0 +1,38 @@
+package org.springframework.cloud.contract.verifier.plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.JarURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+
+final class VersionExtractor {
+	private VersionExtractor() {
+	}
+
+	static String forClass(Class<?> cls) {
+		String implementationVersion = cls.getPackage().getImplementationVersion();
+		if (implementationVersion != null) {
+			return implementationVersion;
+		}
+		URL codeSourceLocation = cls.getProtectionDomain().getCodeSource().getLocation();
+		try {
+			URLConnection connection = codeSourceLocation.openConnection();
+			if (connection instanceof JarURLConnection) {
+				return getImplementationVersion(((JarURLConnection) connection).getJarFile());
+			}
+			try (JarFile jarFile = new JarFile(new File(codeSourceLocation.toURI()))) {
+				return getImplementationVersion(jarFile);
+			}
+		}
+		catch (Exception e) {
+			return null;
+		}
+	}
+
+	private static String getImplementationVersion(JarFile jarFile) throws IOException {
+		return jarFile.getManifest().getMainAttributes().getValue(Attributes.Name.IMPLEMENTATION_VERSION);
+	}
+}

--- a/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/TestGeneratorApplication.java
+++ b/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/TestGeneratorApplication.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.contract.verifier;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.cloud.contract.verifier.config.ContractVerifierConfigProperties;
+
+public final class TestGeneratorApplication {
+
+	private TestGeneratorApplication() {
+	}
+
+	public static void main(String[] args) throws JsonProcessingException {
+		if (args.length != 1) {
+			throw new RuntimeException("Invalid number of arguments");
+		}
+
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		ContractVerifierConfigProperties configProperties = objectMapper.readValue(args[0],
+				ContractVerifierConfigProperties.class);
+
+		TestGenerator generator = new TestGenerator(configProperties);
+		generator.generate();
+	}
+
+}

--- a/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/converter/ToYamlConverterApplication.java
+++ b/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/converter/ToYamlConverterApplication.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.contract.verifier.converter;
+
+import java.io.File;
+
+public final class ToYamlConverterApplication {
+
+	private ToYamlConverterApplication() {
+	}
+
+	public static void main(String[] args) {
+		if (args.length != 1) {
+			throw new RuntimeException("Invalid number of arguments");
+		}
+
+		File copiedContractsFolder = new File(args[0]);
+
+		ToYamlConverter.replaceContractWithYaml(copiedContractsFolder);
+	}
+
+}


### PR DESCRIPTION
This addresses the broken Kotlin support by keeping all things sc-contract in a totally isolated classloader (via process forking). This is the same pattern employed by the Kotlin plugin when attempting to perform Kotlin compilation (albeit much easier in our case).