### PR TITLE
fix: Adds an empty list to nonFilteredFileExtensions

### DIFF
--- a/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/CopyContracts.java
+++ b/spring-cloud-contract-tools/spring-cloud-contract-maven-plugin/src/main/java/org/springframework/cloud/contract/maven/verifier/CopyContracts.java
@@ -82,7 +82,8 @@ class CopyContracts {
 		execution.setOverwrite(true);
 		execution.setIncludeEmptyDirs(false);
 		execution.setFilterFilenames(false);
-		execution.setFilters(Collections.emptyList());
+		execution.setFilters(Collections.<String>emptyList());
+		execution.setNonFilteredFileExtensions(Collections.<String>emptyList());
 		try {
 			this.mavenResourcesFiltering.filterResources(execution);
 		}


### PR DESCRIPTION
without this change an NPE is being thrown from Maven Resources Filtering with this change since the list is empty an NPE is no longer thrown

fixes #2361