### PR TITLE
Fix Docker base image version

### DIFF
--- a/docker/spring-cloud-contract-docker/Dockerfile
+++ b/docker/spring-cloud-contract-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG SDKMAN_JAVA_INSTALLATION=8.0.275.hs-adpt
 

--- a/docker/spring-cloud-contract-stub-runner-docker/Dockerfile
+++ b/docker/spring-cloud-contract-stub-runner-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG SDKMAN_JAVA_INSTALLATION=8.0.275.hs-adpt
 


### PR DESCRIPTION
As part of 4d71108 Docker base images were updated to ubuntu:21.04. According to #1579 the intention is to update to Ubuntu LTS version. 21.04 is not LTS version and as a matter of fact it is not yet released version.

Change the docker base image to the the intended version 20.04 LTS.