### PR TITLE
Adds support for Kafka message keys in contracts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,6 +19,7 @@ If you prefer to learn about the project by doing some tutorials, you can check 
 workshops under
 https://cloud-samples.spring.io/spring-cloud-contract-samples/workshops.html[this link].
 
+
 == Project page
 
 You can read more about Spring Cloud Contract by going to https://spring.io/projects/spring-cloud-contract[the project page]

--- a/docs/src/main/asciidoc/_project-features-messaging.adoc
+++ b/docs/src/main/asciidoc/_project-features-messaging.adoc
@@ -1301,6 +1301,3 @@ Since the route is set for you, you can send a message to the `{output_name}` de
 include::{tests_path}/spring-cloud-contract-stub-runner-kafka/src/test/groovy/org/springframework/cloud/contract/stubrunner/messaging/kafka/KafkaStubRunnerSpec.groovy[tags=trigger_no_output,indent=0]
 ----
 ====
-
-===== Kafka Record Key
-To

--- a/docs/src/main/asciidoc/_project-features-messaging.adoc
+++ b/docs/src/main/asciidoc/_project-features-messaging.adoc
@@ -1201,17 +1201,20 @@ spring:
   kafka:
     bootstrap-servers: ${spring.embedded.kafka.brokers}
     producer:
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       properties:
-        "value.serializer": "org.springframework.kafka.support.serializer.JsonSerializer"
         "spring.json.trusted.packages": "*"
     consumer:
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       properties:
-        "value.deserializer": "org.springframework.kafka.support.serializer.JsonDeserializer"
-        "value.serializer": "org.springframework.kafka.support.serializer.JsonSerializer"
         "spring.json.trusted.packages": "*"
       group-id: groupId
 ----
 ====
+
+NOTE: If your application uses non-integer record keys you will need to set the `spring.kafka.producer.key-serializer`
+and `spring.kafka.consumer.key-deserializer` properties accordingly because the Kafka de/serialization expects non-null
+record keys to be of integer type.
 
 Now consider the following contracts (we number them 1 and 2):
 
@@ -1298,3 +1301,6 @@ Since the route is set for you, you can send a message to the `{output_name}` de
 include::{tests_path}/spring-cloud-contract-stub-runner-kafka/src/test/groovy/org/springframework/cloud/contract/stubrunner/messaging/kafka/KafkaStubRunnerSpec.groovy[tags=trigger_no_output,indent=0]
 ----
 ====
+
+===== Kafka Record Key
+To

--- a/tests/spring-cloud-contract-stub-runner-kafka/src/test/resources/application.yml
+++ b/tests/spring-cloud-contract-stub-runner-kafka/src/test/resources/application.yml
@@ -6,13 +6,14 @@ spring:
   kafka:
     bootstrap-servers: ${spring.embedded.kafka.brokers}
     producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       properties:
-        "value.serializer": "org.springframework.kafka.support.serializer.JsonSerializer"
         "spring.json.trusted.packages": "*"
     consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       properties:
-        "value.deserializer": "org.springframework.kafka.support.serializer.JsonDeserializer"
-        "value.serializer": "org.springframework.kafka.support.serializer.JsonSerializer"
         "spring.json.trusted.packages": "*"
       group-id: ${random.value}
 server:

--- a/tests/spring-cloud-contract-stub-runner-kafka/src/test/resources/stubs/bookReturned3.groovy
+++ b/tests/spring-cloud-contract-stub-runner-kafka/src/test/resources/stubs/bookReturned3.groovy
@@ -1,0 +1,22 @@
+org.springframework.cloud.contract.spec.Contract.make {
+	label 'return_book_3'
+	input {
+		messageFrom('input2')
+		messageBody([
+				bookName: 'bar'
+		])
+		messageHeaders {
+			header('kafka_receivedMessageKey', 'bar5150')
+		}
+	}
+	outputMessage {
+		sentTo('output')
+		body([
+				bookName: 'bar'
+		])
+		headers {
+			header('BOOK-NAME', 'bar')
+			header('kafka_messageKey', 'bar5150')
+		}
+	}
+}


### PR DESCRIPTION
Allows Kafka message keys to be used in messaging contract.

Fixes gh-1267

@marcingrzejszczak 

1. I struggled to find the proper place to add tests for this - please advise. I have been verifying it manually in the [producer_kafka](https://github.com/spring-cloud-samples/spring-cloud-contract-samples/tree/master/producer_kafka) and [consumer_kafka](https://github.com/spring-cloud-samples/spring-cloud-contract-samples/tree/master/consumer_kafka) sample projects. The sort of tests that are valuable here are integration tests (similar to what I am doing manually in the sample projects).

2. I would also like to add some docs around the configuration nuances of the key/value serdes. I will look for a good location to add this info in the current docs shortly. 

3. What is the process of the sample projects? Do we keep those in sync w/ changes here (I would assume so). It may be helpful to add/augment the samples to include some of this capability.

Thanks.
