### PR TITLE
Add kotlin-scripting-compiler-embeddable for Kotlin DSL

### DIFF
--- a/docs/src/main/asciidoc/_project-features-contract.adoc
+++ b/docs/src/main/asciidoc/_project-features-contract.adoc
@@ -153,8 +153,6 @@ buildscript {
     }
 	dependencies {
 		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${scContractVersion}"
-        // remember to add this:
-		classpath "org.springframework.cloud:spring-cloud-contract-spec-kotlin:${scContractVersion}"
 	}
 }
 
@@ -163,6 +161,8 @@ dependencies {
 
     // Remember to add this for the DSL support in the IDE and on the consumer side
     testImplementation "org.springframework.cloud:spring-cloud-contract-spec-kotlin"
+    // Kotlin versions are very particular down to the patch version. The <kotlin_version> needs to be the same as you have imported for your project.
+    testImplementation "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:<kotlin_version>"
 }
 ----
 ====

--- a/docs/src/main/asciidoc/gradle-project.adoc
+++ b/docs/src/main/asciidoc/gradle-project.adoc
@@ -140,7 +140,7 @@ dependencies {
 == Gradle and Rest Assured 2.0
 
 By default, Rest Assured 3.x is added to the classpath. However, to use Rest Assured 2.x,
-you can add it to the plugins classpath, as the following listing shows:
+you can add it instead, as the following listing shows:
 
 ====
 [source,groovy,indent=0]
@@ -152,8 +152,6 @@ buildscript {
 	dependencies {
 		classpath "org.springframework.boot:spring-boot-gradle-plugin:${springboot_version}"
 		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${verifier_version}"
-		classpath "com.jayway.restassured:rest-assured:2.5.0"
-		classpath "com.jayway.restassured:spring-mock-mvc:2.5.0"
 	}
 }
 
@@ -172,13 +170,13 @@ and modifies the imports accordingly.
 [[gradle-snapshot-versions]]
 == Snapshot Versions for Gradle
 
-You can add the additional snapshot repository to your `build.gradle` to use snapshot versions,
+You can add the additional snapshot repository to your `settings.gradle` to use snapshot versions,
 which are automatically uploaded after every successful build, as the following listing shows:
 
 ====
 [source,groovy,indent=0]
 ----
-include::{standalone_samples_path}/http-server/build.gradle[tags=repos,indent=0]
+include::{standalone_samples_path}/http-server/settings.gradle[tags=repos,indent=0]
 }
 ----
 ====


### PR DESCRIPTION
Fixes gh-1600

This is achieved by adding to the documentation that states that `kotlin-scripting-compiler-embeddable` needs to be added to your `build.gradle` in order to keep the Kotlin version used in the project in sync with that used to generate tests from the Kotlin DSL. As we have seen in gh-1600, the Kotlin runtime is sensitive to version discrepancies across modules down to the patch version. 

Additionally, noticed a broken link and some outdated Gradle configuration with respect to Rest Assured configuration, so I have corrected those as well.