### PR TITLE
Fix GH-2035 AutoConfigureWiremock with a pre-defined custom port always defaults to port 8080

### DIFF
--- a/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockApplicationListener.java
+++ b/spring-cloud-contract-wiremock/src/main/java/org/springframework/cloud/contract/wiremock/WireMockApplicationListener.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.contract.wiremock;
 import java.util.HashMap;
 import java.util.Map;
 
+import java.util.Optional;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -63,9 +64,10 @@ public class WireMockApplicationListener implements ApplicationListener<Applicat
 		}
 		else {
 			Map<String, Object> source = getWireMockSource(environment);
-			source.put("wiremock.server.port", 8080);
+			Integer port = Optional.ofNullable(httpPortProperty).orElse(8080);
+			source.put("wiremock.server.port", port);
 			if (log.isDebugEnabled()) {
-				log.debug("Registered WireMock server port property to the default <8080> value");
+				log.debug("Registered WireMock server port property to the <" + port + "> value");
 			}
 		}
 		int httpsPortProperty = environment.getProperty("wiremock.server.https-port", Integer.class, 0);

--- a/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/AutoConfigureWireMockApplicationTests.java
+++ b/spring-cloud-contract-wiremock/src/test/java/org/springframework/cloud/contract/wiremock/AutoConfigureWireMockApplicationTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.contract.wiremock;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.system.OutputCaptureRule;
+import org.springframework.core.env.Environment;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -47,6 +49,12 @@ public class AutoConfigureWireMockApplicationTests {
 	@Autowired
 	private WireMockProperties wireMockProperties;
 
+	@Autowired
+	private WireMockServer wireMockServer;
+
+	@Autowired
+	private Environment env;
+
 	@Test
 	public void contextLoads() throws Exception {
 		stubFor(get(urlEqualTo("/test"))
@@ -61,6 +69,14 @@ public class AutoConfigureWireMockApplicationTests {
 		boolean httpPortDynamic = this.wireMockProperties.getServer().isPortDynamic();
 		boolean httpsPortDynamic = this.wireMockProperties.getServer().isHttpsPortDynamic();
 		assertThat(!httpPortDynamic || !httpsPortDynamic).isTrue();
+	}
+
+	@Test
+	public void portIsAssigned() {
+		Integer expectedPort = 26384;
+		assertThat(this.wireMockServer.port()).isEqualTo(expectedPort);
+		assertThat(this.wireMockProperties.getServer().getPort()).isEqualTo(expectedPort);
+		assertThat(this.env.getProperty("wiremock.server.port", Integer.class)).isEqualTo(expectedPort);
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-contract/issues/2035