### PR TITLE
Fixed DefaultWireMockStubPostProcessor.setMetadata bug

### DIFF
--- a/spring-cloud-contract-tools/spring-cloud-contract-converters/src/main/java/org/springframework/cloud/contract/verifier/wiremock/DefaultWireMockStubPostProcessor.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-converters/src/main/java/org/springframework/cloud/contract/verifier/wiremock/DefaultWireMockStubPostProcessor.java
@@ -60,7 +60,7 @@ class DefaultWireMockStubPostProcessor implements WireMockStubPostProcessor {
 	public void setMetadata(StubMapping stubMapping, StubMapping stubMappingFromMetadata) {
 		Metadata metadata = stubMapping.getMetadata();
 		metadata = metadata != null ? metadata : new Metadata();
-		metadata.putAll(stubMappingFromMetadata.getPostServeActions());
+		metadata.putAll(stubMappingFromMetadata.getMetadata());
 		stubMapping.setMetadata(metadata);
 	}
 


### PR DESCRIPTION
## Problem
Creating a contract like this:
```
Contract.make {            
            metadata(
                    wiremock: [
                            stubMapping: [
                                    metadata: [
                                            foo: "bar"
                                    ]
                            ]
                    ]
            )
        }
}

```
will throw a `NullPointerException`:
```
Exception in thread "main" org.springframework.cloud.contract.verifier.converter.ConversionContractVerifierException: Unable to make conversion of client.groovy
	at org.springframework.cloud.contract.verifier.converter.RecursiveFilesConverter.processFiles(RecursiveFilesConverter.java:145)
	at org.springframework.cloud.contract.verifier.converter.RecursiveFilesConverterApplication.main(RecursiveFilesConverterApplication.java:43)
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.Map.size()" because "m" is null
	at java.base/java.util.HashMap.putMapEntries(HashMap.java:497)
	at java.base/java.util.HashMap.putAll(HashMap.java:785)
	at org.springframework.cloud.contract.verifier.wiremock.DefaultWireMockStubPostProcessor.setMetadata(DefaultWireMockStubPostProcessor.java:63)
	at org.springframework.cloud.contract.verifier.wiremock.DefaultWireMockStubPostProcessor.postProcess(DefaultWireMockStubPostProcessor.java:48)
```

## Solution:
The reason is that there is a bug that instead of using the `stubMappingFromMetadata.getMetadata()` its calling `stubMappingFromMetadata.getPostServeActions()`.
