### PR TITLE
Fix Clone on Windows instructions

### DIFF
--- a/docs/src/main/asciidoc/_building.adoc
+++ b/docs/src/main/asciidoc/_building.adoc
@@ -30,7 +30,7 @@ git clone https://github.com/spring-cloud/spring-cloud-contract.git
 
 [source,bash]
 ----
-git clone -c core.longPaths true https://github.com/spring-cloud/spring-cloud-contract.git
+git clone -c core.longPaths=true https://github.com/spring-cloud/spring-cloud-contract.git
 ----
 
 IMPORTANT: You need to have all the necessary Groovy plugins


### PR DESCRIPTION
If this looks like a déjà vu, that is because I already summited this patch (#1618). I didn't realized `README.adoc` is generated. Hopefully this time I got it right and this is the right file to change.