### PR TITLE
Pin Kotlin version

### DIFF
--- a/specs/spring-cloud-contract-spec-kotlin/pom.xml
+++ b/specs/spring-cloud-contract-spec-kotlin/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xmlns="http://maven.apache.org/POM/4.0.0"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
@@ -13,6 +13,20 @@
 	<packaging>jar</packaging>
 	<name>Spring Cloud Contract Spec Kotlin</name>
 	<description>Spring Cloud Contract Spec Kotlin</description>
+	<properties>
+		<kotlin.version>2.2.21</kotlin.version>
+	</properties>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-bom</artifactId>
+				<version>${kotlin.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
Will fix compatibility builds with Spring Boot 4.1.0
(but requires users of Spring Boot 4.1.0 to do the same
so needs some documentation).