### PR TITLE
Temporary change to see if 2.2.x branch builds are busted

### DIFF
--- a/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/assertion/CollectionAssert.java
+++ b/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/assertion/CollectionAssert.java
@@ -65,6 +65,10 @@ public class CollectionAssert<ELEMENT> extends IterableAssert<ELEMENT> {
 		return this;
 	}
 
+	private void someFakeMethodAddedToCauseAChange() {
+		System.out.println("***** here");
+	}
+
 	private void failWithMessageRelatedToRegex(String regex, Object value) {
 		failWithMessage("The value <%s> doesn't match the regex <%s>", value, regex);
 	}


### PR DESCRIPTION
As title suggests, I am simply seeing what circle CI does on a branch directly from fresh 2.2.x line as my pull request build is failing on Guava Maven access issue and I want to rule out my branch. I will delete this pull request once I get the signal I need from Circle CI