### PR TITLE
allow sendMessage to handle body from file

### DIFF
--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerExecutor.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerExecutor.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import groovy.json.JsonOutput;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -250,16 +251,16 @@ class StubRunnerExecutor implements StubFinder {
 		setMessageType(contract, ContractVerifierMessageMetadata.MessageType.OUTPUT);
 
 		Object payload = null;
-		if (body.getClientValue() instanceof FromFileProperty fromFile) {
+		if (body.getClientValue() instanceof FromFileProperty) {
+			FromFileProperty fromFile = (FromFileProperty) body.getClientValue();
 			if (fromFile.isByte()) {
 				payload = fromFile.asBytes();
-			}
-			else {
+			} else {
 				payload = fromFile.asString();
 			}
 		}
 		else {
-			payload = BodyExtractor.extractClientValueFromBody(body == null ? null : body.getClientValue());
+			payload = JsonOutput.toJson(BodyExtractor.extractClientValueFromBody(body == null ? null : body.getClientValue()));
 		}
 
 		this.messageVerifierSender.send(payload, headers == null ? null : headers.asStubSideMap(),

--- a/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerExecutor.java
+++ b/spring-cloud-contract-stub-runner/src/main/java/org/springframework/cloud/contract/stubrunner/StubRunnerExecutor.java
@@ -28,13 +28,13 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import groovy.json.JsonOutput;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.cloud.contract.spec.Contract;
 import org.springframework.cloud.contract.spec.internal.DslProperty;
+import org.springframework.cloud.contract.spec.internal.FromFileProperty;
 import org.springframework.cloud.contract.spec.internal.Headers;
 import org.springframework.cloud.contract.spec.internal.OutputMessage;
 import org.springframework.cloud.contract.stubrunner.AvailablePortScanner.PortCallback;
@@ -248,11 +248,22 @@ class StubRunnerExecutor implements StubFinder {
 		List<YamlContract> yamlContracts = yamlContractConverter.convertTo(Collections.singleton(groovyDsl));
 		YamlContract contract = yamlContracts.get(0);
 		setMessageType(contract, ContractVerifierMessageMetadata.MessageType.OUTPUT);
-		// TODO: Json is harcoded here
-		this.messageVerifierSender.send(
-				JsonOutput
-						.toJson(BodyExtractor.extractClientValueFromBody(body == null ? null : body.getClientValue())),
-				headers == null ? null : headers.asStubSideMap(), outputMessage.getSentTo().getClientValue(), contract);
+
+		Object payload = null;
+		if (body.getClientValue() instanceof FromFileProperty fromFile) {
+			if (fromFile.isByte()) {
+				payload = fromFile.asBytes();
+			}
+			else {
+				payload = fromFile.asString();
+			}
+		}
+		else {
+			payload = BodyExtractor.extractClientValueFromBody(body == null ? null : body.getClientValue());
+		}
+
+		this.messageVerifierSender.send(payload, headers == null ? null : headers.asStubSideMap(),
+				outputMessage.getSentTo().getClientValue(), contract);
 	}
 
 	private void setMessageType(YamlContract contract, ContractVerifierMessageMetadata.MessageType output) {

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/StubRunnerExecutorSpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/StubRunnerExecutorSpec.groovy
@@ -100,6 +100,18 @@ class StubRunnerExecutorSpec extends Specification {
 			executor.shutdown()
 	}
 
+	def 'should ensure that triggered contracts have properly parsed message body from file as bytes when a message is sent'() {
+		given:
+			StubRunnerExecutor executor = new StubRunnerExecutor(portScanner, new AssertingStubMessages(), [])
+			executor.runStubs(stubRunnerOptions, repository, stub)
+		when:
+			executor.trigger('send_order_bin')
+		then:
+			noExceptionThrown()
+		cleanup:
+			executor.shutdown()
+	}
+
 	def 'should match stub with empty classifier'() {
 		given:
 			def stubConf = new StubConfiguration('groupX', 'artifactX', 'versionX', '')
@@ -209,7 +221,9 @@ class StubRunnerExecutorSpec extends Specification {
 
 		@Override
 		<T> void send(T payload, Map<String, Object> headers, String destination, YamlContract contract) {
-			assert !(JsonOutput.toJson(payload).contains("serverValue"))
+			if(payload instanceof String) {
+				assert !(JsonOutput.toJson(payload).contains("serverValue"))
+			}
 			assert headers.entrySet().every { !(it.value.toString().contains("serverValue")) }
 		}
 

--- a/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/StubRunnerExecutorSpec.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/groovy/org/springframework/cloud/contract/stubrunner/StubRunnerExecutorSpec.groovy
@@ -112,6 +112,42 @@ class StubRunnerExecutorSpec extends Specification {
 			executor.shutdown()
 	}
 
+	def 'should ensure that triggered contracts have properly parsed message body from file as json when a message is sent'() {
+		given:
+			StubRunnerExecutor executor = new StubRunnerExecutor(portScanner, new AssertingStubMessages(), [])
+			executor.runStubs(stubRunnerOptions, repository, stub)
+		when:
+			executor.trigger('send_order_json')
+		then:
+			noExceptionThrown()
+		cleanup:
+			executor.shutdown()
+	}
+
+	def 'should ensure that triggered contracts have properly parsed message body from file as xml when a message is sent'() {
+		given:
+			StubRunnerExecutor executor = new StubRunnerExecutor(portScanner, new AssertingStubMessages(), [])
+			executor.runStubs(stubRunnerOptions, repository, stub)
+		when:
+			executor.trigger('send_order_xml')
+		then:
+			noExceptionThrown()
+		cleanup:
+			executor.shutdown()
+	}
+
+	def 'should ensure that triggered contracts have properly parsed message body from file as text when a message is sent'() {
+		given:
+			StubRunnerExecutor executor = new StubRunnerExecutor(portScanner, new AssertingStubMessages(), [])
+			executor.runStubs(stubRunnerOptions, repository, stub)
+		when:
+			executor.trigger('send_order_csv')
+		then:
+			noExceptionThrown()
+		cleanup:
+			executor.shutdown()
+	}
+
 	def 'should match stub with empty classifier'() {
 		given:
 			def stubConf = new StubConfiguration('groupX', 'artifactX', 'versionX', '')

--- a/spring-cloud-contract-stub-runner/src/test/resources/repository/messagecontract/contract1.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/resources/repository/messagecontract/contract1.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+org.springframework.cloud.contract.spec.Contract.make {
+	description 'issue #1864'
+	label 'send_order_bin'
+	input {
+		triggeredBy('sendOrder()')
+	}
+	outputMessage {
+		sentTo 'orderEventsTopic'
+		headers {
+			[
+					header('contentType': 'application/vnd.orderplaced.v1+avro')
+			]
+		}
+		body(fileAsBytes("orderplaced-event.bin"))
+	}
+}

--- a/spring-cloud-contract-stub-runner/src/test/resources/repository/messagecontract/contract2.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/resources/repository/messagecontract/contract2.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+org.springframework.cloud.contract.spec.Contract.make {
+	description 'issue #1864'
+	label 'send_order_json'
+	input {
+		triggeredBy('sendOrderJson()')
+	}
+	outputMessage {
+		sentTo 'orderEventsTopic'
+		headers {
+			[
+					header('contentType': 'application/json')
+			]
+		}
+		body(file("orderplaced-event.json"))
+	}
+}

--- a/spring-cloud-contract-stub-runner/src/test/resources/repository/messagecontract/contract3.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/resources/repository/messagecontract/contract3.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+org.springframework.cloud.contract.spec.Contract.make {
+	description 'issue #1864'
+	label 'send_order_xml'
+	input {
+		triggeredBy('sendOrderXml()')
+	}
+	outputMessage {
+		sentTo 'orderEventsTopic'
+		headers {
+			[
+					header('contentType': 'application/xml')
+			]
+		}
+		body(file("orderplaced-event.xml"))
+	}
+}

--- a/spring-cloud-contract-stub-runner/src/test/resources/repository/messagecontract/contract4.groovy
+++ b/spring-cloud-contract-stub-runner/src/test/resources/repository/messagecontract/contract4.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+org.springframework.cloud.contract.spec.Contract.make {
+	description 'issue #1864'
+	label 'send_order_csv'
+	input {
+		triggeredBy('sendOrderCsv()')
+	}
+	outputMessage {
+		sentTo 'orderEventsTopic'
+		headers {
+			[
+					header('contentType': 'text/plain')
+			]
+		}
+		body(file("orderplaced-event.csv"))
+	}
+}

--- a/spring-cloud-contract-stub-runner/src/test/resources/repository/messagecontract/orderplaced-event.bin
+++ b/spring-cloud-contract-stub-runner/src/test/resources/repository/messagecontract/orderplaced-event.bin
@@ -1,0 +1,1 @@
+H505c50a7-0c26-4582-b9ae-bc1c0f65fec10fakeCustomer@example.comÀþÙ³Àa

--- a/spring-cloud-contract-stub-runner/src/test/resources/repository/messagecontract/orderplaced-event.csv
+++ b/spring-cloud-contract-stub-runner/src/test/resources/repository/messagecontract/orderplaced-event.csv
@@ -1,0 +1,2 @@
+orderId,customerId,orderCreated
+505c50a7-0c26-4582-b9ae-bc1c0f65fec1,fakeUser@example.com,orderCreated": "2023-01-30T15:11:00Z

--- a/spring-cloud-contract-stub-runner/src/test/resources/repository/messagecontract/orderplaced-event.json
+++ b/spring-cloud-contract-stub-runner/src/test/resources/repository/messagecontract/orderplaced-event.json
@@ -1,0 +1,5 @@
+{
+  "orderId": "505c50a7-0c26-4582-b9ae-bc1c0f65fec1",
+  "customerId": "fakeUser@example.com",
+  "orderCreated": "2023-01-30T15:11:00Z"
+}

--- a/spring-cloud-contract-stub-runner/src/test/resources/repository/messagecontract/orderplaced-event.xml
+++ b/spring-cloud-contract-stub-runner/src/test/resources/repository/messagecontract/orderplaced-event.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<orderPlaced>
+	<orderId>505c50a7-0c26-4582-b9ae-bc1c0f65fec1</orderId>
+	<custmerId>fakeCustomer@example.com</custmerId>
+	<orderPlaced>2023-01-30T15:11:00Z</orderPlaced>
+</orderPlaced>


### PR DESCRIPTION
- add test for populating `bodyFromFileAsBytes`
- update `StubRunnerExecutor` to handle more than just json payloads

fixes #1864