### PR TITLE
Ensure stdout/stderr are logged when using debug mode logging.

### DIFF
--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/ContractsCopyTask.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/ContractsCopyTask.java
@@ -186,15 +186,20 @@ class ContractsCopyTask extends DefaultTask {
 		} else {
 			os = NullOutputStream.INSTANCE;
 		}
-		getProject().javaexec(exec -> {
-			exec.setMain("org.springframework.cloud.contract.verifier.converter.ToYamlConverterApplication");
-			exec.classpath(classpath);
-			exec.args(quoteAndEscape(outputContractsFolder.getAbsolutePath()));
-			exec.setStandardOutput(os);
-			exec.setErrorOutput(os);
-		});
-		if (getLogger().isDebugEnabled()) {
-			getLogger().debug(os.toString());
+		try {
+			getProject().javaexec(exec -> {
+				exec.setMain("org.springframework.cloud.contract.verifier.converter.ToYamlConverterApplication");
+				exec.classpath(classpath);
+				exec.args(quoteAndEscape(outputContractsFolder.getAbsolutePath()));
+				exec.setStandardOutput(os);
+				exec.setErrorOutput(os);
+			});
+		} catch (Exception e) {
+			throw new GradleException("Spring Cloud Contract Verifier Plugin exception: " + e.getMessage(), e);
+		} finally {
+			if (getLogger().isDebugEnabled()) {
+				getLogger().debug(os.toString());
+			}
 		}
 		getLogger().info("Replaced DSL files with their YAML representation at [{}]", outputContractsFolder);
 	}

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/GenerateClientStubsFromDslTask.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/GenerateClientStubsFromDslTask.java
@@ -24,6 +24,7 @@ import javax.inject.Inject;
 
 import org.eclipse.jgit.util.io.NullOutputStream;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
@@ -88,16 +89,21 @@ class GenerateClientStubsFromDslTask extends DefaultTask {
 		} else {
 			os = NullOutputStream.INSTANCE;
 		}
-		getProject().javaexec(exec -> {
-			exec.setMain("org.springframework.cloud.contract.verifier.converter.RecursiveFilesConverterApplication");
-			exec.classpath(classpath);
-			exec.args(quoteAndEscape(output.getAbsolutePath()), quoteAndEscape(contractsDslDir.get().getAsFile().getAbsolutePath()),
-					quoteAndEscape(StringUtils.collectionToCommaDelimitedString(excludedFiles.get())), quoteAndEscape(".*"), excludeBuildFolders.get());
-			exec.setStandardOutput(os);
-			exec.setErrorOutput(os);
-		});
-		if (getLogger().isDebugEnabled()) {
-			getLogger().debug(os.toString());
+		try {
+			getProject().javaexec(exec -> {
+				exec.setMain("org.springframework.cloud.contract.verifier.converter.RecursiveFilesConverterApplication");
+				exec.classpath(classpath);
+				exec.args(quoteAndEscape(output.getAbsolutePath()), quoteAndEscape(contractsDslDir.get().getAsFile().getAbsolutePath()),
+						quoteAndEscape(StringUtils.collectionToCommaDelimitedString(excludedFiles.get())), quoteAndEscape(".*"), excludeBuildFolders.get());
+				exec.setStandardOutput(os);
+				exec.setErrorOutput(os);
+			});
+		} catch (Exception e) {
+			throw new GradleException("Spring Cloud Contract Verifier Plugin exception: " + e.getMessage(), e);
+		} finally {
+			if (getLogger().isDebugEnabled()) {
+				getLogger().debug(os.toString());
+			}
 		}
 	}
 

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/GenerateServerTestsTask.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/GenerateServerTestsTask.java
@@ -131,14 +131,14 @@ class GenerateServerTestsTask extends DefaultTask {
 		getLogger().info("Contracts are unpacked to [{}]", contractsDslDir);
 		getLogger().info("Included contracts are [{}]", includedContracts);
 		ContractVerifierConfigProperties properties = toConfigProperties(contractsDslDir, includedContracts, generatedTestSources, generatedTestResources);
+		OutputStream os;
+		if (getLogger().isDebugEnabled()) {
+			os = new ByteArrayOutputStream();
+		} else {
+			os = NullOutputStream.INSTANCE;
+		}
 		try {
 			String propertiesJson = new ObjectMapper().writeValueAsString(properties);
-			OutputStream os;
-			if (getLogger().isDebugEnabled()) {
-				os = new ByteArrayOutputStream();
-			} else {
-				os = NullOutputStream.INSTANCE;
-			}
 			getProject().javaexec(exec -> {
 				exec.setMain("org.springframework.cloud.contract.verifier.TestGeneratorApplication");
 				exec.classpath(classpath);
@@ -146,12 +146,13 @@ class GenerateServerTestsTask extends DefaultTask {
 				exec.setStandardOutput(os);
 				exec.setErrorOutput(os);
 			});
-			if (getLogger().isDebugEnabled()) {
-				getLogger().debug(os.toString());
-			}
 		}
 		catch (Exception e) {
 			throw new GradleException("Spring Cloud Contract Verifier Plugin exception: " + e.getMessage(), e);
+		} finally {
+			if (getLogger().isDebugEnabled()) {
+				getLogger().debug(os.toString());
+			}
 		}
 	}
 


### PR DESCRIPTION
Relates to gh-1600.

As you can see in the changes, if `javaexec` were to exit with a return code of 1 an exception was raised and the stdout/stderr that we may have collected during debug logging would have been lost. By usage of the `finally` block we can now ensure that the stdout/stderr from the different forked processes we will create can be captured for debugging information.