### PR TITLE
Fixes #1672: allow users to specify a custom build.gradle when using standalone docker image

### DIFF
--- a/docker/spring-cloud-contract-docker/Dockerfile
+++ b/docker/spring-cloud-contract-docker/Dockerfile
@@ -16,21 +16,29 @@ RUN useradd -u1000 -m scc
 COPY sdkman/ /usr/local/bin/
 RUN chmod +x /usr/local/bin/sdkman-wrapper.sh
 
+# provide output & contract directories and change owner to scc
+RUN mkdir -p /contracts
+RUN mkdir -p /spring-cloud-contract-output
+RUN mkdir -p /spring-cloud-contract
+RUN chown -R scc:scc /contracts
+RUN chown -R scc:scc /spring-cloud-contract-output /spring-cloud-contract
+RUN chown -R scc:scc /spring-cloud-contract
+
 USER scc
 RUN curl -s https://get.sdkman.io/ | bash
-COPY --chown=scc sdkman.config /home/scc/.sdkman/etc/config
+COPY --chown=scc:scc sdkman.config /home/scc/.sdkman/etc/config
 RUN bash -c "source /home/scc/.sdkman/bin/sdkman-init.sh"
 RUN bash -c "sdkman-wrapper.sh install java ${SDKMAN_JAVA_INSTALLATION}"
 ENV JAVA_HOME /home/scc/.sdkman/candidates/java/current/
 ENV PATH "${PATH}:${JAVA_HOME}/bin"
 
 # Spring Cloud Contract
-COPY --chown=scc project /home/scc/spring-cloud-contract/
-WORKDIR /home/scc/spring-cloud-contract/
+COPY --chown=scc:scc project /spring-cloud-contract/
+WORKDIR /spring-cloud-contract/
 
 # Let's copy the downloaded deps to .m2 and the gradle cache
-COPY --chown=scc target/maven_dependencies /home/scc/.m2/repository/
-COPY --chown=scc target/gradle_dependencies /home/scc/.gradle/
+COPY --chown=scc:scc target/maven_dependencies /home/scc/.m2/repository/
+COPY --chown=scc:scc target/gradle_dependencies /home/scc/.gradle/
 
 # Let's download gradle wrapper if for some reason it hasn't been downloaded
 RUN ./gradlew clean resolveDependencies build --stacktrace -x copyOutput || echo "Expected to fail"

--- a/docker/spring-cloud-contract-docker/project/README.adoc
+++ b/docker/spring-cloud-contract-docker/project/README.adoc
@@ -2,6 +2,7 @@
 
 ## Developer tips
 
+### Environment variables
 In order to use a new environment variable inside the Gradle script, you need to add it to the `envVars` map together with a description and a default value. Otherwise, any attempt to resolve such an environment variable will lead to an exception being thrown.
 
 If you're referencing any environment variables from inside the Java code please follow the following convention.
@@ -15,3 +16,9 @@ String envVar;
 ```
 
 If you provide Javadocs, we will automatically parse any `@Value` annotated fields and build a table of environment variables with description and default values.
+
+### Customizing the gradle build
+
+You can provide a customized `gradle.build` to be run in the container by mounting your customized build file as a volume when running the container:
+
+`docker run -v <absolute-path-of-your-custom-file>:/spring-cloud-contract/build.gradle springcloud/spring-cloud-contract:<version>`

--- a/docker/spring-cloud-contract-stub-runner-docker/Dockerfile
+++ b/docker/spring-cloud-contract-stub-runner-docker/Dockerfile
@@ -29,11 +29,11 @@ ENV PATH "${PATH}:${JAVA_HOME}/bin"
 # Spring Cloud Contract
 ENV SERVER_PORT 8750
 VOLUME /tmp
-COPY --chown=scc target/maven_dependencies /home/scc/.m2/repository/
-COPY --chown=scc target/libs/stub-runner-boot.jar stub-runner-boot.jar
+COPY --chown=scc:scc target/maven_dependencies /home/scc/.m2/repository/
+COPY --chown=scc:scc target/libs/stub-runner-boot.jar stub-runner-boot.jar
 RUN echo "Fetching dependencies, please wait..."
 RUN java -Dthin.dryrun=true -jar stub-runner-boot.jar
 RUN java -Dthin.dryrun=true -jar stub-runner-boot.jar --thin.profile=rabbit
 RUN java -Dthin.dryrun=true -jar stub-runner-boot.jar --thin.profile=kafka
-COPY --chown=scc run.sh run.sh
+COPY --chown=scc:scc run.sh run.sh
 ENTRYPOINT ["./run.sh"]

--- a/docs/src/main/asciidoc/docker-project.adoc
+++ b/docs/src/main/asciidoc/docker-project.adoc
@@ -82,6 +82,17 @@ The following environment variables are used when tests are run:
 
 include::{project-root}/docker/spring-cloud-contract-docker/target/adoc/appProps.adoc[indent=0]
 
+### Customizing the gradle build
+
+You can provide a customized `gradle.build` to be run in the container by mounting your customized build file as a volume when running the container:
+
+====
+[source,bash]
+----
+$ docker run -v <absolute-path-of-your-custom-file>:/spring-cloud-contract/build.gradle springcloud/spring-cloud-contract:<version>
+----
+====
+
 [[docker-example-of-usage]]
 === Example of Usage via HTTP
 
@@ -458,7 +469,7 @@ $ curl -X GET http://localhost:9876/api/books
 
 IMPORTANT: If you want use the stubs that you have built locally, on your host,
 you should set the `-e STUBRUNNER_STUBS_MODE=LOCAL` environment variable and mount
-the volume of your local m2 (`-v "${HOME}/.m2/:/root/.m2:ro"`).
+the volume of your local m2 (`-v "${HOME}/.m2/:/home/scc/.m2:ro"`).
 
 [[docker-stubrunner-example-messaging]]
 === Example of Usage with Messaging
@@ -576,9 +587,9 @@ $ docker run \
     -e "STUBRUNNER_REPOSITORY_ROOT=git://https://github.com/marcingrzejszczak/cdct_python_contracts.git" \ <3>
     -e ADDITIONAL_OPTS="--thin.properties.dependencies.rabbitmq=org.apache.camel.springboot:camel-rabbitmq-starter:3.4.0" \ <4>
     -e "STUBRUNNER_STUBS_MODE=REMOTE" \ <5>
-    -v "${HOME}/.m2/:/root/.m2:ro" \ <6>
+    -v "${HOME}/.m2/:/home/scc/.m2:ro" \ <6>
     -p 8750:8750 \ <7>
-    springcloud/spring-cloud-contract-stub-runner:3.0.1-SNAPSHOT <8>
+    springcloud/spring-cloud-contract-stub-runner:3.0.4-SNAPSHOT <8>
 ```
 <1> We're injecting the address of RabbitMQ via https://camel.apache.org/components/latest/rabbitmq-component.html#_spring_boot_auto_configuration[Apache Camel's Spring Boot Auto-Configuration]
 <2> We're telling Stub Runner which stubs to download


### PR DESCRIPTION
- added documentation on how to overwrite `build.gradle` with docker
- using the directories in docker container that are defined and described in the documentation and pre-create them with appropriate permissions during container image creation:
`/contracts`, `/spring-cloud-contract`, `/spring-cloud-contract-output`