### PR TITLE
Remove <at>Internal annotation

### DIFF
--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/ContractsCopyTask.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/ContractsCopyTask.java
@@ -355,7 +355,6 @@ class ContractsCopyTask extends DefaultTask {
 			return stringNotation;
 		}
 
-		@Internal
 		StubConfiguration toStubConfiguration() {
 			String stringNotation = this.stringNotation.getOrNull();
 			if (StringUtils.hasText(stringNotation)) {


### PR DESCRIPTION
Fixes gh-1636

Using [spring-cloud-samples/spring-cloud-contract-samples - 3.0.x](https://github.com/spring-cloud-samples/spring-cloud-contract-samples/tree/3.0.x) `producer` sample, I was able to recreate the issue described in gh-1636.

| Gradle Version | SCC Verifier Version | Result |
| ---------------- | ---------------------- | ------ |
| 5.6.4 | 3.0.2-SNAPSHOT | ✅ |
| 5.6.4 | 3.0.3-SNAPSHOT (local remove `@Internal`) | ✅ |
| 6.8.3 | 3.0.2-SNAPSHOT | ✅ |
| 6.8.3 | 3.0.3-SNAPSHOT (local remove `@Internal`) | ✅ |
| 7.0 | 3.0.2-SNAPSHOT | ❌ |
| 7.0 | 3.0.3-SNAPSHOT (local remove `@Internal`) | ✅ |