### PR TITLE
Add javadoc for AutoConfigureWireMock

### DIFF
--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/AutoConfigureWireMock.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/AutoConfigureWireMock.java
@@ -46,12 +46,50 @@ import org.springframework.context.annotation.Import;
 @Inherited
 public @interface AutoConfigureWireMock {
 
+	/**
+	 * Configures WireMock instance to listen on specified port.
+	 * <p>
+	 * Set this value to 0 for WireMock to listen to a random port.
+	 * </p>
+	 * @return port to which WireMock instance should listen to
+	 */
 	int port() default 8080;
 
+	/**
+	 * If specified, configures WireMock instance to enable <em>HTTPS</em> on specified
+	 * port.
+	 * <p>
+	 * Set this value to 0 for WireMock to listen to a random port.
+	 * </p>
+	 * @return port to which WireMock instance should listen to
+	 */
 	int httpsPort() default -1;
 
+	/**
+	 * The resource locations to use for loading WireMock mappings.
+	 * <p>
+	 * When none specified, <em>src/test/resources/mappings</em> is used as default
+	 * location.
+	 * </p>
+	 * <p>
+	 * To customize the location, this attribute must be set to the directory where
+	 * mappings are stored.
+	 * </p>
+	 * @return locations to read WireMock mappings from
+	 */
 	String[] stubs() default { "" };
 
+	/**
+	 * The resource locations to use for loading WireMock response bodies.
+	 * <p>
+	 * When none specified, <em>src/test/resources/__files</em> is used as default.
+	 * </p>
+	 * <p>
+	 * To customize the location, this attribute must be set to the parent directory of
+	 * <strong>__files</strong> directory.
+	 * </p>
+	 * @return locations to read WireMock response bodies from
+	 */
 	String[] files() default { "" };
 
 }


### PR DESCRIPTION
Having basic details added to javadoc makes it easy for other developers to find these details easily. Of course javadoc is in no way meant to be replacement for detailed documentation where this information is already available.

This PR is submitted in response to the discussion in thread #1583  