### PR TITLE
Do not escape quotes in IllegalStateException

### DIFF
--- a/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/converter/YamlToContracts.java
+++ b/spring-cloud-contract-verifier/src/main/java/org/springframework/cloud/contract/verifier/converter/YamlToContracts.java
@@ -929,7 +929,7 @@ class YamlToContracts {
 	protected String file(String relativePath) {
 		URL resource = Thread.currentThread().getContextClassLoader().getResource(relativePath);
 		if (resource == null) {
-			throw new IllegalStateException("File [\"+relativePath+\"] is not present");
+			throw new IllegalStateException("File [" + relativePath + "] is not present");
 		}
 		try {
 			return String.join("\n", Files.readAllLines(Paths.get(resource.toURI())));


### PR DESCRIPTION
Now relativePath is logged correctly when resource is null.

fixes #1894