### PR TITLE
Adds support for unqualified namespaced XML content

### DIFF
--- a/docs/src/main/asciidoc/_project-features-contract.adoc
+++ b/docs/src/main/asciidoc/_project-features-contract.adoc
@@ -1854,8 +1854,9 @@ Consider the following explicitly namespaced XML document:
     <email>customer@test.com</email>
 </ns1:customer>
 ----
-The XPath expression to select the email address is: `/ns1:customer/email/text()`. Beware as the unqualified expression
-(`/customer/email/text()`) results in `""`.
+The XPath expression to select the email address is: `/ns1:customer/email/text()`.
+
+WARNING: Beware as the unqualified expression (`/customer/email/text()`) results in `""`.
 
 For content that uses an unqualified namespace, the expression is more verbose. Consider the following XML document that
 uses an unqualified namespace:
@@ -1870,7 +1871,7 @@ The XPath expression to select the email address is
 ```
 */[local-name()='customer' and namespace-uri()='http://demo.com/customer']/*[local-name()='email']/text()
 ```
-Beware, as the unqualified expressions (`/customer/email/text()` or `*/[local-name()='customer' and namespace-uri()='http://demo.com/customer']/email/text()`)
+WARNING: Beware, as the unqualified expressions (`/customer/email/text()` or `*/[local-name()='customer' and namespace-uri()='http://demo.com/customer']/email/text()`)
 result in `""`. Even the child elements have to be referenced with the `local-name` syntax.
 
 ====== General Namespaced Node Expression Syntax

--- a/docs/src/main/asciidoc/_project-features-contract.adoc
+++ b/docs/src/main/asciidoc/_project-features-contract.adoc
@@ -1843,8 +1843,8 @@ public void validate_xmlMatches() throws Exception {
 ----
 ====
 
-==== XML Support for namespaces
-Namespaced XML is supported. However, any XPath expresssions used to select namespaced content must be updated slightly.
+==== XML Support for Namespaces
+Namespaced XML is supported. However, any XPath expresssions used to select namespaced content must be updated.
 
 Consider the following explicitly namespaced XML document:
 
@@ -1854,10 +1854,10 @@ Consider the following explicitly namespaced XML document:
     <email>customer@test.com</email>
 </ns1:customer>
 ----
-The XPath expression to select the email address is `/ns1:customer/email/text()`. Beware as the unqualified expression
-`/customer/email/text()` results in `""`.
+The XPath expression to select the email address is: `/ns1:customer/email/text()`. Beware as the unqualified expression
+(`/customer/email/text()`) results in `""`.
 
-For content that uses an unqualfied namespace the expression is more verbose. Consider the following XML document that
+For content that uses an unqualified namespace, the expression is more verbose. Consider the following XML document that
 uses an unqualified namespace:
 
 [source,xml,indent=0]
@@ -1870,10 +1870,10 @@ The XPath expression to select the email address is
 ```
 */[local-name()='customer' and namespace-uri()='http://demo.com/customer']/*[local-name()='email']/text()
 ```
-Beware as the unqualified expressions `/customer/email/text()` or `*/[local-name()='customer' and namespace-uri()='http://demo.com/customer']/email/text()`
+Beware, as the unqualified expressions (`/customer/email/text()` or `*/[local-name()='customer' and namespace-uri()='http://demo.com/customer']/email/text()`)
 result in `""`. Even the child elements have to be referenced with the `local-name` syntax.
 
-====== General namespaced node expression syntax
+====== General Namespaced Node Expression Syntax
 - Node using qualified namespace:
 ```
 /<node-name>
@@ -1882,7 +1882,7 @@ result in `""`. Even the child elements have to be referenced with the `local-na
 ```
 /*[local-name=()='<node-name>' and namespace-uri=()='<namespace-uri>']
 ```
-NOTE: In some case the `namespace_uri` portion can be omitted but may lead to ambiguity.
+NOTE: In some cases, you can omit the `namespace_uri` portion, but doing so may lead to ambiguity.
 
 - Node using an unqualified namespace (one of its ancestor's defines the xmlns attribute):
 ```

--- a/docs/src/main/asciidoc/_project-features-contract.adoc
+++ b/docs/src/main/asciidoc/_project-features-contract.adoc
@@ -1843,6 +1843,53 @@ public void validate_xmlMatches() throws Exception {
 ----
 ====
 
+==== XML Support for namespaces
+Namespaced XML is supported. However, any XPath expresssions used to select namespaced content must be updated slightly.
+
+Consider the following explicitly namespaced XML document:
+
+[source,xml,indent=0]
+----
+<ns1:customer xmlns:ns1="http://demo.com/customer">
+    <email>customer@test.com</email>
+</ns1:customer>
+----
+The XPath expression to select the email address is `/ns1:customer/email/text()`. Beware as the unqualified expression
+`/customer/email/text()` results in `""`.
+
+For content that uses an unqualfied namespace the expression is more verbose. Consider the following XML document that
+uses an unqualified namespace:
+
+[source,xml,indent=0]
+----
+<customer xmlns="http://demo.com/customer">
+    <email>customer@test.com</email>
+</customer>
+----
+The XPath expression to select the email address is
+```
+*/[local-name()='customer' and namespace-uri()='http://demo.com/customer']/*[local-name()='email']/text()
+```
+Beware as the unqualified expressions `/customer/email/text()` or `*/[local-name()='customer' and namespace-uri()='http://demo.com/customer']/email/text()`
+result in `""`. Even the child elements have to be referenced with the `local-name` syntax.
+
+====== General namespaced node expression syntax
+- Node using qualified namespace:
+```
+/<node-name>
+```
+- Node using and defining an unqualified namespace:
+```
+/*[local-name=()='<node-name>' and namespace-uri=()='<namespace-uri>']
+```
+NOTE: In some case the `namespace_uri` portion can be omitted but may lead to ambiguity.
+
+- Node using an unqualified namespace (one of its ancestor's defines the xmlns attribute):
+```
+/*[local-name=()='<node-name>']
+```
+
+
 [[contract-dsl-multiple]]
 === Multiple Contracts in One File
 

--- a/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/util/xml/ArrayValueAssertion.java
+++ b/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/util/xml/ArrayValueAssertion.java
@@ -79,6 +79,12 @@ class ArrayValueAssertion extends FieldAssertion implements XmlArrayVerifiable {
 	}
 
 	@Override
+	public FieldAssertion nodeWithDefaultNamespace(String value, String defaultNamespace) {
+		FieldAssertion assertion = super.nodeWithDefaultNamespace(value, defaultNamespace);
+		return new ArrayValueAssertion(assertion, false);
+	}
+
+	@Override
 	public FieldAssertion node(String... nodeNames) {
 		FieldAssertion assertion = super.node(nodeNames);
 		return new ArrayValueAssertion(assertion, false);

--- a/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/util/xml/XmlVerifiable.java
+++ b/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/util/xml/XmlVerifiable.java
@@ -21,6 +21,7 @@ package org.springframework.cloud.contract.verifier.util.xml;
  *
  * @author Marcin Grzejszczak
  * @author Olga Maciaszek-Sharma
+ * @author Chris Bono
  * @since 2.1.0
  */
 public interface XmlVerifiable extends IteratingOverArray, XmlReader {
@@ -31,6 +32,16 @@ public interface XmlVerifiable extends IteratingOverArray, XmlReader {
 	 * @return new {@code XmlVerifiable}
 	 */
 	XmlVerifiable node(String nodeName);
+
+	/**
+	 * Field assertion. Adds a XPath entry for a single node that uses a default
+	 * namespace.
+	 * @param nodeName local name of the node
+	 * @param namespace the default namespace uri or null if one of the node ancestor
+	 * declares the namespace
+	 * @return new {@code XmlVerifiable}
+	 */
+	XmlVerifiable nodeWithDefaultNamespace(String nodeName, String namespace);
 
 	/**
 	 * Field assertion. Adds a attribute to the currently checked node. NOTE: If you want

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/XmlMethodBodyBuilderSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/XmlMethodBodyBuilderSpec.groovy
@@ -31,6 +31,7 @@ import org.springframework.cloud.contract.verifier.util.SyntaxChecker
 
 /**
  * @author Olga Maciaszek-Sharma
+ * @author Chris Bono
  * @since 2.1.0
  */
 class XmlMethodBodyBuilderSpec extends Specification {
@@ -155,6 +156,214 @@ class XmlMethodBodyBuilderSpec extends Specification {
 			test.contains('assertThat(valueFromXPath(parsedXml, "/test/time/text()")).matches("(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])")')
 			test.contains('assertThat(valueFromXPath(parsedXml, "/test/*/complex/text()")).isEqualTo("foo")')
 			test.contains('assertThat(valueFromXPath(parsedXml, "/test/duck/@type")).isEqualTo("xtype")')
+		and:
+			SyntaxChecker.tryToCompile(methodBuilderName, test)
+		where:
+			methodBuilderName | methodBuilder
+			"spock"           | {
+				properties.testFramework = TestFramework.SPOCK
+			}
+			"testng"          | {
+				properties.testFramework = TestFramework.TESTNG
+			}
+			"junit"           | {
+				properties.testMode = TestMode.MOCKMVC
+			}
+			"jaxrs-spock"     | {
+				properties.testFramework = TestFramework.SPOCK; properties.testMode = TestMode.JAXRSCLIENT
+			}
+			"jaxrs"           | {
+				properties.testFramework = TestFramework.JUNIT; properties.testMode = TestMode.JAXRSCLIENT
+			}
+			"webclient"       | {
+				properties.testMode = TestMode.WEBTESTCLIENT
+			}
+	}
+
+	@Unroll
+	def 'should generate correct verification from named xml with body matchers  [#methodBuilderName]'() {
+		given:
+			Contract contractDsl =
+					// tag::xmlgroovy[]
+					Contract.make {
+						request {
+							method GET()
+							urlPath '/get'
+							headers {
+								contentType(applicationXml())
+							}
+						}
+						response {
+							status(OK())
+							headers {
+								contentType(applicationXml())
+							}
+							body """
+<ns1:test xmlns:ns1="http://demo.com/testns">
+ <ns1:header>
+    <duck-bucket type='bigbucket'>
+      <duck>duck5150</duck>
+    </duck-bucket>
+</ns1:header>
+</ns1:test>
+"""
+							bodyMatchers {
+								xPath('/test/duck/text()', byRegex("[0-9]{3}"))
+								xPath('/test/duck/text()', byCommand('equals($it)'))
+								xPath('/test/duck/xxx', byNull())
+								xPath('/test/duck/text()', byEquality())
+								xPath('/test/alpha/text()', byRegex(onlyAlphaUnicode()))
+								xPath('/test/alpha/text()', byEquality())
+								xPath('/test/number/text()', byRegex(number()))
+								xPath('/test/date/text()', byDate())
+								xPath('/test/dateTime/text()', byTimestamp())
+								xPath('/test/time/text()', byTime())
+								xPath('/test/duck/@type', byEquality())
+							}
+						}
+					}
+			// end::xmlgroovy[]
+			methodBuilder()
+		when:
+			String test = singleTestGenerator(contractDsl)
+		then:
+			test.contains('assertThat(valueFromXPath(parsedXml, "/ns1:test/ns1:header/duck-bucket/duck/text()")).isEqualTo("duck5150")')
+			test.contains('assertThat(valueFromXPath(parsedXml, "/ns1:test/namespace::ns1")).isEqualTo("http://demo.com/testns")')
+			test.contains('assertThat(valueFromXPath(parsedXml, "/ns1:test/ns1:header/duck-bucket/@type")).isEqualTo("bigbucket")')
+		and:
+			SyntaxChecker.tryToCompile(methodBuilderName, test)
+		where:
+			methodBuilderName | methodBuilder
+			"spock"           | {
+				properties.testFramework = TestFramework.SPOCK
+			}
+			"testng"          | {
+				properties.testFramework = TestFramework.TESTNG
+			}
+			"junit"           | {
+				properties.testMode = TestMode.MOCKMVC
+			}
+			"jaxrs-spock"     | {
+				properties.testFramework = TestFramework.SPOCK; properties.testMode = TestMode.JAXRSCLIENT
+			}
+			"jaxrs"           | {
+				properties.testFramework = TestFramework.JUNIT; properties.testMode = TestMode.JAXRSCLIENT
+			}
+			"webclient"       | {
+				properties.testMode = TestMode.WEBTESTCLIENT
+			}
+	}
+
+	@Unroll
+	def 'should generate correct verification from complex named xml with body matchers  [#methodBuilderName]'() {
+		given:
+			Contract contractDsl =
+					// tag::xmlgroovy[]
+					Contract.make {
+						request {
+							method GET()
+							urlPath '/get'
+							headers {
+								contentType(applicationXml())
+							}
+						}
+						response {
+							status(OK())
+							headers {
+								contentType(applicationXml())
+							}
+							body """
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+   <SOAP-ENV:Header>
+      <RsHeader xmlns="http://schemas.xmlsoap.org/soap/custom">
+         <MsgSeqId>1234</MsgSeqId>
+      </RsHeader>
+   </SOAP-ENV:Header>
+</SOAP-ENV:Envelope>
+"""
+							bodyMatchers {
+								xPath('//*[local-name()=\'RsHeader\' and namespace-uri()=\'http://schemas.xmlsoap.org/soap/custom\']/*[local-name()=\'MsgSeqId\']/text()', byEquality())
+							}
+						}
+					}
+			// end::xmlgroovy[]
+			methodBuilder()
+		when:
+			String test = singleTestGenerator(contractDsl)
+		then:
+			test.contains('assertThat(valueFromXPath(parsedXml, "//*[local-name()=\'RsHeader\' and namespace-uri()=\'http://schemas.xmlsoap.org/soap/custom\']/*[local-name()=\'MsgSeqId\']/text()")).isEqualTo("1234")')
+			test.contains('assertThat(valueFromXPath(parsedXml, "/SOAP-ENV:Envelope/namespace::SOAP-ENV")).isEqualTo("http://schemas.xmlsoap.org/soap/envelope/")')
+			!test.contains('assertThat(valueFromXPath(parsedXml, "/SOAP-ENV:Envelope/SOAP-ENV:Header/*[local-name()=\'RsHeader\' and namespace-uri()=\'http://schemas.xmlsoap.org/soap/custom\']/@xmlns")).isEqualTo"')
+		and:
+			SyntaxChecker.tryToCompile(methodBuilderName, test)
+		where:
+			methodBuilderName | methodBuilder
+			"spock"           | {
+				properties.testFramework = TestFramework.SPOCK
+			}
+			"testng"          | {
+				properties.testFramework = TestFramework.TESTNG
+			}
+			"junit"           | {
+				properties.testMode = TestMode.MOCKMVC
+			}
+			"jaxrs-spock"     | {
+				properties.testFramework = TestFramework.SPOCK; properties.testMode = TestMode.JAXRSCLIENT
+			}
+			"jaxrs"           | {
+				properties.testFramework = TestFramework.JUNIT; properties.testMode = TestMode.JAXRSCLIENT
+			}
+			"webclient"       | {
+				properties.testMode = TestMode.WEBTESTCLIENT
+			}
+	}
+
+	@Unroll
+	def 'should generate correct verification from very complex named xml without body matchers  [#methodBuilderName]'() {
+		given:
+			Contract contractDsl =
+					// tag::xmlgroovy[]
+					Contract.make {
+						request {
+							method GET()
+							urlPath '/get'
+							headers {
+								contentType(applicationXml())
+							}
+						}
+						response {
+							status(OK())
+							headers {
+								contentType(applicationXml())
+							}
+							body """
+<ns1:customer xmlns:ns1="http://demo.com/customer" xmlns:addr="http://demo.com/address">
+	<email>customer@test.com</email>
+	<contact-info xmlns="http://demo.com/contact-info">
+		<name>Krombopulous</name>
+		<address>
+			<addr:gps>
+				<lat>51</lat>
+				<addr:lon>50</addr:lon>
+			</addr:gps>
+		</address>
+	</contact-info>
+</ns1:customer>
+"""
+						}
+					}
+			// end::xmlgroovy[]
+			methodBuilder()
+		when:
+			String test = singleTestGenerator(contractDsl)
+		then:
+			test.contains('assertThat(valueFromXPath(parsedXml, "/ns1:customer/namespace::ns1")).isEqualTo("http://demo.com/customer")')
+			test.contains('assertThat(valueFromXPath(parsedXml, "/ns1:customer/namespace::addr")).isEqualTo("http://demo.com/address")')
+			test.contains('assertThat(valueFromXPath(parsedXml, "/ns1:customer/email/text()")).isEqualTo("customer@test.com")')
+			test.contains('assertThat(valueFromXPath(parsedXml, "/ns1:customer/*[local-name()=\'contact-info\' and namespace-uri()=\'http://demo.com/contact-info\']/*[local-name()=\'name\']/text()")).isEqualTo("Krombopulous")')
+			test.contains('assertThat(valueFromXPath(parsedXml, "/ns1:customer/*[local-name()=\'contact-info\' and namespace-uri()=\'http://demo.com/contact-info\']/*[local-name()=\'address\']/addr:gps/*[local-name()=\'lat\']/text()")).isEqualTo("51")')
+			test.contains('assertThat(valueFromXPath(parsedXml, "/ns1:customer/*[local-name()=\'contact-info\' and namespace-uri()=\'http://demo.com/contact-info\']/*[local-name()=\'address\']/addr:gps/addr:lon/text()")).isEqualTo("50")')
+			!test.contains('assertThat(valueFromXPath(parsedXml,"/ns1:customer/*[local-name()=\'contact-info\' and namespace-uri()=\'http://demo.com/contact-info\']/@xmlns")).isEqualTo"')
 		and:
 			SyntaxChecker.tryToCompile(methodBuilderName, test)
 		where:


### PR DESCRIPTION
Adds support for unqualified namespaced XML content and fixes how qualified namespace URIs values are retrieved.

Fixes gh-1571 gh-1517

-----

### Overview
The main theme behind this change is to access XPath expressions for nodes that are using an unqualified namespace. Please read the document updates first as that should clarify a bit more.

This is definitely a problem of edge-casing and one could probably come up w/ a twisted nested complicated XML document that we may not properly support. I added in a decent set of complicated XML content in the tests but I also don't want to over complicate the maintenance of our tests. We can add more later if need be but we are definitely in a better position, code coverage wise, with the new additions in this code proposal.

----

#### Concern / Improvement

I want to point the verbose nature of the required XPath expressions.

For the following XML:
```xml
<customer xmlns="http://demo.com/customer">
    <email>customer@test.com</email>
</customer>
```
The XPath expression to select the email address is
```
*/[local-name()='customer' and namespace-uri()='http://demo.com/customer']/*[local-name()='email']/text()
```
We may want to consider later supporting a more user-friendly form in the body matchers so that users could instead specify the matcher expression in the unqualfied mamner such as:
```
/customer/email/text()
```
and we would behind the scenes translate that into the proper fully-qualified XPath expression:
```
*/[local-name()='customer' and namespace-uri()='http://demo.com/customer']/*[local-name()='email']/text()
```
