### PR TITLE
Removes the exclusions of old asm lib from jsonpath lib.

### DIFF
--- a/spring-cloud-contract-dependencies/pom.xml
+++ b/spring-cloud-contract-dependencies/pom.xml
@@ -110,12 +110,6 @@
 				<groupId>com.toomuchcoding.jsonassert</groupId>
 				<artifactId>jsonassert</artifactId>
 				<version>${jsonassert.version}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>org.ow2.asm</groupId>
-						<artifactId>asm</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 			<!-- This has shadowed deps -->
 			<dependency>

--- a/spring-cloud-contract-starters/spring-cloud-starter-contract-verifier/pom.xml
+++ b/spring-cloud-contract-starters/spring-cloud-starter-contract-verifier/pom.xml
@@ -41,12 +41,6 @@
 		<dependency>
 			<groupId>com.toomuchcoding.jsonassert</groupId>
 			<artifactId>jsonassert</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>org.ow2.asm</groupId>
-					<artifactId>asm</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>cglib</groupId>

--- a/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/test/projects/complex-configuration/pom.xml
+++ b/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/test/projects/complex-configuration/pom.xml
@@ -66,12 +66,6 @@
 			<artifactId>jsonassert</artifactId>
 			<version>0.5.0</version>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.ow2.asm</groupId>
-					<artifactId>asm</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/test/projects/different-module-configuration/module/pom.xml
+++ b/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/test/projects/different-module-configuration/module/pom.xml
@@ -65,12 +65,6 @@
 			<artifactId>jsonassert</artifactId>
 			<version>0.5.0</version>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.ow2.asm</groupId>
-					<artifactId>asm</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/spring-cloud-contract-verifier/pom.xml
+++ b/spring-cloud-contract-verifier/pom.xml
@@ -109,12 +109,6 @@
 		<dependency>
 			<groupId>com.toomuchcoding.jsonassert</groupId>
 			<artifactId>jsonassert</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>org.ow2.asm</groupId>
-					<artifactId>asm</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.resolver</groupId>


### PR DESCRIPTION
The exclusions were added in gh-1568 in an effort to get rid of the old asm lib that jsonpath brings with it. However, it turns out the issue is bigger than that. Spring Cloud Contract has a direct dependency on `cglib:3.2.9` which in turn brings in a more recent `asm:7.x`. So even before the exclusions, the old `asm` lib was being cancelled out in favor of the new `asm` lib. I originally thought that the more recent asm was being brought in by `spring-core` but it actually shades `cglib` and `asm`. 

While the changes made in gh-1568 were probably harmless - they were not really providing any benefit. Let's remove the changes and revisit later and see if we can remove the direct dependence on cglib at that time as well. 

Reverts gh-1568