### PR TITLE
Adds support to specify priority and allow for template override

### DIFF
--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/restdocs/ContractDslSnippet.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/restdocs/ContractDslSnippet.java
@@ -84,11 +84,15 @@ public class ContractDslSnippet extends TemplatedSnippet {
 	@Override
 	public void document(Operation operation) throws IOException {
 		TemplateEngine templateEngine = (TemplateEngine) operation.getAttributes().get(TemplateEngine.class.getName());
-		String renderedContract = templateEngine.compileTemplate("default-dsl-contract-only")
+		String renderedContract = templateEngine.compileTemplate(getTemplate())
 				.render(createModelForContract(operation));
 		this.model.put("contract", renderedContract);
 		storeDslContract(operation, renderedContract);
 		super.document(operation);
+	}
+
+	protected String getTemplate() {
+		return "default-dsl-contract-only";
 	}
 
 	private void insertResponseModel(Operation operation, Map<String, Object> model) {
@@ -152,7 +156,16 @@ public class ContractDslSnippet extends TemplatedSnippet {
 		Map<String, Object> modelForContract = new HashMap<>();
 		insertRequestModel(operation, modelForContract);
 		insertResponseModel(operation, modelForContract);
+		insertAdditionalModel(operation, modelForContract);
 		return modelForContract;
+	}
+
+	protected void insertAdditionalModel(Operation operation, Map<String, Object> modelForContract) {
+		boolean hasPriority = getAttributes().containsKey("priority");
+		modelForContract.put("priority_present", hasPriority);
+		if (hasPriority) {
+			modelForContract.put("priority", getAttributes().get("priority"));
+		}
 	}
 
 	private void storeDslContract(Operation operation, String content) throws IOException {

--- a/spring-cloud-contract-wiremock/src/main/resources/org/springframework/restdocs/templates/default-dsl-contract-only.snippet
+++ b/spring-cloud-contract-wiremock/src/main/resources/org/springframework/restdocs/templates/default-dsl-contract-only.snippet
@@ -41,4 +41,7 @@ Contract.make {
         }
     {{/response_headers_present}}
     }
+    {{#priority_present}}
+    priority {{priority}}
+    {{/priority_present}}
 }

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/restdocs/ContractDslSnippetTests.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/restdocs/ContractDslSnippetTests.java
@@ -121,6 +121,40 @@ public class ContractDslSnippetTests {
 	}
 
 	@Test
+	public void should_create_contract_template_and_doc_with_placeholder_names() throws Exception {
+		this.mockMvc
+				.perform(post("/foo").accept(MediaType.APPLICATION_PDF).accept(MediaType.APPLICATION_JSON)
+						.contentType(MediaType.APPLICATION_JSON).content("{\"foo\": 23, \"bar\" : \"baz\" }"))
+				.andExpect(status().isOk()).andExpect(content().string("bar"))
+				// first WireMock
+				.andDo(WireMockRestDocs.verify().jsonPath("$[?(@.foo >= 20)]")
+						.jsonPath("$[?(@.bar in ['baz','bazz','bazzz'])]")
+						.contentType(MediaType.valueOf("application/json")))
+				// then Contract DSL documentation
+				.andDo(document("{methodName}", SpringCloudContractRestDocs.dslContract()));
+
+		then(file("/contracts/should_create_contract_template_and_doc_with_placeholder_names.groovy")).exists();
+		then(file("/stubs/should_create_contract_template_and_doc_with_placeholder_names.json")).exists();
+		then(file("/should_create_contract_template_and_doc_with_placeholder_names/dsl-contract.adoc")).exists();
+		Collection<Contract> parsedContracts = ContractVerifierDslConverter.convertAsCollection(new File("/"),
+				file("/contracts/should_create_contract_template_and_doc_with_placeholder_names.groovy"));
+		Contract parsedContract = parsedContracts.iterator().next();
+		then(parsedContract.getRequest().getHeaders().getEntries()).isNotNull();
+		then(headerNames(parsedContract.getRequest().getHeaders().getEntries())).doesNotContain(HttpHeaders.HOST,
+				HttpHeaders.CONTENT_LENGTH);
+		then(headerNames(parsedContract.getResponse().getHeaders().getEntries())).doesNotContain(HttpHeaders.HOST,
+				HttpHeaders.CONTENT_LENGTH);
+		then(parsedContract.getRequest().getMethod().getClientValue()).isNotNull();
+		then(parsedContract.getRequest().getUrlPath().getClientValue()).isNotNull();
+		then(parsedContract.getRequest().getUrlPath().getClientValue().toString()).startsWith("/");
+		then(parsedContract.getRequest().getBody().getClientValue()).isNotNull();
+		then(parsedContract.getRequest().getBodyMatchers().hasMatchers()).isTrue();
+		then(parsedContract.getResponse().getStatus().getClientValue()).isNotNull();
+		then(parsedContract.getResponse().getHeaders().getEntries()).isNotEmpty();
+		then(parsedContract.getResponse().getBody().getClientValue()).isNotNull();
+	}
+
+	@Test
 	public void should_create_contract_template_and_doc_without_body_and_headers() throws Exception {
 		this.mockMvc.perform(MockMvcRequestBuilders.get("/foo").param("one", "newValueOne").param("two", "newValueTwo"))
 				.andExpect(status().isOk()).andDo(document("empty", dslContract()));

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/restdocs/ContractDslSnippetTests.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/restdocs/ContractDslSnippetTests.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.groovy.util.Maps;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -94,7 +95,7 @@ public class ContractDslSnippetTests {
 						.jsonPath("$[?(@.bar in ['baz','bazz','bazzz'])]")
 						.contentType(MediaType.valueOf("application/json")))
 				// then Contract DSL documentation
-				.andDo(document("index", SpringCloudContractRestDocs.dslContract()));
+				.andDo(document("index", SpringCloudContractRestDocs.dslContract(Maps.of("priority", 1))));
 		// end::contract_snippet[]
 
 		then(file("/contracts/index.groovy")).exists();
@@ -116,40 +117,7 @@ public class ContractDslSnippetTests {
 		then(parsedContract.getResponse().getStatus().getClientValue()).isNotNull();
 		then(parsedContract.getResponse().getHeaders().getEntries()).isNotEmpty();
 		then(parsedContract.getResponse().getBody().getClientValue()).isNotNull();
-	}
-
-	@Test
-	public void should_create_contract_template_and_doc_with_placeholder_names() throws Exception {
-		this.mockMvc
-				.perform(post("/foo").accept(MediaType.APPLICATION_PDF).accept(MediaType.APPLICATION_JSON)
-						.contentType(MediaType.APPLICATION_JSON).content("{\"foo\": 23, \"bar\" : \"baz\" }"))
-				.andExpect(status().isOk()).andExpect(content().string("bar"))
-				// first WireMock
-				.andDo(WireMockRestDocs.verify().jsonPath("$[?(@.foo >= 20)]")
-						.jsonPath("$[?(@.bar in ['baz','bazz','bazzz'])]")
-						.contentType(MediaType.valueOf("application/json")))
-				// then Contract DSL documentation
-				.andDo(document("{methodName}", SpringCloudContractRestDocs.dslContract()));
-
-		then(file("/contracts/should_create_contract_template_and_doc_with_placeholder_names.groovy")).exists();
-		then(file("/stubs/should_create_contract_template_and_doc_with_placeholder_names.json")).exists();
-		then(file("/should_create_contract_template_and_doc_with_placeholder_names/dsl-contract.adoc")).exists();
-		Collection<Contract> parsedContracts = ContractVerifierDslConverter.convertAsCollection(new File("/"),
-				file("/contracts/should_create_contract_template_and_doc_with_placeholder_names.groovy"));
-		Contract parsedContract = parsedContracts.iterator().next();
-		then(parsedContract.getRequest().getHeaders().getEntries()).isNotNull();
-		then(headerNames(parsedContract.getRequest().getHeaders().getEntries())).doesNotContain(HttpHeaders.HOST,
-				HttpHeaders.CONTENT_LENGTH);
-		then(headerNames(parsedContract.getResponse().getHeaders().getEntries())).doesNotContain(HttpHeaders.HOST,
-				HttpHeaders.CONTENT_LENGTH);
-		then(parsedContract.getRequest().getMethod().getClientValue()).isNotNull();
-		then(parsedContract.getRequest().getUrlPath().getClientValue()).isNotNull();
-		then(parsedContract.getRequest().getUrlPath().getClientValue().toString()).startsWith("/");
-		then(parsedContract.getRequest().getBody().getClientValue()).isNotNull();
-		then(parsedContract.getRequest().getBodyMatchers().hasMatchers()).isTrue();
-		then(parsedContract.getResponse().getStatus().getClientValue()).isNotNull();
-		then(parsedContract.getResponse().getHeaders().getEntries()).isNotEmpty();
-		then(parsedContract.getResponse().getBody().getClientValue()).isNotNull();
+		then(parsedContract.getPriority().intValue()).isEqualTo(1);
 	}
 
 	@Test


### PR DESCRIPTION
Allows specifying priority eg

```
SpringCloudContractRestDocs.dslContract(Maps.of("priority", 1))))
```

and makes it possible to override the dsl template
```
 new ContractDslSnippet(){
                            @Override
                            protected String getTemplate() {
                                return "custom-dsl-contract";
                            }
                        }));
```

(template must live in resources/org/springframework/restdocs/templates)

Fixes gh-1818