### PR TITLE
Add support for v4 UUIDs, and allow UUIDs to be case insensitive

### DIFF
--- a/specs/spring-cloud-contract-spec-java/src/main/java/org/springframework/cloud/contract/spec/internal/RegexPatterns.java
+++ b/specs/spring-cloud-contract-spec-java/src/main/java/org/springframework/cloud/contract/spec/internal/RegexPatterns.java
@@ -68,6 +68,9 @@ public final class RegexPatterns {
 	protected static final Pattern UUID = Pattern
 			.compile("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}");
 
+	protected static final Pattern UUID4 = Pattern
+			.compile("[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}");
+
 	protected static final Pattern ANY_DATE = Pattern
 			.compile("(\\d\\d\\d\\d)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])");
 
@@ -162,6 +165,10 @@ public final class RegexPatterns {
 
 	public static RegexProperty uuid() {
 		return new RegexProperty(UUID).asString();
+	}
+
+	public static RegexProperty uuid4() {
+		return new RegexProperty(UUID4).asString();
 	}
 
 	public static RegexProperty isoDate() {

--- a/specs/spring-cloud-contract-spec-java/src/main/java/org/springframework/cloud/contract/spec/internal/RegexPatterns.java
+++ b/specs/spring-cloud-contract-spec-java/src/main/java/org/springframework/cloud/contract/spec/internal/RegexPatterns.java
@@ -66,10 +66,10 @@ public final class RegexPatterns {
 	protected static final Pattern HTTPS_URL = UrlHelper.HTTPS_URL;
 
 	protected static final Pattern UUID = Pattern
-			.compile("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}");
+			.compile("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}", Pattern.CASE_INSENSITIVE);
 
 	protected static final Pattern UUID4 = Pattern
-			.compile("[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}");
+			.compile("[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}", Pattern.CASE_INSENSITIVE);
 
 	protected static final Pattern ANY_DATE = Pattern
 			.compile("(\\d\\d\\d\\d)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])");

--- a/specs/spring-cloud-contract-spec/src/test/groovy/org/springframework/cloud/contract/spec/internal/RegexPatternsSpec.groovy
+++ b/specs/spring-cloud-contract-spec/src/test/groovy/org/springframework/cloud/contract/spec/internal/RegexPatternsSpec.groovy
@@ -237,13 +237,32 @@ class RegexPatternsSpec extends Specification {
 
 	def "should generate a regex for a uuid [#textToMatch] that is a match [#shouldMatch]"() {
 		expect:
-			shouldMatch == RegexPatterns.uuid().matcher(textToMatch).matches()
+		shouldMatch == RegexPatterns.uuid().matcher(textToMatch).matches()
+		where:
+		textToMatch                           || shouldMatch
+		UUID.randomUUID().toString()          || true
+		UUID.randomUUID().toString()          || true
+		UUID.randomUUID().toString() + "!"    || false
+		'23e4567-z89b-12z3-j456-426655440000' || false
+		'dog'                                 || false
+		'5'                                   || false
+	}
+
+	def "should generate a regex for a uuidv4 [#textToMatch] that is a match [#shouldMatch]"() {
+		expect:
+			shouldMatch == RegexPatterns.uuid4().matcher(textToMatch).matches()
 		where:
 			textToMatch                           || shouldMatch
 			UUID.randomUUID().toString()          || true
 			UUID.randomUUID().toString()          || true
+			'123e4567-e89b-42d3-a456-556642440000' || true
+			'00000000-0000-4000-8000-000000000000' || true
+			'00000000-0000-4000-9000-000000000000' || true
+			'00000000-0000-4000-a000-000000000000' || true
+			'00000000-0000-4000-b000-000000000000' || true
+			'00000000-0000-4000-1000-000000000000' || false
 			UUID.randomUUID().toString() + "!"    || false
-			'23e4567-z89b-12z3-j456-426655440000' || false
+			'00000000-0000-0000-0000-000000000000' || false
 			'dog'                                 || false
 			'5'                                   || false
 	}

--- a/specs/spring-cloud-contract-spec/src/test/groovy/org/springframework/cloud/contract/spec/internal/RegexPatternsSpec.groovy
+++ b/specs/spring-cloud-contract-spec/src/test/groovy/org/springframework/cloud/contract/spec/internal/RegexPatternsSpec.groovy
@@ -242,6 +242,7 @@ class RegexPatternsSpec extends Specification {
 		textToMatch                           || shouldMatch
 		UUID.randomUUID().toString()          || true
 		UUID.randomUUID().toString()          || true
+		UUID.randomUUID().toString().toUpperCase() || true
 		UUID.randomUUID().toString() + "!"    || false
 		'23e4567-z89b-12z3-j456-426655440000' || false
 		'dog'                                 || false
@@ -255,6 +256,7 @@ class RegexPatternsSpec extends Specification {
 			textToMatch                           || shouldMatch
 			UUID.randomUUID().toString()          || true
 			UUID.randomUUID().toString()          || true
+			UUID.randomUUID().toString().toUpperCase() || true
 			'123e4567-e89b-42d3-a456-556642440000' || true
 			'00000000-0000-4000-8000-000000000000' || true
 			'00000000-0000-4000-9000-000000000000' || true


### PR DESCRIPTION
As some web services expect to receive a valid UUIDv4, rather than a rough UUID
pattern, we should provide a convenience method to generate them.

We should add test coverage to make it clear that this is a strict UUIDv4.

Also, allow uppercase UUID generation, as it's perfectly valid for a UUID to be
formatted with uppercase or lowercase, as per RFC4122 Section 3.
