### PR TITLE
Fix kotlin spec contracts not falling back on the file name when no name is set.

### DIFF
--- a/specs/spring-cloud-contract-spec-kotlin/src/test/kotlin/org/springframework/cloud/contract/spec/ContractTests.kt
+++ b/specs/spring-cloud-contract-spec-kotlin/src/test/kotlin/org/springframework/cloud/contract/spec/ContractTests.kt
@@ -826,6 +826,31 @@ then:
 	}
 
 	@Test
+	fun `should use filename as fallback for single unnamed contract`() {
+		val contract = KotlinContractConverter()
+				.convertFrom(File(javaClass.classLoader.getResource("contracts/unnamed_single.kts")!!.toURI()))
+				.single()
+		assertDoesNotThrow {
+			Contract.assertContract(contract)
+		}.also {
+			assertThat(contract.name).isEqualTo("unnamed_single")
+		}
+	}
+
+	@Test
+	fun `should use filename with index as fallback for multiple unnamed contracts`() {
+		val contracts = KotlinContractConverter()
+				.convertFrom(File(javaClass.classLoader.getResource("contracts/unnamed_multiple.kts")!!.toURI()))
+				.toList()
+		assertDoesNotThrow {
+			contracts.forEach(Contract::assertContract)
+		}.also {
+			assertThat(contracts[0].name).isEqualTo("unnamed_multiple_0")
+			assertThat(contracts[1].name).isEqualTo("unnamed_multiple_1")
+		}
+	}
+
+	@Test
 	/**
 	 * See issue https://github.com/spring-cloud/spring-cloud-contract/issues/1668
 	 */

--- a/specs/spring-cloud-contract-spec-kotlin/src/test/resources/contracts/unnamed_multiple.kts
+++ b/specs/spring-cloud-contract-spec-kotlin/src/test/resources/contracts/unnamed_multiple.kts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package contracts
+
+import org.springframework.cloud.contract.spec.ContractDsl.Companion.contract
+
+arrayOf(
+    contract {
+        request {
+            method = GET
+            url = url("/test1")
+        }
+    },
+    contract {
+        request {
+            method = GET
+            url = url("/test2")
+        }
+    }
+)

--- a/specs/spring-cloud-contract-spec-kotlin/src/test/resources/contracts/unnamed_single.kts
+++ b/specs/spring-cloud-contract-spec-kotlin/src/test/resources/contracts/unnamed_single.kts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package contracts
+
+import org.springframework.cloud.contract.spec.ContractDsl.Companion.contract
+
+contract {
+    request {
+        method = GET
+        url = url("/test")
+    }
+}


### PR DESCRIPTION
Currently the `KotlinContractConverter` will use what looks like a random hashcode when the contract it's converting does not have a `name` property. This leads to the failure of the generated tests because the tests expect a different file name. 

This commit adds a mechanism to fall back to the file name, the same way it is done in the `ContractVerifierDslConverter`. 