### PR TITLE
docs: Update JUnit5 example, fixes gh-1746

### DIFF
--- a/docs/src/main/asciidoc/using.adoc
+++ b/docs/src/main/asciidoc/using.adoc
@@ -488,7 +488,7 @@ For the consumer side, you can use a JUnit rule. That way, you need not start a 
 [source,java,indent=0,subs="verbatim,attributes",role="secondary"]
 .JUnit 5 Extension
 ----
-@Rule
+@RegisterExtension
 	public StubRunnerExtension stubRunnerExtension = new StubRunnerExtension()
 			.downloadStub("com.example","artifact-id", "0.0.1")
 			.repoRoot("git://git@github.com:spring-cloud-samples/spring-cloud-contract-nodejs-contracts-git.git")


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-contract/issues/1746
I referred to the [Consumer setup](https://docs.spring.io/spring-cloud-contract/docs/current/reference/html/using.html#flows-provider-git-consumer) JUnit5 Extension example while making the change.
Applying the change to the `3.1.x` branch as required.