### PR TITLE
fix #1656: Add missing support for JSON values inside arrays in WireMockStub

### DIFF
--- a/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/dsl/wiremock/BaseWireMockStubStrategy.java
+++ b/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/dsl/wiremock/BaseWireMockStubStrategy.java
@@ -95,8 +95,15 @@ abstract class BaseWireMockStubStrategy {
 	/**
 	 * For the given {@link ContentType} returns the Boolean version of the body.
 	 */
-	String parseBody(Boolean value, ContentType contentType) {
-		return value.toString();
+	Boolean parseBody(Boolean value, ContentType contentType) {
+		return value;
+	}
+
+	/**
+	 * For the given {@link ContentType} returns the Number version of the body.
+	 */
+	Number parseBody(Number value, ContentType contentType) {
+		return value;
 	}
 
 	/**
@@ -155,6 +162,15 @@ abstract class BaseWireMockStubStrategy {
 			}
 			else if (l instanceof List) {
 				result.add(parseBody((List<?>) l, contentType));
+			}
+			else if (l instanceof Boolean) {
+				result.add(parseBody((Boolean) l, contentType));
+			}
+			else if (l instanceof Number) {
+				result.add(parseBody((Number) l, contentType));
+			}
+			else if (l == null) {
+				result.add(null);
 			}
 			else {
 				result.add(parseBody(l, contentType));


### PR DESCRIPTION
Currently, numbers, booleans and null inside arrays are double-quoted when converting DSL into stubs, which results in generating incorrect json stubs for WireMock. This PR fixes it.


Fixes #1656.