### PR TITLE
Run Kotlin scripting tests conditionally

### DIFF
--- a/specs/spring-cloud-contract-spec-kotlin/src/test/kotlin/org/springframework/cloud/contract/spec/internal/KotlinContractConverterTests.kt
+++ b/specs/spring-cloud-contract-spec-kotlin/src/test/kotlin/org/springframework/cloud/contract/spec/internal/KotlinContractConverterTests.kt
@@ -17,6 +17,7 @@
 package org.springframework.cloud.contract.spec.internal
 
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.DisabledIf
 import org.springframework.cloud.contract.spec.Contract
 import java.io.File
 import kotlin.test.assertEquals
@@ -24,12 +25,19 @@ import kotlin.test.assertTrue
 
 class KotlinContractConverterTests {
 
+	companion object {
+		@JvmStatic
+		fun isKotlin23OrGreater() = KotlinVersion.CURRENT.isAtLeast(2, 3)
+	}
+
     @Test
+	@DisabledIf(value = "org.springframework.cloud.contract.spec.internal.KotlinContractConverterTests#isKotlin23OrGreater")
     fun `accept kts files`() {
         assertTrue(KotlinContractConverter().isAccepted(file("contracts/singleDefinition.kts")))
     }
 
     @Test
+	@DisabledIf(value = "org.springframework.cloud.contract.spec.internal.KotlinContractConverterTests#isKotlin23OrGreater")
     fun `should convert single contract definition`() {
         val converter = KotlinContractConverter()
         val contracts = converter.convertFrom(file("contracts/singleDefinition.kts"))
@@ -38,6 +46,7 @@ class KotlinContractConverterTests {
     }
 
     @Test
+	@DisabledIf(value = "org.springframework.cloud.contract.spec.internal.KotlinContractConverterTests#isKotlin23OrGreater")
     fun `should convert multiple contract definitions`() {
         val converter = KotlinContractConverter()
         val contracts = converter.convertFrom(file("contracts/multipleDefinitions.kts"))
@@ -46,6 +55,7 @@ class KotlinContractConverterTests {
     }
 
     @Test
+	@DisabledIf(value = "org.springframework.cloud.contract.spec.internal.KotlinContractConverterTests#isKotlin23OrGreater")
     fun `should work with binary payload`() {
         val converter = KotlinContractConverter()
         val contracts = converter.convertFrom(file("contracts/shouldWorkWithBinaryPayload.kts"))


### PR DESCRIPTION
Not supported on Kotlin 2.3+.

Supersedes https://github.com/spring-cloud/spring-cloud-contract/pull/2475.