### PR TITLE
Allows @AutoConfigureWireMock to respect user-specified properties 

### DIFF
--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/AutoConfigureWireMock.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/AutoConfigureWireMock.java
@@ -24,6 +24,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.springframework.boot.test.autoconfigure.properties.PropertyMapping;
+import org.springframework.boot.test.autoconfigure.properties.SkipPropertyMapping;
 import org.springframework.context.annotation.Import;
 
 /**
@@ -40,7 +41,7 @@ import org.springframework.context.annotation.Import;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Import(WireMockConfiguration.class)
-@PropertyMapping("wiremock.server")
+@PropertyMapping(value = "wiremock.server", skip = SkipPropertyMapping.ON_DEFAULT_VALUE)
 @AutoConfigureHttpClient
 @Inherited
 public @interface AutoConfigureWireMock {

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/AutoConfigureWireMockConfigurationInYamlTests.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/AutoConfigureWireMockConfigurationInYamlTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.contract.wiremock;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = WiremockTestsApplication.class,
+		properties = "app.baseUrl=http://localhost:${wiremock.server.port}",
+		webEnvironment = WebEnvironment.NONE)
+@AutoConfigureWireMock
+@ActiveProfiles("customfoo")
+public class AutoConfigureWireMockConfigurationInYamlTests {
+
+	@Autowired
+	private Service service;
+
+	@Autowired
+	private WireMockProperties wireMockProperties;
+
+	@Test
+	public void contextLoadsWithWiremockConfigFromYaml() {
+		assertThat(this.service.go())
+				.isEqualToIgnoringWhitespace("{\"message\":\"Hello Custom One\"}");
+		assertThat(this.wireMockProperties.getServer().isPortDynamic()).isTrue();
+	}
+
+}

--- a/spring-cloud-contract-wiremock/src/test/resources/application-customfoo.yml
+++ b/spring-cloud-contract-wiremock/src/test/resources/application-customfoo.yml
@@ -1,0 +1,7 @@
+wiremock:
+  server:
+    port: 0
+    stubs:
+      - "file:src/test/resources/custom-from-yml/mappings"
+    files:
+      - "file:src/test/resources/custom-from-yml"

--- a/spring-cloud-contract-wiremock/src/test/resources/custom-from-yml/__files/hello-custom.json
+++ b/spring-cloud-contract-wiremock/src/test/resources/custom-from-yml/__files/hello-custom.json
@@ -1,0 +1,3 @@
+{
+  "message": "Hello Custom One"
+}

--- a/spring-cloud-contract-wiremock/src/test/resources/custom-from-yml/mappings/custom-test-endpoint.json
+++ b/spring-cloud-contract-wiremock/src/test/resources/custom-from-yml/mappings/custom-test-endpoint.json
@@ -1,0 +1,11 @@
+{
+  "request": {
+    "urlPath": "/test",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "bodyFileName": "hello-custom.json"
+  }
+}
+


### PR DESCRIPTION
Allows @AutoConfigureWireMock to respect user-specified properties in application.yml

Fixes gh-1555