### PR TITLE
Fix JGit integration

### DIFF
--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/build.gradle
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/build.gradle
@@ -64,9 +64,7 @@ dependencies {
 	implementation "org.apache.maven.resolver:maven-resolver-api:1.4.1"
 	implementation "org.eclipse.jgit:org.eclipse.jgit:${jgitVersion}"
 	implementation "org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:${jgitVersion}"
-	implementation "com.jcraft:jsch.agentproxy.sshagent:${jschVersion}"
 	implementation "com.jcraft:jsch.agentproxy.jsch:${jschVersion}"
-	implementation "com.jcraft:jsch.agentproxy.usocket-jna:${jschVersion}"
 	implementation "com.fasterxml.jackson.core:jackson-databind:2.11.4"
 
 	implementation "org.springframework:spring-core:5.3.9"

--- a/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/pom.xml
+++ b/spring-cloud-contract-tools/spring-cloud-contract-gradle-plugin/pom.xml
@@ -68,6 +68,10 @@
 			<artifactId>org.eclipse.jgit</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.eclipse.jgit</groupId>
+			<artifactId>org.eclipse.jgit.ssh.jsch</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.jcraft</groupId>
 			<artifactId>jsch.agentproxy.jsch</artifactId>
 		</dependency>


### PR DESCRIPTION
Minimal changes to get JGit working.

@marcingrzejszczak, I'm not sure if there was a purpose for which you also added the sshagent and unix socket dependencies, but if they're really necessary we can add them back in. 

Root issue is that 5.8.0 of jgit the Jsch/SSH implementation (JschSessionFactory) was split out into a new jar. As a result this jar needs to be included as the GitScmDownloader configuration needs for it to be available for clones to work properly.