### PR TITLE
Javadoc fixed

### DIFF
--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockSpring.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockSpring.java
@@ -32,7 +32,7 @@ import org.springframework.util.ClassUtils;
  * <pre>
  * &#64;ClassRule
  * public static WireMockClassRule wiremock = new WireMockClassRule(
- * 		WireMockSpring.config());
+ * 		WireMockSpring.options());
  * </pre>
  *
  * and then use {@link com.github.tomakehurst.wiremock.client.WireMock} as normal in your


### PR DESCRIPTION
WireMockSpring.config() replaced by WireMockSpring.options() at javadoc