### PR TITLE
#1630 Fix assertion for Map<String, Set<String>>

### DIFF
--- a/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/util/MapConverter.java
+++ b/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/util/MapConverter.java
@@ -16,9 +16,11 @@
 
 package org.springframework.cloud.contract.verifier.util;
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -41,6 +43,7 @@ import org.springframework.cloud.contract.verifier.template.TemplateProcessor;
  *
  * @author Marcin Grzejszczak
  * @author Stessy Delcroix
+ * @author Ravil Galeyev
  * @since 1.1.0
  */
 public class MapConverter {
@@ -123,8 +126,8 @@ public class MapConverter {
 		else if (value instanceof Map) {
 			return convert((Map) value, function, parsingFunction);
 		}
-		else if (value instanceof List) {
-			return ((List) value).stream().map((v) -> transformValues(v, function, parsingFunction))
+		else if (value instanceof List || value instanceof Set) {
+			return ((Collection) value).stream().map((v) -> transformValues(v, function, parsingFunction))
 					.collect(Collectors.toList());
 		}
 		return transformValue(function, value, parsingFunction);

--- a/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/util/MapConverter.java
+++ b/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/util/MapConverter.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -126,7 +125,7 @@ public class MapConverter {
 		else if (value instanceof Map) {
 			return convert((Map) value, function, parsingFunction);
 		}
-		else if (value instanceof List || value instanceof Set) {
+		else if (value instanceof Collection) {
 			return ((Collection) value).stream().map((v) -> transformValues(v, function, parsingFunction))
 					.collect(Collectors.toList());
 		}

--- a/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/SpringTestMethodBodyBuildersSpec.groovy
+++ b/spring-cloud-contract-verifier/src/test/groovy/org/springframework/cloud/contract/verifier/builder/SpringTestMethodBodyBuildersSpec.groovy
@@ -16,12 +16,7 @@
 
 package org.springframework.cloud.contract.verifier.builder
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 import java.util.regex.Pattern
-import java.util.Set;
-import java.util.function.Supplier;
 
 import org.junit.Rule
 import spock.lang.Issue
@@ -1951,7 +1946,7 @@ World.'''"""
 			}
 			response {
 				status OK()
-				body(Map.of("key", Set.of("value1", "value2")))
+				body(["key": ["value1", "value2"] as Set])
 				headers {
 					header('Content-Type': 'application/json;charset=UTF-8')
 				}


### PR DESCRIPTION
Relates to [#1630](https://github.com/spring-cloud/spring-cloud-contract/issues/1630)

I added a test that reproduces the issue and added a fix that achieves the expected behavior.

@marcingrzejszczak in the ticket you say `it should work with sets`, 
but a set is an unordered collection, but arrays in JSON are ordered.

Do we check the order of elements in JSON?  If not, just accept my PR :)

If yes, I'm hesitating that we can treat sets as lists. Maybe we have to check `contains` for sets, but not `equals`.
I can work on it, but I need this to be clarified.

Also
`SingleTestGeneratorSpec` fails in the `main` branch as well, so it's not related to my changes. 