### PR TITLE
Parse ExecutionProperty in queryParameters

### DIFF
--- a/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/builder/JaxRsUrlPathWhen.java
+++ b/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/builder/JaxRsUrlPathWhen.java
@@ -75,8 +75,8 @@ class JaxRsUrlPathWhen implements When, JaxRsAcceptor, QueryParamsResolver {
 				.iterator();
 		while (iterator.hasNext()) {
 			QueryParameter param = iterator.next();
-			String text = ".queryParam(\"" + param.getName() + "\", "
-					+ this.bodyParser.quotedShortText(resolveParamValue(param)) + ")";
+			String queryParamValue = getQueryParamValue(param);
+			String text = ".queryParam(\"" + param.getName() + "\", " + queryParamValue + ")";
 			if (iterator.hasNext()) {
 				this.blockBuilder.addLine(text);
 			}
@@ -84,6 +84,14 @@ class JaxRsUrlPathWhen implements When, JaxRsAcceptor, QueryParamsResolver {
 				this.blockBuilder.addIndented(text);
 			}
 		}
+	}
+
+	private String getQueryParamValue(QueryParameter param) {
+		Object serverValue = param.getServerValue();
+		if (serverValue instanceof ExecutionProperty) {
+			return ((ExecutionProperty) serverValue).getExecutionCommand();
+		}
+		return this.bodyParser.quotedShortText(resolveParamValue(param));
 	}
 
 	/**

--- a/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/builder/MockMvcQueryParamsWhen.java
+++ b/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/builder/MockMvcQueryParamsWhen.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.cloud.contract.spec.internal.ExecutionProperty;
 import org.springframework.cloud.contract.spec.internal.MatchingStrategy;
 import org.springframework.cloud.contract.spec.internal.QueryParameter;
 import org.springframework.cloud.contract.spec.internal.Request;
@@ -85,10 +86,17 @@ class MockMvcQueryParamsWhen implements When, MockMvcAcceptor, QueryParamsResolv
 	}
 
 	private String addQueryParameter(QueryParameter queryParam) {
+		String queryParamValue = getQueryParamValue(queryParam);
 		return "." + QUERY_PARAM_METHOD + "(" + this.bodyParser.quotedLongText(queryParam.getName()) + ","
-				+ this.bodyParser
-						.quotedLongText(resolveParamValue(MapConverter.getTestSideValuesForNonBody(queryParam)))
-				+ ")";
+				+ queryParamValue + ")";
+	}
+
+	private String getQueryParamValue(QueryParameter queryParam) {
+		Object serverValue = queryParam.getServerValue();
+		if (serverValue instanceof ExecutionProperty) {
+			return ((ExecutionProperty) serverValue).getExecutionCommand();
+		}
+		return this.bodyParser.quotedLongText(resolveParamValue(MapConverter.getTestSideValuesForNonBody(queryParam)));
 	}
 
 	@Override


### PR DESCRIPTION
Fixes gh-854. Query param isn't quoted if it's an ExecutionProperty, similarly to https://github.com/spring-cloud/spring-cloud-contract/blob/c323e3e105810498a2bb9869d87eb144d5c8d0d5/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/builder/JaxRsRequestHeadersWhen.java#L46-L67