### PR TITLE
Fix invalid Asciidoc link by adding missing space

### DIFF
--- a/docs/src/main/asciidoc/sagan-index.adoc
+++ b/docs/src/main/asciidoc/sagan-index.adoc
@@ -10,7 +10,7 @@ Spring Cloud Contract Verifier is a tool that enables Consumer Driven Contract (
 
 Spring Cloud Contract Verifier moves TDD to the level of software architecture.
 
-To see how Spring Cloud Contract supports other languages just check out https://spring.io/blog/2018/02/13/spring-cloud-contract-in-a-polyglot-world[this blog post].
+To see how Spring Cloud Contract supports other languages just check out https://spring.io/blog/2018/02/13/spring-cloud-contract-in-a-polyglot-world [this blog post].
 
 ## Features
 


### PR DESCRIPTION
The missing space between link and the label caused URL to be malformed, resulting in a redirect to 404 Not Found page. 
Adding this space will fix the malformed URL.