### PR TITLE
Fix docker gradle build

### DIFF
--- a/docker/spring-cloud-contract-docker/project/build.gradle
+++ b/docker/spring-cloud-contract-docker/project/build.gradle
@@ -181,6 +181,7 @@ task cleanOutput(type: Delete) {
 
 task copyOutput(type: Copy) {
 	dependsOn("cleanOutput")
+	mustRunAfter("build", "generatePomFileForMavenPublication")
 	from 'build'
 	into '/spring-cloud-contract-output'
 }


### PR DESCRIPTION
Using springcloud/spring-cloud-contract to run external contracts fails due to:

```
org.gradle.internal.execution.WorkValidationException: A problem was found with the configuration of task ':generatePomFileForMavenPublication' (type 'GenerateMavenPom').
  - Gradle detected a problem with the following location: '/spring-cloud-contract/build/publications/maven/pom-default.xml'.
    
    Reason: Task ':copyOutput' uses this output of task ':generatePomFileForMavenPublication' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':generatePomFileForMavenPublication' as an input of ':copyOutput'.
      2. Declare an explicit dependency on ':generatePomFileForMavenPublication' from ':copyOutput' using Task#dependsOn.
      3. Declare an explicit dependency on ':generatePomFileForMavenPublication' from ':copyOutput' using Task#mustRunAfter.
```