### PR TITLE
Fix Clone on Windows instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -237,7 +237,7 @@ git clone https://github.com/spring-cloud/spring-cloud-contract.git
 
 [source,bash]
 ----
-git clone -c core.longPaths true https://github.com/spring-cloud/spring-cloud-contract.git
+git clone -c core.longPaths=true https://github.com/spring-cloud/spring-cloud-contract.git
 ----
 
 IMPORTANT: You need to have all the necessary Groovy plugins


### PR DESCRIPTION
The following command, suggested by the README

```
git clone -c core.longPaths true https://github.com/spring-cloud/spring-cloud-contract.git
```

fails because Git recognizes `true` as the repo to be cloned.

Add equal sign (`=`) to fix this issue. This way Git will properly recognize `true` as the value for `core.longPaths`