### PR TITLE
Relaxed SSL validation with RestTemplate interceptors

### DIFF
--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockRestTemplateConfiguration.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockRestTemplateConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.contract.wiremock;
 
 import java.lang.reflect.Field;
+
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
@@ -30,14 +31,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.client.RestTemplateCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpRequestFactory;
-import org.springframework.http.client.ClientHttpRequestInitializer;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.client.InterceptingClientHttpRequestFactory;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.util.ReflectionUtils;
+import org.springframework.web.client.RestTemplate;
 
 import static org.apache.hc.client5.http.ssl.NoopHostnameVerifier.INSTANCE;
 

--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockRestTemplateConfiguration.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockRestTemplateConfiguration.java
@@ -63,7 +63,8 @@ public class WireMockRestTemplateConfiguration {
 					Field requestFactoryField = ReflectionUtils.findField(RestTemplate.class, "requestFactory");
 					if (requestFactoryField != null) {
 						requestFactoryField.setAccessible(true);
-						ClientHttpRequestFactory requestFactory = (ClientHttpRequestFactory) ReflectionUtils.getField(requestFactoryField, restTemplate);
+						ClientHttpRequestFactory requestFactory = (ClientHttpRequestFactory) ReflectionUtils
+								.getField(requestFactoryField, restTemplate);
 						if (requestFactory instanceof HttpComponentsClientHttpRequestFactory factory) {
 							factory.setHttpClient(createSslHttpClient());
 						}

--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockRestTemplateConfiguration.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockRestTemplateConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.contract.wiremock;
 
+import java.lang.reflect.Field;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
@@ -29,13 +30,20 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.client.RestTemplateCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.ClientHttpRequest;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.ClientHttpRequestInitializer;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.client.InterceptingClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.util.ReflectionUtils;
 
 import static org.apache.hc.client5.http.ssl.NoopHostnameVerifier.INSTANCE;
 
 /**
  * @author Dave Syer
+ * @author Nikola Kološnjaji
  *
  */
 @Configuration(proxyBeanMethods = false)
@@ -48,10 +56,18 @@ public class WireMockRestTemplateConfiguration {
 		return new RestTemplateCustomizer() {
 			@Override
 			public void customize(RestTemplate restTemplate) {
-				if (restTemplate.getRequestFactory() instanceof HttpComponentsClientHttpRequestFactory) {
-					HttpComponentsClientHttpRequestFactory factory = (HttpComponentsClientHttpRequestFactory) restTemplate
-							.getRequestFactory();
+				if (restTemplate.getRequestFactory() instanceof HttpComponentsClientHttpRequestFactory factory) {
 					factory.setHttpClient(createSslHttpClient());
+				}
+				else if (restTemplate.getRequestFactory() instanceof InterceptingClientHttpRequestFactory) {
+					Field requestFactoryField = ReflectionUtils.findField(RestTemplate.class, "requestFactory");
+					if (requestFactoryField != null) {
+						requestFactoryField.setAccessible(true);
+						ClientHttpRequestFactory requestFactory = (ClientHttpRequestFactory) ReflectionUtils.getField(requestFactoryField, restTemplate);
+						if (requestFactory instanceof HttpComponentsClientHttpRequestFactory factory) {
+							factory.setHttpClient(createSslHttpClient());
+						}
+					}
 				}
 			}
 

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/AutoConfigureWireMockHttpsPortApplicationTests.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/AutoConfigureWireMockHttpsPortApplicationTests.java
@@ -70,7 +70,6 @@ public class AutoConfigureWireMockHttpsPortApplicationTests {
 		assertThat(this.service.goWithApacheClientAndAdditonalInterceptor()).isEqualTo("Hello World!");
 	}
 
-
 	@Test
 	public void portsAreFixed() {
 		boolean httpPortDynamic = this.wireMockProperties.getServer().isPortDynamic();

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/AutoConfigureWireMockHttpsPortApplicationTests.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/AutoConfigureWireMockHttpsPortApplicationTests.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -30,6 +31,11 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * @author Dave Syer
+ * @author Nikola Kološnjaji
+ *
+ */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = WiremockTestsApplication.class,
 		properties = "app.baseUrl=https://localhost:${wiremock.server.https-port}",
@@ -49,6 +55,21 @@ public class AutoConfigureWireMockHttpsPortApplicationTests {
 				.willReturn(aResponse().withHeader("Content-Type", "text/plain").withBody("Hello World!")));
 		assertThat(this.service.go()).isEqualTo("Hello World!");
 	}
+
+	@Test
+	public void contextLoadsWithApacheClient() throws Exception {
+		stubFor(get(urlEqualTo("/test"))
+				.willReturn(aResponse().withHeader("Content-Type", "text/plain").withBody("Hello World!")));
+		assertThat(this.service.goWithApacheClient()).isEqualTo("Hello World!");
+	}
+
+	@Test
+	public void contextLoadsWithApacheClientAndAdditonalInterceptor() throws Exception {
+		stubFor(get(urlEqualTo("/test"))
+				.willReturn(aResponse().withHeader("Content-Type", "text/plain").withBody("Hello World!")));
+		assertThat(this.service.goWithApacheClientAndAdditonalInterceptor()).isEqualTo("Hello World!");
+	}
+
 
 	@Test
 	public void portsAreFixed() {

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/AutoConfigureWireMockHttpsPortApplicationTests.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/AutoConfigureWireMockHttpsPortApplicationTests.java
@@ -20,7 +20,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.junit4.SpringRunner;

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/WiremockTestsApplication.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/WiremockTestsApplication.java
@@ -22,22 +22,30 @@ import java.util.stream.Stream;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.client.support.BasicAuthenticationInterceptor;
 import org.springframework.stereotype.Component;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
+/**
+ * @author Dave Syer
+ * @author Nikola Kološnjaji
+ *
+ */
 @Configuration
 @EnableAutoConfiguration
-@Import({ Service.class, Controller.class })
+@Import( Service.class )
 public class WiremockTestsApplication {
 
 	public static void main(String[] args) {
@@ -45,26 +53,23 @@ public class WiremockTestsApplication {
 	}
 
 	@Bean
+	@Primary
 	public RestTemplate restTemplate() {
 		return new RestTemplate();
 	}
 
-}
-
-@RestController
-class Controller {
-
-	private final Service service;
-
-	Controller(Service service) {
-		this.service = service;
+	@Bean
+	public RestTemplate apacheHttpClient(RestTemplateBuilder builder) {
+		return builder.requestFactory(() -> new HttpComponentsClientHttpRequestFactory())
+				.build();
 	}
 
-	@RequestMapping("/")
-	public String home() {
-		return this.service.go();
+	@Bean
+	public RestTemplate apacheHttpClientWithInterceptor(RestTemplateBuilder builder) {
+		return builder.requestFactory(() -> new HttpComponentsClientHttpRequestFactory())
+				.additionalInterceptors(new BasicAuthenticationInterceptor("u","p"))
+				.build();
 	}
-
 }
 
 @Component
@@ -77,14 +82,34 @@ class Service {
 
 	private RestTemplate restTemplate;
 
-	Service(RestTemplate restTemplate) {
+	private RestTemplate apacheHttpClient;
+
+	private RestTemplate apacheHttpClientWithInterceptor;
+
+	Service(RestTemplate restTemplate,
+			@Qualifier("apacheHttpClient") RestTemplate apacheHttpClient,
+			@Qualifier("apacheHttpClientWithInterceptor") RestTemplate apacheHttpClientWithInterceptor) {
 		this.restTemplate = restTemplate;
+		this.apacheHttpClient = apacheHttpClient;
+		this.apacheHttpClientWithInterceptor = apacheHttpClientWithInterceptor;
 	}
 
 	public String go() {
 		String requestUrl = this.base + "/test";
 		log.info("Will send a request to [" + requestUrl + "]");
 		return this.restTemplate.getForEntity(requestUrl, String.class).getBody();
+	}
+
+	public String goWithApacheClient() {
+		String requestUrl = this.base + "/test";
+		log.info("Will send a request to [" + requestUrl + "]");
+		return this.apacheHttpClient.getForEntity(requestUrl, String.class).getBody();
+	}
+
+	public String goWithApacheClientAndAdditonalInterceptor() {
+		String requestUrl = this.base + "/test";
+		log.info("Will send a request to [" + requestUrl + "]");
+		return this.apacheHttpClientWithInterceptor.getForEntity(requestUrl, String.class).getBody();
 	}
 
 	public String link() {

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/WiremockTestsApplication.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/WiremockTestsApplication.java
@@ -45,7 +45,7 @@ import org.springframework.web.client.RestTemplate;
  */
 @Configuration
 @EnableAutoConfiguration
-@Import( Service.class )
+@Import(Service.class)
 public class WiremockTestsApplication {
 
 	public static void main(String[] args) {
@@ -60,16 +60,15 @@ public class WiremockTestsApplication {
 
 	@Bean
 	public RestTemplate apacheHttpClient(RestTemplateBuilder builder) {
-		return builder.requestFactory(() -> new HttpComponentsClientHttpRequestFactory())
-				.build();
+		return builder.requestFactory(() -> new HttpComponentsClientHttpRequestFactory()).build();
 	}
 
 	@Bean
 	public RestTemplate apacheHttpClientWithInterceptor(RestTemplateBuilder builder) {
 		return builder.requestFactory(() -> new HttpComponentsClientHttpRequestFactory())
-				.additionalInterceptors(new BasicAuthenticationInterceptor("u","p"))
-				.build();
+				.additionalInterceptors(new BasicAuthenticationInterceptor("u", "p")).build();
 	}
+
 }
 
 @Component
@@ -86,8 +85,7 @@ class Service {
 
 	private RestTemplate apacheHttpClientWithInterceptor;
 
-	Service(RestTemplate restTemplate,
-			@Qualifier("apacheHttpClient") RestTemplate apacheHttpClient,
+	Service(RestTemplate restTemplate, @Qualifier("apacheHttpClient") RestTemplate apacheHttpClient,
 			@Qualifier("apacheHttpClientWithInterceptor") RestTemplate apacheHttpClientWithInterceptor) {
 		this.restTemplate = restTemplate;
 		this.apacheHttpClient = apacheHttpClient;


### PR DESCRIPTION
- Added test with Apache client and HTTPS
- Added test with Apache client and HTTPS and additional interceptor (original issue)
- Implementation is done with ReflectionUtils :( as I was not able to find better way (InterceptingClientHttpRequestFactory expose only "createRequest")


closes #1868