### PR TITLE
Add explicit dependency to generateContractTests task for processContractTestResources

### DIFF
--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/SpringCloudContractVerifierGradlePlugin.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/src/main/java/org/springframework/cloud/contract/verifier/plugin/SpringCloudContractVerifierGradlePlugin.java
@@ -232,6 +232,9 @@ public class SpringCloudContractVerifierGradlePlugin implements Plugin<Project> 
 
 			generateServerTestsTask.dependsOn(copyContracts);
 		});
+		project.getTasks().named(contractTestSourceSet.getProcessResourcesTaskName(), processContractTestResourcesTask -> {
+			processContractTestResourcesTask.dependsOn(task);
+		});
 		project.getTasks().named(contractTestSourceSet.getCompileJavaTaskName(), compileContractTestJava -> compileContractTestJava.dependsOn(task));
 		project.getPlugins().withType(GroovyPlugin.class, groovyPlugin -> {
 			project.getTasks().named(contractTestSourceSet.getCompileTaskName("groovy"), compileContractTestGroovy -> {


### PR DESCRIPTION
With Gradle 7.0, a new warning is being logged indicating that Gradle is using a fallback mode to ensure task correctness.

```
Execution optimizations have been disabled for task ':processContractTestResources' to ensure correctness due to the following reasons:
    - Gradle detected a problem with the following location: '/home/runner/work/spring-cloud-contract-samples/spring-cloud-contract-samples/producer/build/generated-test-resources/contractTest'. Reason: Task ':processContractTestResources' uses this output of task ':generateContractTests' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.0.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```