### PR TITLE
Select value of an `anyOf()` property at random

### DIFF
--- a/specs/spring-cloud-contract-spec-java/src/main/java/org/springframework/cloud/contract/spec/internal/PatternValueDslProperty.java
+++ b/specs/spring-cloud-contract-spec-java/src/main/java/org/springframework/cloud/contract/spec/internal/PatternValueDslProperty.java
@@ -168,7 +168,7 @@ abstract class PatternValueDslProperty<T extends DslProperty> implements RegexCr
 
 	@Override
 	public T anyOf(String... values) {
-		return createAndValidateProperty(RegexPatterns.anyOf(values), values[0]);
+		return createAndValidateProperty(RegexPatterns.anyOf(values), values[this.random.nextInt(values.length)]);
 	}
 
 }


### PR DESCRIPTION
The current implementation of `anyOf()` always only selects the first value
when generating a property. It means that other possible enum values are always
ignored when producing a value for the property.

This changes the behaviour so that the value is picked at random from any of
the provided values. It could be considered a breaking changes because of the
change of behaviour although it shouldn't be from the contract perspective.

Fixes #1424