### PR TITLE
fix: Fixed an issue that could not find a resources in the jar file

### DIFF
--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/file/ResourcesFileSource.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/file/ResourcesFileSource.java
@@ -110,16 +110,23 @@ public class ResourcesFileSource implements FileSource {
 	public BinaryFile getBinaryFileNamed(String name) {
 		for (FileSource resource : this.sources) {
 			try {
+				if (resource instanceof ClasspathFileSource) {
+					ClasspathFileSource classpathFileSource = (ClasspathFileSource) resource;
+					if (classpathFileSource.exists() && compressedResource(classpathFileSource.getUri())) {
+						return classpathFileSource.getBinaryFileNamed(name);
+					}
+				}
 				UrlResource uri = new UrlResource(resource.getUri());
 				if (uri.exists()) {
-					Resource relativeResource = new UrlResource(uri.getURI() + "/" + name);
+					Resource relativeResource = uri.createRelative(name);
 					if (relativeResource.exists()) {
 						return resource.getBinaryFileNamed(name);
 					}
 				}
-			}
-			catch (IOException e) {
-				// Ignore
+			} catch (RuntimeException e) {
+				// Ignore - find next stub file
+			} catch (IOException e) {
+				// Ignore - find next stub file
 			}
 		}
 		throw new IllegalStateException("Cannot create file for " + name);


### PR DESCRIPTION
I found a new bug while building the CI automation system.
When running the test in the cli environment, 
I found an issue that could not read the stubs file in the built jar file.
I changed it to read differently if stubs-uri's protocol is jar.