### PR TITLE
fix: Use exec for better PID 1 handling

### DIFF
--- a/docker/spring-cloud-contract-stub-runner-docker/run.sh
+++ b/docker/spring-cloud-contract-stub-runner-docker/run.sh
@@ -14,5 +14,9 @@ if [[ "${MESSAGING_TYPE}" != "" ]]; then
   ADDITIONAL_OPTS="${ADDITIONAL_OPTS} --thin.profile=${MESSAGING_TYPE}"
 fi
 
-echo "Please wait for the dependencies to be downloaded..."
-java -Djava.security.egd=file:/dev/./urandom -jar /home/scc/stub-runner-boot.jar ${ADDITIONAL_OPTS}
+exec \
+ java \
+  -Djava.security.egd=file:/dev/./urandom \
+  -jar /home/scc/stub-runner-boot.jar \
+  ${ADDITIONAL_OPTS} \
+  "$@"

--- a/docker/spring-cloud-contract-stub-runner-docker/run.sh
+++ b/docker/spring-cloud-contract-stub-runner-docker/run.sh
@@ -14,6 +14,7 @@ if [[ "${MESSAGING_TYPE}" != "" ]]; then
   ADDITIONAL_OPTS="${ADDITIONAL_OPTS} --thin.profile=${MESSAGING_TYPE}"
 fi
 
+echo "Please wait for the dependencies to be downloaded..."
 exec \
  java \
   -Djava.security.egd=file:/dev/./urandom \


### PR DESCRIPTION
Also pass the arguments along to the java execution

Previously the arguments were silently dropped