### PR TITLE
Fixed relative URL computation in wIthoutBaseUrl

### DIFF
--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockRestServiceServer.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockRestServiceServer.java
@@ -277,7 +277,7 @@ public final class WireMockRestServiceServer {
 		if (indexOfBaseUrl == -1) {
 			return url;
 		}
-		return url.substring(indexOfBaseUrl + this.baseUrl.length() + 1);
+		return url.substring(indexOfBaseUrl + this.baseUrl.length());
 	}
 
 	private Matcher<String> requestMatcher(RequestPattern request) {

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/WiremockMockServerApplicationTests.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/WiremockMockServerApplicationTests.java
@@ -412,6 +412,24 @@ public class WiremockMockServerApplicationTests {
 	}
 
 	@Test
+	public void getWithSimpleUrlPathMatchingWithTrailingSlashInBaseUrl() throws Exception {
+		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate).baseUrl("https://example.org/")
+				.stubs("classpath:/mappings/url-simple-path-pattern-without-leading-slash.json").build();
+		assertThat(this.restTemplate.getForObject("https://example.org/my/api", String.class))
+				.isEqualTo("Hello Url Path Matcher");
+		server.verify();
+	}
+
+	@Test
+	public void getWithSimpleUrlPathMatchingWithLeadingSlashInPattern() throws Exception {
+		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate).baseUrl("https://example.org")
+				.stubs("classpath:/mappings/url-simple-path-pattern-with-leading-slash.json").build();
+		assertThat(this.restTemplate.getForObject("https://example.org/my/api", String.class))
+				.isEqualTo("Hello Url Path Matcher");
+		server.verify();
+	}
+
+	@Test
 	public void getWithUrlMatching() throws Exception {
 		MockRestServiceServer server = WireMockRestServiceServer.with(this.restTemplate) //
 				.baseUrl("https://example.org") //

--- a/spring-cloud-contract-wiremock/src/test/resources/mappings/url-simple-path-pattern-with-leading-slash.json
+++ b/spring-cloud-contract-wiremock/src/test/resources/mappings/url-simple-path-pattern-with-leading-slash.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "urlPathPattern": "/([0-9]+)/url-path-pattern/"
+    "urlPathPattern": "/my/api"
   },
   "response": {
     "status": 200,

--- a/spring-cloud-contract-wiremock/src/test/resources/mappings/url-simple-path-pattern-without-leading-slash.json
+++ b/spring-cloud-contract-wiremock/src/test/resources/mappings/url-simple-path-pattern-without-leading-slash.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "urlPathPattern": "/([0-9]+)/url-path-pattern/"
+    "urlPathPattern": "my/api"
   },
   "response": {
     "status": 200,


### PR DESCRIPTION
Current behaviour :
base URL = http://foo.bar, url = http://foo.bar/my/api => my/api
base URL = http://foo.bar/, url = http://foo.bar/my/api => y/api

Fixed behaviour : 
base URL = http://foo.bar, url = http://foo.bar/my/api => /my/api
base URL = http://foo.bar/, url = http://foo.bar/my/api => my/api